### PR TITLE
feat: organize scanner results into dedicated folder structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,9 +146,7 @@ postgres_data/
 
 # DevSecOps Scanner Artifacts
 .gitleaks.toml
-checkov-results.json
-gitleaks-results.json
-opa-results.json
+scanner-results/
 *.sarif
 scanner-reports/
 security-reports/

--- a/DevSecOps/opa-policies/iam-policies.rego
+++ b/DevSecOps/opa-policies/iam-policies.rego
@@ -78,3 +78,48 @@ deny[msg] {
 allow {
     count(deny) == 0
 }
+
+# Test functions for OPA test command
+test_deny_wildcard_action {
+    input := {
+        "resource_type": "aws_iam_policy",
+        "resource": {
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "*",
+                "Resource": "arn:aws:s3:::my-bucket/*"
+            }]
+        }
+    }
+    deny[msg] with input as input
+    msg == "IAM policy contains wildcard action (*) - use specific actions"
+}
+
+test_deny_wildcard_resource {
+    input := {
+        "resource_type": "aws_iam_policy", 
+        "resource": {
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "*"
+            }]
+        }
+    }
+    deny[msg] with input as input
+    msg == "IAM policy contains wildcard resource (*) - use specific resources"
+}
+
+test_allow_specific_permissions {
+    input := {
+        "resource_type": "aws_iam_policy",
+        "resource": {
+            "Statement": [{
+                "Effect": "Allow", 
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::my-bucket/*"
+            }]
+        }
+    }
+    count(deny) == 0 with input as input
+}

--- a/Makefile
+++ b/Makefile
@@ -52,17 +52,17 @@ scan: check-docker ## Run all security scans (OPA + Checkov + Gitleaks)
 # Run OPA policy validation
 opa: check-docker ## Run OPA policy validation
 	@echo "🔍 Running OPA policy validation..."
-	@docker-compose --profile scanners run --rm opa-scanner && echo "✅ OPA policy validation passed" || (echo "❌ OPA policy validation failed" && exit 1)
+	@docker-compose --profile scanners run --rm opa-scanner > scanner-results/opa-results.json && echo "✅ OPA policy validation passed" || (echo "❌ OPA policy validation failed" && exit 1)
 
 # Run Checkov infrastructure scan
 checkov: check-docker ## Run Checkov infrastructure scan
 	@echo "🔍 Running Checkov infrastructure scan..."
-	@docker-compose --profile scanners run --rm checkov-scanner && echo "✅ Checkov infrastructure scan passed" || (echo "❌ Checkov infrastructure scan failed" && exit 1)
+	@docker-compose --profile scanners run --rm checkov-scanner > scanner-results/checkov-results.json && echo "✅ Checkov infrastructure scan passed" || (echo "❌ Checkov infrastructure scan failed" && exit 1)
 
 # Run Gitleaks secret detection
 gitleaks: check-docker ## Run Gitleaks secret detection
 	@echo "🔍 Running Gitleaks secret detection..."
-	@docker-compose --profile scanners run --rm gitleaks-scanner && echo "✅ Gitleaks secret detection passed" || (echo "❌ Gitleaks secret detection found secrets" && exit 1)
+	@docker-compose --profile scanners run --rm gitleaks-scanner > scanner-results/gitleaks-results.json 2>&1 && echo "✅ Gitleaks secret detection passed" || (echo "❌ Gitleaks secret detection found secrets" && exit 1)
 
 # Clean up scan results and containers
 clean-scans: ## Clean up scan results and containers

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
       - .:/workspace:ro
       - ./DevSecOps/opa-policies:/policies:ro
     working_dir: /workspace
-    command: test /policies/ --verbose
+    command: test /policies/ --format json
     profiles:
       - scanners
     networks:
@@ -114,7 +114,7 @@ services:
     volumes:
       - .:/workspace:ro
     working_dir: /workspace
-    command: -d /workspace --framework terraform --framework dockerfile --output json --output-file-path /tmp/checkov-results.json --quiet --skip-check CKV_AWS_1,CKV_AWS_2,CKV_AWS_3
+    command: -d /workspace --framework terraform --framework dockerfile --output json --quiet --skip-check CKV_AWS_1,CKV_AWS_2,CKV_AWS_3
     profiles:
       - scanners
     networks:
@@ -127,7 +127,7 @@ services:
     volumes:
       - .:/workspace:ro
     working_dir: /workspace
-    command: detect --config /workspace/DevSecOps/.gitleaks.toml --source /workspace --no-git --report-format json --report-path /tmp/gitleaks-results.json
+    command: detect --config /workspace/DevSecOps/.gitleaks.toml --source /workspace --no-git --report-format json
     profiles:
       - scanners
     networks:


### PR DESCRIPTION
- Create scanner-results/ folder for organized JSON storage
- Update docker-compose.yml to output all scanner results to scanner-results/
- Update Makefile to redirect scanner output to organized folder
- Update .gitignore to exclude scanner-results/ folder
- Add OPA test functions to demonstrate JSON output
- All scanners now output JSON to scanner-results/:
  - opa-results.json (OPA policy validation)
  - checkov-results.json (Checkov infrastructure scan)
  - gitleaks-results.json (Gitleaks secret detection)

This provides a clean, organized structure for team collaboration and easy backend integration with all scanner results in one location.