### PR TITLE
docs: add PMO team scope and update backlog

### DIFF
--- a/docs/GITHUB_ISSUES_BACKLOG.md
+++ b/docs/GITHUB_ISSUES_BACKLOG.md
@@ -107,6 +107,10 @@ This section highlights **known dependencies** and **common bottlenecks** so tea
 | **Metrics Endpoint (B18)** | Prometheus & Grafana | Data |
 | **Account APIs (B12)** | Account UI & switcher | Frontend |
 | **RBAC (B9)** | Secure multi-user access | Security |
+| **API Gateway auth (S17)** | Scan endpoints protected | Frontend, DevOps |
+| **AI remediation (AI-5, AI-7)** | Remediation text to review | Security (S26) |
+| **Terraform CI/CD (D14)** | Infra applies on merge | Backend (B6), all infra work |
+| **MailHog (D16)** | Local email testing | Backend (B19), Frontend (W12) |
 
 ---
 
@@ -138,6 +142,7 @@ This is **expected behavior**, not failure.
 - Single AWS account + optional **1 extra account**
 - RBAC (admin/viewer)
 - Health + metrics endpoints
+- Email service (MailHog dev, SES prod)
 
 ## Frontend (≈4)
 - Marketing landing page
@@ -147,6 +152,7 @@ This is **expected behavior**, not failure.
 - Persist scan results on refresh
 - Simple account switcher (if backend supports)
 - First-time onboarding
+- Email flows UX (welcome, reset, alerts) with MailHog testing
 
 ## Security (≈4)
 - Top **10 IAM finding types**
@@ -154,6 +160,9 @@ This is **expected behavior**, not failure.
 - False-positive reduction + deduplication
 - IAM relationships (user / group / role)
 - OAuth + RBAC security review
+- API Gateway auth, CORS, rate limiting, security headers
+- OPA/Checkov/Gitleaks documentation and baseline
+- Remediation content review (pairs with AI)
 
 ## DevOps (≈4)
 - CI green
@@ -161,6 +170,9 @@ This is **expected behavior**, not failure.
 - One deployable environment
 - Terraform cleanup
 - Health check + deployment verification
+- Terraform apply on merge (infra deployment)
+- Vite in Docker (Frontend onboarding)
+- MailHog (local email testing)
 
 ## Data (≈4)
 - Prometheus scraping backend metrics
@@ -230,6 +242,7 @@ This is **expected behavior**, not failure.
 | B13 | (SEMESTER) Normalize scans to unified findings schema | M4 |
 | B14b | (SEMESTER) API: latest scan results (refresh-safe) | M4 |
 | B18 | (SEMESTER) Metrics endpoint for Prometheus | M4 |
+| B19 | (SEMESTER) Configure email service (MailHog for dev, SES for prod) | M4 |
 | B2 | (SEMESTER) Design multi-account *lite* (2 accounts max) | M5 |
 | B4 | (SEMESTER) Cross-account role assumption | M5 |
 | B11 | (SEMESTER) Multi-account scanning (*lite*) | M5 |
@@ -250,6 +263,7 @@ This is **expected behavior**, not failure.
 | W5 | (SEMESTER) Account connection status UI | M5 |
 | W7 | (SEMESTER) Simple account switcher | M5 |
 | W4 | (SEMESTER) First-time onboarding | M5 |
+| W12 | (SEMESTER) Use MailHog for local email flows (welcome, reset password, alerts) | M4 |
 
 ### Security
 | ID | Title | Milestone |
@@ -260,6 +274,17 @@ This is **expected behavior**, not failure.
 | S5 | (SEMESTER) Deduplicate/suppress noise | M4 |
 | S15 | (SEMESTER) Review OAuth/Cognito config | M3 |
 | S16 | (SEMESTER) Validate backend authz enforcement | M5 |
+| S17 | (SEMESTER) API Gateway auth (Cognito JWT or API key) | M5 |
+| S18 | (SEMESTER) Document OPA/Rego policies | M4 |
+| S19 | (SEMESTER) Document Checkov skip rationale | M4 |
+| S20 | (SEMESTER) Gitleaks baseline & allowlist | M3 |
+| S21 | (SEMESTER) IAM least-privilege audit (Lambda, GitHub Actions) | M5 |
+| S22 | (SEMESTER) Security headers on API responses | M4 |
+| S23 | (SEMESTER) Rate limiting on API Gateway | M5 |
+| S24 | (SEMESTER) Audit logging for sensitive actions | M5 |
+| S25 | (SEMESTER) CORS configuration review | M3 |
+| S26 | (SEMESTER) Remediation content security review (pairs with AI) | M4 |
+| S27 | (SEMESTER) Dependency vulnerability scanning in CI | M1 |
 
 ### Data & Reporting (Expanded)
 | ID | Title | Milestone |
@@ -279,6 +304,9 @@ This is **expected behavior**, not failure.
 | D8 | (SEMESTER) Lint/format gates in CI | M6 |
 | D12 | (SEMESTER) Optimize Docker images | M6 |
 | D13 | (SEMESTER) Deployment verification (/health) | M6 |
+| D14 | (SEMESTER) Add CI/CD workflow to apply Terraform on merge (infra deployment) | M1 |
+| D15 | (SEMESTER) Add Vite service to Docker for simpler Frontend onboarding | M1 |
+| D16 | (SEMESTER) Add MailHog for local email testing (welcome, reset password, alerts) | M4 |
 
 ### AI (v1 only)
 | ID | Title | Milestone |
@@ -316,11 +344,11 @@ This table shows the *ideal long-term flow* of the project and explains why mile
 
 | Milestone | Name | Issues | Goal |
 |---|---|---|---|
-| **M1** | Foundation & process | F1–F6, P1, P2, P4 | CI green, docs updated, clear “done” criteria |
+| **M1** | Foundation & process | F1–F6, P1, P2, P4, S27, D14, D15 | CI green, docs updated, clear “done” criteria |
 | **M2** | Auth spine (backend) | B1, B6, B7, B10 | Cognito exists; OAuth + JWT working |
-| **M3** | Auth + landing (frontend) | W1, W2, W3 | Landing page + login/session end-to-end |
-| **M4** | Single-account quality | S1–S3, B13, B14b, B17, B18, A8, A9, W8–W11, W10b | Trusted findings, unified schema, better UX, refresh persistence, starter dashboards |
-| **M5** | Multi-account backend | B2, B4, B8, B11, B12 | Cross-account ingestion + account APIs (lite) |
+| **M3** | Auth + landing (frontend) | W1, W2, W3, S15, S20, S25 | Landing page + login/session end-to-end |
+| **M4** | Single-account quality | S1–S3, S5, S18, S19, S22, S26, B13, B14b, B17, B18, B19, A8, A9, W8–W11, W10b, W12, D16 | Trusted findings, unified schema, better UX, refresh persistence, starter dashboards |
+| **M5** | Multi-account backend | B2, B4, B8, B11, B12, S16, S17, S21, S23, S24 | Cross-account ingestion + account APIs (lite) |
 | **M6** | Multi-account frontend | W5, W6, W7 | Account status, switcher, multi-account UI |
 | **M7** | RBAC & security review *(POST)* | B9, S15, S16, W4 | RBAC enforced, auth security reviewed, onboarding |
 | **M8** | Data & reporting *(POST)* | A1–A7, A10–A15 | Metrics pipelines, Grafana, exports, docs |
@@ -333,7 +361,7 @@ This table shows the *ideal long-term flow* of the project and explains why mile
 
 > **Note:**  
 > This is the **entire backlog**, including post-semester work.  
-> **This semester:** we will only create and work issues labeled `(SEMESTER)` (≈70 total).
+> **This semester:** we will only create and work issues labeled `(SEMESTER)` (≈85 total).
 
 | Department | # of issues |
 |---|---:|

--- a/docs/team-scope/PMO.md
+++ b/docs/team-scope/PMO.md
@@ -1,0 +1,178 @@
+# PMO Team Scope — IAM Dashboard (Spring 2026)
+
+**Team:** Project Management Office (PMO)  
+**Members:** 3  
+**Timeline:** Feb 17 – Apr 17, 2026 (9 weeks)
+
+---
+
+## Team Mission
+
+Keep the project on pace, manage dependencies, enforce scope, and ensure smooth delivery of the Apr 17 demo.
+
+---
+
+## Team Members & Roles
+
+| Name | Role | Responsibilities |
+|---|---|---|
+| **Joaquin** | PMO Lead | Overall project pacing, external stakeholder management, escalation, final sign-off on scope/demo readiness |
+| **Elsa** | PM — Dependency & Demo Coordination | Track cross-team blockers, organize weekly demos, ensure features are demo-ready |
+| **Jewels** | PM — Scope Enforcement & Documentation | Maintain backlog/roadmap, enforce semester scope, update docs, track progress/velocity |
+
+**Note:** All 3 PMs can pick up technical issues during downtime by coordinating with team leads.
+
+---
+
+## In Scope (Semester)
+
+### Core Responsibilities
+
+1. **Project Pacing & Deadlines**
+   - Track milestone progress (P0, M1–M6) and ensure Apr 17 demo readiness
+   - Escalate risks and blockers to instructors or leads
+
+2. **PR Management**
+   - Monitor open PRs, ensure 2 required reviews (GitHub-enforced)
+   - Nudge reviewers when PRs stall, verify PRs link issues and pass CI
+
+3. **Dependency Tracking & Escalation**
+   - Track cross-team blockers (e.g. Frontend blocked by Backend schema)
+   - **Escalation SLA:**
+     - **24 hours:** Escalate blocker to team leads or PMO Lead
+     - **48 hours max:** Re-route issue or assign workaround if blocker unresolved
+
+4. **Weekly Demos**
+   - Organize and run weekly demos, ensure teams are prepared
+   - Capture feedback and next steps
+
+5. **Scope Enforcement**
+   - Ensure teams only work on `(SEMESTER)` issues
+   - Block `(POST)` work, protect delivery timeline
+
+6. **Documentation Maintenance**
+   - Keep `docs/GITHUB_ISSUES_BACKLOG.md` up to date
+   - Update milestone mappings and document decisions
+
+7. **Progress Visibility & Velocity Tracking**
+   - **Target velocity:** 9–11 issues closed per week (85 issues ÷ 9 weeks ≈ 9.4/week)
+   - Track weekly issue closure rate by team and overall
+   - Report weekly: "Week X: Y issues closed (Z% of target), A blockers escalated"
+   - Identify teams ahead/behind, adjust workload or re-route issues
+
+8. **Cross-Team Coordination**
+   - Facilitate standups, async check-ins, or WhatsApp communication
+   - Ensure teams know who owns what and when
+
+9. **Technical Contribution (Downtime)**
+   - Pick up issues from any team during light PM load
+   - Coordinate with team leads before starting
+
+---
+
+## Out of Scope (Implied)
+
+- Writing code for features owned by other teams (unless explicitly picking up an issue during downtime)
+- Detailed technical design decisions (defer to team leads)
+- Infrastructure provisioning or AWS account management (defer to DevOps/Infra)
+
+---
+
+## Key Dependencies
+
+| Depends On | Why |
+|---|---|
+| **All teams** | PMO needs status updates and honest communication to track progress |
+| **CI Green (F1)** | PRs can't be reviewed/merged if CI is broken |
+| **GitHub org access** | All PMs need repo admin/triage access for PR management and issue triage |
+
+---
+
+## Risks & Assumptions
+
+| Risk | Mitigation |
+|---|---|
+| **Teams don't report blockers early** | Weekly check-ins, async WhatsApp pings, dependency tracking |
+| **PR reviews stall (missing 2nd reviewer)** | PMO nudges reviewers, escalates to leads |
+| **Scope creep (teams work on `(POST)` issues)** | PMO reviews new issues, blocks out-of-scope work |
+| **PMO lead unavailable (external club)** | Elsa and Jewels escalate and decide independently |
+| **PMO becomes a bottleneck** | Clear delegation, PMs act independently |
+
+**Assumptions:**
+- Teams report progress and blockers honestly
+- GitHub enforces 2-reviewer requirement
+- Weekly demos happen consistently
+
+---
+
+## Definition of Done (Demo-Level)
+
+PMO is "done" if:
+
+1. **Apr 17 demo is successful** — all 7 demo criteria met, no major blockers
+2. **All `(SEMESTER)` issues tracked** — created, assigned, closed; no out-of-scope work
+3. **Dependency blockers resolved** — escalated within 24 hours, resolved or re-routed within 48 hours max
+4. **Documentation up to date** — backlog, roadmap, onboarding reflect current state
+5. **Weekly demos run** — at least 7 demos (P0 → M6), teams demoed working features
+6. **Retrospective complete** — lessons learned captured, post-semester roadmap published
+
+---
+
+## Interview-Ready Outcomes
+
+When describing PMO work in interviews, you can say:
+
+- **"Managed an 85-issue backlog across 7 teams (Backend, Frontend, Security, DevOps, Data, AI, Foundation) for a 9-week sprint."**
+
+- **"Tracked and escalated cross-team dependencies with 24-hour SLA, re-routing work within 48 hours if blockers persisted."**
+
+- **"Organized and ran 7 weekly demos, keeping stakeholders aligned and teams accountable."**
+
+- **"Enforced semester scope by blocking out-of-scope work and re-routing teams when priorities shifted."**
+
+- **"Tracked velocity at 9.4 issues/week average across 9-week sprint, identifying bottlenecks and re-routing work to stay on pace."**
+
+- **"Led a team of 3 PMs, delegating dependency tracking, demo coordination, and documentation maintenance."**
+
+- **"Delivered a live demo on Apr 17 with 100% of semester goals met (auth, scan, findings, remediation, exports)."**
+
+---
+
+## Task Delegation
+
+| Responsibility | Owner | Notes |
+|---|---|---|
+| **Overall project pacing** | Lead | Final escalation point, stakeholder communication |
+| **External club management** | Lead | Not PMO work, but affects availability |
+| **Cross-team dependency tracking** | Elsa | Maintains dependency matrix, escalates blockers |
+| **Weekly demo organization** | Elsa | Schedules, coordinates, ensures teams are ready |
+| **Scope enforcement (issue triage)** | Jewels | Reviews new issues, blocks `(POST)` work |
+| **Backlog/roadmap maintenance** | Jewels | Updates `GITHUB_ISSUES_BACKLOG.md` as work shifts |
+| **Progress tracking & velocity** | Jewels | Tracks completed issues, reports weekly status |
+| **PR monitoring & nudging** | All 3 | Shared responsibility; rotate weekly or per-team |
+| **Standups / Slack coordination** | Lead + Elsa | Lead sets tone, Elsa facilitates day-to-day |
+| **Technical issue pickup (downtime)** | All 3 | Coordinate with team leads before starting work |
+| **End-of-semester retro (P5)** | Lead + Elsa + Jewels | Co-facilitate, document lessons learned |
+
+---
+
+## Weekly Cadence (Example)
+
+- **Monday:** Check milestone progress, review open PRs, ping stalled reviewers
+- **Tuesday:** Dependency check-in (WhatsApp or standup), escalate blockers
+- **Wednesday:** Demo prep (Elsa confirms what each team will demo)
+- **Thursday:** Weekly demo (Elsa runs, all 3 attend)
+- **Friday:** Backlog review (Jewels updates docs), **velocity report (X issues closed this week, Y% of 9.4/week target)**, plan next week
+
+---
+
+## Contact & Escalation
+
+- **WhatsApp:** Team group chat or DMs
+- **Escalation:** Elsa/Jewels → Lead → Instructor/TA
+- **Technical issues:** Coordinate with team leads before picking up work
+
+---
+
+**Signature (Conceptual):**  
+This scope was defined by the PMO team on [Date]. Work begins immediately after submission.


### PR DESCRIPTION
- Add PMO team scope document (docs/team-scope/PMO.md)

- Update GITHUB_ISSUES_BACKLOG.md with new Security and DevOps issues