### PR TITLE
Add dependency vulnerability scanning to CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,26 @@
 # Dependabot configuration for IAM Dashboard
-# This file configures automated dependency updates
+# This file configures automated dependency updates.
+# PRs opened by Dependabot are checked by the Dependency Vulnerability Audit workflow;
+# high/critical vulns will block merge. See docs/VULNERABILITY_SCANNING.md.
 
 version: 2
 updates:
+  # Frontend (npm) dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "security-team"
+    assignees:
+      - "security-team"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
   # Python dependencies
   - package-ecosystem: "pip"
     directory: "/"

--- a/.github/pip-audit-ignore.txt
+++ b/.github/pip-audit-ignore.txt
@@ -1,0 +1,4 @@
+# List of vulnerability IDs to ignore (one per line).
+# Use only for documented, accepted exceptions. See docs/VULNERABILITY_SCANNING.md.
+# Example:
+# CVE-2024-12345

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -48,6 +48,14 @@ Before deploying, you must configure the following secrets in GitHub:
   - Uploads results as artifacts
 - **Secrets Required**: None
 
+### dependency-audit.yml
+- **Triggers**: Pull request and push to `main` and `develop`
+- **Actions**:
+  - **Frontend**: `npm audit` — fails when severity is high or critical (configurable via `NPM_AUDIT_LEVEL`)
+  - **Backend**: `pip-audit` on `requirements.txt` and `infra/lambda/requirements.txt` — fails on any vuln unless listed in `.github/pip-audit-ignore.txt`
+- **Purpose**: Block PRs when known dependency vulnerabilities are present. See [docs/VULNERABILITY_SCANNING.md](../docs/VULNERABILITY_SCANNING.md) for resolving and suppressing findings.
+- **Secrets Required**: None
+
 ## 🔒 Security Notes
 
 - Never commit AWS account IDs or ARNs directly in workflow files

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,91 @@
+# Dependency Vulnerability Scanning - Blocks PRs when high/critical vulns are found
+# Severities that trigger a block are configurable via env vars below.
+
+name: Dependency Vulnerability Audit
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+
+env:
+  # Minimum npm severity to fail the pipeline: critical | high | moderate | low
+  # Default: high (so high and critical block the PR)
+  NPM_AUDIT_LEVEL: "high"
+  # Pip-audit fails on any vulnerability by default; use .github/pip-audit-ignore.txt
+  # to list acceptable exceptions (one CVE/vuln ID per line).
+
+jobs:
+  frontend-audit:
+    name: Frontend (npm audit)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run npm audit
+        run: |
+          echo "Running npm audit (fail on severity >= ${{ env.NPM_AUDIT_LEVEL }})..."
+          npm audit --audit-level="${{ env.NPM_AUDIT_LEVEL }}" || {
+            echo "::error::Frontend has ${{ env.NPM_AUDIT_LEVEL }} or critical vulnerabilities. Fix with 'npm audit fix' or update dependencies. See docs/VULNERABILITY_SCANNING.md"
+            exit 1
+          }
+        env:
+          NPM_AUDIT_LEVEL: ${{ env.NPM_AUDIT_LEVEL }}
+
+  backend-audit:
+    name: Backend (pip-audit)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install pip-audit
+        run: pip install pip-audit
+
+      - name: Run pip-audit (main app)
+        run: |
+          IGNORE_ARGS=()
+          if [ -f .github/pip-audit-ignore.txt ]; then
+            while IFS= read -r line; do
+              [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
+              IGNORE_ARGS+=(--ignore-vuln "$line")
+            done < .github/pip-audit-ignore.txt
+            echo "Using ignore list from .github/pip-audit-ignore.txt"
+          fi
+          echo "Auditing main requirements.txt..."
+          pip-audit -r requirements.txt --desc "${IGNORE_ARGS[@]}" || {
+            echo "::error::Backend dependencies have known vulnerabilities. Update packages or add acceptable exceptions to .github/pip-audit-ignore.txt. See docs/VULNERABILITY_SCANNING.md"
+            exit 1
+          }
+
+      - name: Run pip-audit (Lambda)
+        run: |
+          IGNORE_ARGS=()
+          if [ -f .github/pip-audit-ignore.txt ]; then
+            while IFS= read -r line; do
+              [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
+              IGNORE_ARGS+=(--ignore-vuln "$line")
+            done < .github/pip-audit-ignore.txt
+          fi
+          echo "Auditing infra/lambda/requirements.txt..."
+          pip-audit -r infra/lambda/requirements.txt --desc "${IGNORE_ARGS[@]}" || {
+            echo "::error::Lambda dependencies have known vulnerabilities. Update packages or add acceptable exceptions to .github/pip-audit-ignore.txt. See docs/VULNERABILITY_SCANNING.md"
+            exit 1
+          }

--- a/docs/VULNERABILITY_SCANNING.md
+++ b/docs/VULNERABILITY_SCANNING.md
@@ -1,0 +1,134 @@
+# Dependency Vulnerability Scanning
+
+This project runs **dependency vulnerability scanning** in CI. Pull requests are **blocked** when high or critical vulnerabilities are found in frontend (npm) or backend (Python) dependencies.
+
+## Tools Used
+
+| Stack    | Tool       | Purpose                          |
+|----------|------------|-----------------------------------|
+| Frontend | `npm audit`| Scan npm dependencies for CVEs   |
+| Backend  | `pip-audit`| Scan pip dependencies for CVEs   |
+
+The workflow runs on every **pull request** and **push** to `main` and `develop`. If the audit fails, the PR cannot be merged until vulnerabilities are fixed or explicitly accepted (see [Suppressing acceptable exceptions](#suppressing-acceptable-exceptions)).
+
+---
+
+## Configuring Which Severities Block CI
+
+### Frontend (npm)
+
+The minimum severity that fails the pipeline is set by the **`NPM_AUDIT_LEVEL`** environment variable in [.github/workflows/dependency-audit.yml](../.github/workflows/dependency-audit.yml).
+
+| Value      | Effect: PR is blocked when…        |
+|-----------|-------------------------------------|
+| `critical`| Only critical vulnerabilities      |
+| `high`    | High or critical (default)         |
+| `moderate`| Moderate, high, or critical         |
+| `low`     | Any vulnerability                  |
+
+To change it, edit the `env` block in the workflow:
+
+```yaml
+env:
+  NPM_AUDIT_LEVEL: "high"   # change to "critical", "moderate", or "low"
+```
+
+### Backend (pip-audit)
+
+`pip-audit` currently fails the job when **any** vulnerability is reported. There is no severity filter in the tool itself. To allow specific vulnerabilities (e.g. accepted risks), use the [ignore list](#suppressing-acceptable-exceptions) below.
+
+---
+
+## How to Resolve Identified Vulnerabilities
+
+### Frontend (npm)
+
+1. **Run the audit locally**
+   ```bash
+   npm audit
+   ```
+2. **Apply automatic fixes where possible**
+   ```bash
+   npm audit fix
+   ```
+3. **For breaking or major upgrades**, review and upgrade manually:
+   ```bash
+   npm audit fix --force   # may introduce breaking changes; test thoroughly
+   ```
+   Or update specific packages:
+   ```bash
+   npm update <package-name>
+   # or
+   npm install <package-name>@latest
+   ```
+4. **Re-run the audit**
+   ```bash
+   npm audit --audit-level=high
+   ```
+5. Commit the updated `package.json` and `package-lock.json` and push. CI will run the same check.
+
+### Backend (Python)
+
+1. **Run the audit locally**
+   ```bash
+   pip install pip-audit
+   pip-audit -r requirements.txt
+   pip-audit -r infra/lambda/requirements.txt
+   ```
+2. **Act on the report**  
+   `pip-audit` prints each vulnerability and, when available, fix versions. Update your `requirements.txt` (or Lambda `requirements.txt`) to use the suggested versions, for example:
+   ```text
+   # Before (vulnerable)
+   requests==2.28.0
+
+   # After (fixed)
+   requests==2.31.0
+   ```
+3. **Reinstall and re-audit**
+   ```bash
+   pip install -r requirements.txt
+   pip-audit -r requirements.txt
+   ```
+4. Commit the updated `requirements.txt` and push. CI will run the same check.
+
+---
+
+## Suppressing Acceptable Exceptions
+
+Sometimes a vulnerability is **accepted** (e.g. false positive, no fix yet, or accepted risk with mitigation). In those cases you can suppress it so it does not block CI.
+
+### Process for adding an exception
+
+1. **Document the exception**  
+   In the PR or in a comment in the repo, record:
+   - The vulnerability ID (e.g. CVE-2024-12345).
+   - Why it is accepted (e.g. “Not in our code path”, “Mitigated by network policy”, “No fix available; tracking in ISSUE-123”).
+   - A short expiry or review date if it is temporary.
+
+2. **Add the ID to the ignore list**  
+   Edit [.github/pip-audit-ignore.txt](../.github/pip-audit-ignore.txt) and add one vulnerability ID per line. Lines starting with `#` and blank lines are ignored.
+
+   **Example `.github/pip-audit-ignore.txt`:**
+   ```text
+   # Accepted: not used in production code path. Review in Q3.
+   CVE-2024-12345
+   # Pending upstream fix; tracked in ISSUE-456
+   PYSEC-2024-42
+   ```
+
+3. **Only for Python**  
+   The ignore list is used only by `pip-audit` in the backend-audit job. npm does not use this file.
+
+### npm exceptions
+
+For npm, use [audit exceptions](https://docs.npmjs.com/cli/v8/commands/npm-audit#audit-level) via `package.json` or `npm audit` configuration, or adjust `NPM_AUDIT_LEVEL` in the workflow if you want to allow lower severities. Prefer fixing or upgrading over suppressing.
+
+---
+
+## Integration with Dependabot
+
+- **Dependabot** is configured in [.github/dependabot.yml](../.github/dependabot.yml) for npm, pip, GitHub Actions, Docker, and Terraform.
+- It opens PRs to bump dependencies on a schedule. When those PRs are opened, the **Dependency Vulnerability Audit** workflow runs and will block merge if new high/critical vulnerabilities are present.
+- Workflow: **Dependabot PR → dependency-audit workflow runs → PR blocked if vulns → fix or suppress → merge.**
+
+This keeps dependency updates and vulnerability scanning aligned: Dependabot proposes updates, and the audit ensures we don’t merge PRs that introduce or retain blocking vulnerabilities.


### PR DESCRIPTION
- Add dependency-audit workflow: npm audit (frontend) + pip-audit (backend)
- Block PRs when high/critical vulns found; configurable via NPM_AUDIT_LEVEL
- Add .github/pip-audit-ignore.txt for acceptable exceptions
- Add npm to Dependabot; document integration with audit workflow
- Add docs/VULNERABILITY_SCANNING.md: resolve vulns, suppress exceptions