### PR TITLE
D14 - Add CI/CD workflow to apply Terraform on merge (infra deployment) #179

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,0 +1,80 @@
+name: Terraform Apply (infra)
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "infra/**"
+      - ".github/workflows/terraform-apply.yml"
+
+  push:
+    branches: [ main ]
+    paths:
+      - "infra/**"
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: terraform-infra-main
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    name: Terraform Plan (PR)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform fmt
+        run: terraform fmt -check -recursive
+
+      - name: Terraform init
+        run: terraform init -input=false
+
+      - name: Terraform validate
+        run: terraform validate
+
+      - name: Terraform plan
+        run: terraform plan -input=false -no-color
+
+  apply:
+    name: Terraform Apply (main)
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform init
+        run: terraform init -input=false
+
+      - name: Terraform apply
+        run: terraform apply -auto-approve -input=false


### PR DESCRIPTION
## Solve Issue #179
Terraform changes merged into main do not automatically run terraform apply, requiring manual infrastructure updates.

## Solution
Adds a GitHub Actions workflow that:
- Runs terraform plan on pull requests affecting infra/
- Runs terraform apply on merge to main
- Uses the existing OIDC role and remote S3 backend
- Triggers only when infrastructure files change

This improves deployment automation and reduces the risk of infrastructure drift.