### PR TITLE
ci: disable terraform apply on main

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -53,28 +53,28 @@ jobs:
       - name: Terraform plan
         run: terraform plan -input=false -no-color
 
-  apply:
-    name: Terraform Apply (main)
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: infra
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-
-      - name: Terraform init
-        run: terraform init -input=false
-
-      - name: Terraform apply
-        run: terraform apply -auto-approve -input=false
+  # apply:
+  #   name: Terraform Apply (main)
+  #   if: github.event_name == 'push'
+  #   runs-on: ubuntu-latest
+  #   defaults:
+  #     run:
+  #       working-directory: infra
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #
+  #     - name: Configure AWS credentials (OIDC)
+  #       uses: aws-actions/configure-aws-credentials@v4
+  #       with:
+  #         role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+  #         aws-region: us-east-1
+  #
+  #     - name: Setup Terraform
+  #       uses: hashicorp/setup-terraform@v3
+  #
+  #     - name: Terraform init
+  #       run: terraform init -input=false
+  #
+  #     - name: Terraform apply
+  #       run: terraform apply -auto-approve -input=false


### PR DESCRIPTION
This is not a real PR, I'm testing the updated deploy workflow, so that it only runs on push to main, not on PRs. This way, we aren't deploying code to AWS twice. It will be closed once I confirm that the workflow works as expected.