### PR TITLE
security:  CKV_DOCKER_2 and CKV_DOCKER_3 skips to affected Docker files

### DIFF
--- a/DevSecOps/.checkov.yml
+++ b/DevSecOps/.checkov.yml
@@ -44,8 +44,6 @@ skip-check:
   - CKV_AWS_355 # Does not allow * for statement resource. Skipping because the GitHub user needs admin privileges
   - CKV_AWS_290 # Does not allow write access without constraints
   - CKV2_AWS_40 # Does not allow of for full IAM privileges
-  - CKV_DOCKER_2 # Build images (e.g. Lambda package) don't need HEALTHCHECK; tracked in DevOps backlog
-  - CKV_DOCKER_3 # Frontend entrypoint runs as root to install deps then su-exec app; tracked in DevOps backlog
 
 # Optional: keep summary at top
 summary-position: top

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,4 +1,5 @@
 # Vite dev server for local development — no Node.js needed on host
+#checkov:skip=CKV_DOCKER_3:Entrypoint runs as root for npm ci on mounted volumes, then su-exec drops to app user
 FROM node:20-alpine
 
 # Healthcheck + su-exec to run dev server as app user after entrypoint installs deps

--- a/infra/lambda/Dockerfile.build
+++ b/infra/lambda/Dockerfile.build
@@ -1,5 +1,7 @@
 # Build Lambda deployment package (zip) with deps. Use from repo root:
 #   docker build -f infra/lambda/Dockerfile.build -o out infra/lambda
+#checkov:skip=CKV_DOCKER_2:Build-only image with no runtime process; HEALTHCHECK is not applicable
+#checkov:skip=CKV_DOCKER_3:Build-only image with no CMD/ENTRYPOINT; non-root user is not applicable
 FROM python:3.13-slim
 
 WORKDIR /build


### PR DESCRIPTION
Moves CKV_DOCKER_2 and CKV_DOCKER_3 from global .checkov.yml skips to inline #checkov:skip; new dockerfiles will be scanned against both rules.

No change needed for Dockerfile as it passes CKV_DOCKER_2 & 3.
Added inline skip for dockerfile.frontend (ckv-docker3, using su-exec pattern)
Added inline skips for dockerfile.build for both CKV_DOCKER_2 & 3.