### PR TITLE
Feature/refine iam rules s1 false positive audit

### DIFF
--- a/docs/security/FALSE_POSITIVES_CATALOG.md
+++ b/docs/security/FALSE_POSITIVES_CATALOG.md
@@ -1,0 +1,91 @@
+# False Positives Catalog (S1)
+
+**Purpose:** Catalog findings that the IAM/security scanner reports as risks but are not real security issues in this project’s context. For each type, cause and impact are noted so detection rules (e.g. S2), deduplication/suppression (S5), and remediation guidance can be updated for a more trustworthy dashboard.
+
+**Source:** Security Summary Report (comprehensive IAM scan), 93 findings (5 critical, 78 high, 9 medium, 1 low). This document lists **types** of findings that should be treated as false positives or accepted-by-design.
+
+---
+
+## 1. AWS service-linked roles (write on `*` / service-wide permissions)
+
+| Item | Details |
+|------|--------|
+| **Finding type** | Role has “write permissions on all resources (`*`)” or “full &lt;service&gt; service permissions (&lt;service&gt;:*)” |
+| **Example resources** | `AWSServiceRoleForAmazonGuardDuty`, `AWSServiceRoleForAmazonInspector2`, `AWSServiceRoleForAPIGateway`, `AWSServiceRoleForCloudTrail`, `AWSServiceRoleForConfig`, `AWSServiceRoleForOrganizations`, `AWSServiceRoleForResourceExplorer`, `AWSServiceRoleForSupport` |
+| **Cause** | Scanner flags any role with `Resource: "*"` or broad service actions (e.g. `cloudtrail:*`) as high risk. |
+| **Impact** | These roles are created and managed by AWS. Customers cannot change or restrict their policies; they are required for the service to operate. Flagging them is noise and reduces trust in the dashboard. |
+
+**Recommendation:** Suppress or exclude roles whose name (or ARN) matches AWS service-linked role patterns (e.g. `arn:aws:iam::*:role/aws-service-role/*`). Do not show them as actionable findings.
+
+---
+
+## 2. Intentional test/demo roles (admin, wildcard, S3 wildcard)
+
+| Item | Details |
+|------|--------|
+| **Finding type** | Role has AdministratorAccess, full wildcard policy (`*`), or service-wide policy (e.g. `s3:*`) and name indicates test/demo use. |
+| **Example resources** | `test-admin-role-1764893836`, `test-wildcard-role-1764893836`, `test-s3-wildcard-role-1764893836` |
+| **Cause** | Scanner flags admin and wildcard permissions as critical/high regardless of intent. |
+| **Impact** | These roles exist to test the scanner and dashboard (intentional misconfigurations). They are not used by production workloads. Showing them as critical/high findings obscures real issues. |
+
+**Recommendation:** Suppress or tag as “Known test resource” by role name pattern (e.g. `test-*-*`) or by a resource tag. Optionally allow users to mark roles as “test/demo” so they are deduplicated or shown with lower severity.
+
+---
+
+## 3. Project CI/CD and application roles (broad permissions by design)
+
+| Item | Details |
+|------|--------|
+| **Finding type** | Role has “write permissions on all resources (`*`)”, “full &lt;service&gt; service permissions”, or “can create/modify IAM resources” (e.g. `iam:CreateRole`, `iam:PutRolePolicy`, `iam:AttachRolePolicy`). |
+| **Example resources** | `IAM-Dash-GitHub-CD`, `iam-dashboard-deployer-prod`, `iam-dashboard-lambda-role`, `iam-dashboard-role-backend`, `iam-dashboard-role-data`, `iam-dashboard-role-devops` |
+| **Cause** | Scanner treats any `Resource: "*"` or `Action: "service:*"` as high risk and flags IAM write actions as dangerous. |
+| **Impact** | Deployment and application roles need broad access to deploy and operate the dashboard (Lambda, S3, DynamoDB, API Gateway, CloudFront, IAM for role creation, etc.). Restricting to a minimal set would require very long action/resource lists; risk is mitigated by OIDC (GitHub Actions), assume-role scope, and controlled use. These are accepted by design for this project. |
+
+**Recommendation:** Allow suppression or “accepted-by-design” for specific role names or tags (e.g. `project=iam-dashboard`). Update remediation guidance to say: “If this role is a deploy or app role with documented justification, you can mark it as accepted; otherwise apply least privilege.”
+
+---
+
+## 4. Demo/lab users (MFA, access key age, inactive login)
+
+| Item | Details |
+|------|--------|
+| **Finding type** | User “does not have MFA enabled”; access key “is X days old” (e.g. &gt; 90); user “has not logged in for X days”; access key “has not been used in X days”. |
+| **Example resources** | `cyber-alvin`, `cyber-Akif`, `cyber-Alexa`, `cyber-Dev`, `cyber-test`, and their access keys |
+| **Cause** | Scanner applies standard best practices (MFA, 90-day key rotation, inactive user review) without account context. |
+| **Impact** | In a shared demo/lab account, these may be placeholder or training identities with no real usage. Treating them as critical/high/medium creates noise and can be misleading when the account is not production. |
+
+**Recommendation:** When the account (or user list) is marked as “demo” or “lab”, suppress or downgrade these findings. In remediation guidance, add: “If this is a demo/lab account, consider tagging it so MFA/key-age/inactivity findings are filtered or de-prioritized.”
+
+---
+
+## 5. Unrelated application roles (same account, different scope)
+
+| Item | Details |
+|------|--------|
+| **Finding type** | Same as for project roles: write on `*`, full service permissions (e.g. `dynamodb:*`, `dax:*`). |
+| **Example resources** | `KeenKloud`, `MarketUpdater-role-gyl79baw`, `NextWave-role-e212w7zp`, `keen-vibe-api-role`, `keen-vibe-worker-role`, `riterhythm-lambda-role` |
+| **Cause** | Scanner runs account-wide and flags all IAM entities with broad permissions. |
+| **Impact** | These roles belong to other applications in the same AWS account, not to the IAM Dashboard. For a project-focused dashboard, they are out of scope; showing them mixes project findings with unrelated ones and can confuse owners. |
+
+**Recommendation:** Support scope filtering (e.g. by tag, role name prefix, or “project” attribute) so the dashboard can show only project-relevant resources. Optionally suppress or separate “out-of-scope” roles so they are not counted in project metrics.
+
+---
+
+## 6. Single admin user in lab/demo (AdministratorAccess)
+
+| Item | Details |
+|------|--------|
+| **Finding type** | User has AdministratorAccess (or equivalent) attached. |
+| **Example resources** | `iamadmin` |
+| **Cause** | Scanner flags any user with admin policy as critical. |
+| **Impact** | In a lab or demo account, a single admin user is often intentional for setup and testing. In production, this would be a real finding. Context-dependent. |
+
+**Recommendation:** In remediation guidance, state: “Acceptable in lab/demo accounts for setup; in production, remove AdministratorAccess and use least-privilege roles.” Allow marking the finding as “Accepted – lab account” so it can be suppressed or deduplicated (S5).
+
+---
+
+## Summary: How to use this catalog
+
+- **Detection rules (S2):** Add exceptions or lower severity for AWS service-linked roles, test role name patterns, and (optionally) tagged “demo” accounts or “accepted-by-design” roles.
+- **Deduplication/suppression (S5):** Use role/user name patterns, ARN patterns, or tags to suppress the types above so they do not inflate critical/high counts.
+- **Remediation guidance:** For each type, link to this doc and clarify when a finding is a false positive or accepted-by-design so analysts can triage without treating them as real security issues.

--- a/docs/security/SCANNERS.md
+++ b/docs/security/SCANNERS.md
@@ -289,6 +289,33 @@ If OPA policies seem too strict:
 
 ---
 
+## IAM Scanner tuning (false-positive reduction)
+
+The IAM scanner used by the dashboard (Lambda: `infra/lambda/lambda_function.py`, function `scan_iam`) supports optional parameters to reduce known false positives identified in **S1**.
+
+### Defaults (safe for dev/demo)
+
+- **Service-linked roles suppressed**: AWS-managed roles (e.g. `AWSServiceRoleFor*` and ARNs containing `:role/aws-service-role/`) are excluded unless explicitly enabled.
+- **Test/demo resources suppressed**: identities/roles starting with `test-` or `demo-` are excluded (these are commonly created by `scripts/create-iam-test-resources.sh`).
+- **Demo identity best-practice findings suppressed in non-prod**: user names starting with prefixes in `demo_identity_prefixes` (default `["cyber-"]`) are excluded when `ENVIRONMENT != "prod"`.
+
+### Request parameters (JSON)
+
+Pass these in the body of the scan request (e.g. `POST /scan/iam`):
+
+- **`suppress_service_linked_roles`**: boolean (default `true`)
+- **`suppress_test_resources`**: boolean (default `true`)
+- **`suppress_demo_identity_findings`**: boolean (default `true` when `ENVIRONMENT != "prod"`)
+- **`demo_identity_prefixes`**: string[] (default `["cyber-"]`)
+- **`scope_name_prefixes`**: string[] (optional). If set, only include users/roles whose names start with one of these prefixes.
+- **`scope_tag_key`** / **`scope_tag_value`**: strings (optional). If set, only include users/roles whose IAM tags match this key/value.
+
+### Why this exists
+
+These knobs apply the S1 false-positive catalog so findings focus on actionable project-owned roles/users rather than AWS-managed service roles, intentional test fixtures, or demo identities.
+
+---
+
 ## Getting Help
 
 ### Resources

--- a/infra/lambda/lambda_function.py
+++ b/infra/lambda/lambda_function.py
@@ -258,6 +258,47 @@ def _cors_response_headers(event: Optional[Dict[str, Any]]) -> Dict[str, str]:
         headers['Vary'] = 'Origin'
     return headers
 
+def is_service_linked_role(role_name: str, role_arn: str) -> bool:
+    """
+    AWS service-linked roles are AWS-managed and generally not actionable:
+    - Name often starts with AWSServiceRoleFor*
+    - ARN path usually contains :role/aws-service-role/
+    """
+    rn = (role_name or "").strip()
+    ra = (role_arn or "").strip()
+    return rn.startswith("AWSServiceRoleFor") or (":role/aws-service-role/" in ra)
+
+def is_test_resource(name: str) -> bool:
+    """Heuristic for intentional test/demo resources created by project scripts."""
+    n = (name or "").strip().lower()
+    return n.startswith("test-") or n.startswith("demo-")
+
+def is_demo_identity(name: str, scan_params: Dict[str, Any]) -> bool:
+    """
+    Heuristic for lab/demo identities that are expected to violate best practices.
+    Kept intentionally configurable to avoid hiding real production issues.
+    """
+    prefixes = scan_params.get("demo_identity_prefixes")
+    if not isinstance(prefixes, list) or not prefixes:
+        prefixes = ["cyber-"]
+    nn = (name or "").strip().lower()
+    return any(nn.startswith(str(p).lower()) for p in prefixes)
+
+def _tags_match(tags: list, key: str, value: str) -> bool:
+    if not key or value is None:
+        return False
+    for t in tags or []:
+        if t.get("Key") == key and t.get("Value") == value:
+            return True
+    return False
+
+def is_in_scope_by_name(name: str, scan_params: Dict[str, Any]) -> bool:
+    prefixes = scan_params.get("scope_name_prefixes")
+    if not isinstance(prefixes, list) or not prefixes:
+        return True  # no scoping requested
+    nn = (name or "").strip().lower()
+    return any(nn.startswith(str(p).lower()) for p in prefixes)
+
 
 def publish_metric(metric_name: str, value: float, dimensions: Dict[str, str] = None):
     """Publish a custom CloudWatch metric"""
@@ -1115,6 +1156,12 @@ def scan_iam(region: str, scan_params: Dict[str, Any], scan_id: str) -> Dict[str
     """Scan IAM for security issues"""
     try:
         logger.info(f"Scanning IAM in region: {region}")
+        scan_params = scan_params or {}
+        suppress_service_linked = bool(scan_params.get("suppress_service_linked_roles", True))
+        suppress_test_resources = bool(scan_params.get("suppress_test_resources", True))
+        suppress_demo_identities = bool(scan_params.get("suppress_demo_identity_findings", ENVIRONMENT != "prod"))
+        scope_tag_key = scan_params.get("scope_tag_key")
+        scope_tag_value = scan_params.get("scope_tag_value")
         
         # List users
         users = iam.list_users()
@@ -1138,6 +1185,22 @@ def scan_iam(region: str, scan_params: Dict[str, Any], scan_id: str) -> Dict[str
             user_arn = user.get('Arn', f'arn:aws:iam::{account_id}:user/{user_name}')
             
             try:
+                if suppress_test_resources and is_test_resource(user_name):
+                    continue
+                if suppress_demo_identities and is_demo_identity(user_name, scan_params):
+                    # Demo/lab identities are expected to be noncompliant; suppress to reduce noise.
+                    continue
+                if not is_in_scope_by_name(user_name, scan_params):
+                    continue
+                if scope_tag_key and scope_tag_value:
+                    try:
+                        user_tags = iam.list_user_tags(UserName=user_name).get("Tags", [])
+                        if not _tags_match(user_tags, str(scope_tag_key), str(scope_tag_value)):
+                            continue
+                    except ClientError:
+                        # If we can't read tags, fall back to name-only scoping.
+                        pass
+
                 # Check MFA
                 mfa_devices = iam.list_mfa_devices(UserName=user_name)
                 if not mfa_devices.get('MFADevices'):
@@ -1270,6 +1333,20 @@ def scan_iam(region: str, scan_params: Dict[str, Any], scan_id: str) -> Dict[str
             role_arn = role.get('Arn', f'arn:aws:iam::{account_id}:role/{role_name}')
             
             try:
+                if suppress_test_resources and is_test_resource(role_name):
+                    continue
+                if suppress_service_linked and is_service_linked_role(role_name, role_arn):
+                    continue
+                if not is_in_scope_by_name(role_name, scan_params):
+                    continue
+                if scope_tag_key and scope_tag_value:
+                    try:
+                        role_tags = iam.list_role_tags(RoleName=role_name).get("Tags", [])
+                        if not _tags_match(role_tags, str(scope_tag_key), str(scope_tag_value)):
+                            continue
+                    except ClientError:
+                        pass
+
                 # Get role details including trust policy
                 role_details = iam.get_role(RoleName=role_name)
                 assume_role_policy = role_details.get('Role', {}).get('AssumeRolePolicyDocument', {})

--- a/infra/lambda/lambda_function.py
+++ b/infra/lambda/lambda_function.py
@@ -217,6 +217,52 @@ def _target_account_from_scan_params(params: Dict[str, Any]) -> Optional[str]:
     return None
 
 
+def is_service_linked_role(role_name: str, role_arn: str) -> bool:
+    """
+    AWS service-linked roles are AWS-managed and generally not actionable:
+    - Name often starts with AWSServiceRoleFor*
+    - ARN path usually contains :role/aws-service-role/
+    """
+    rn = (role_name or "").strip()
+    ra = (role_arn or "").strip()
+    return rn.startswith("AWSServiceRoleFor") or (":role/aws-service-role/" in ra)
+
+
+def is_test_resource(name: str) -> bool:
+    """Heuristic for intentional test/demo resources created by project scripts."""
+    n = (name or "").strip().lower()
+    return n.startswith("test-") or n.startswith("demo-")
+
+
+def is_demo_identity(name: str, scan_params: Dict[str, Any]) -> bool:
+    """
+    Heuristic for lab/demo identities that are expected to violate best practices.
+    Kept intentionally configurable to avoid hiding real production issues.
+    """
+    prefixes = scan_params.get("demo_identity_prefixes")
+    if not isinstance(prefixes, list) or not prefixes:
+        prefixes = ["cyber-"]
+    nn = (name or "").strip().lower()
+    return any(nn.startswith(str(p).lower()) for p in prefixes)
+
+
+def _tags_match(tags: list, key: str, value: str) -> bool:
+    if not key or value is None:
+        return False
+    for t in tags or []:
+        if t.get("Key") == key and t.get("Value") == value:
+            return True
+    return False
+
+
+def is_in_scope_by_name(name: str, scan_params: Dict[str, Any]) -> bool:
+    prefixes = scan_params.get("scope_name_prefixes")
+    if not isinstance(prefixes, list) or not prefixes:
+        return True
+    nn = (name or "").strip().lower()
+    return any(nn.startswith(str(p).lower()) for p in prefixes)
+
+
 def _cors_allowed_origins_set() -> set:
     raw = os.environ.get('CORS_ALLOWED_ORIGINS', '')
     return {o.strip() for o in raw.split(',') if o.strip()}
@@ -1162,7 +1208,7 @@ def scan_iam(region: str, scan_params: Dict[str, Any], scan_id: str) -> Dict[str
         suppress_demo_identities = bool(scan_params.get("suppress_demo_identity_findings", ENVIRONMENT != "prod"))
         scope_tag_key = scan_params.get("scope_tag_key")
         scope_tag_value = scan_params.get("scope_tag_value")
-        
+
         # List users
         users = iam.list_users()
         user_list = users.get('Users', [])
@@ -1179,16 +1225,14 @@ def scan_iam(region: str, scan_params: Dict[str, Any], scan_id: str) -> Dict[str
         
         # Get account ID
         account_id = sts.get_caller_identity().get('Account', 'N/A')
-        
+        users_considered = 0
+
         for user in user_list:
             user_name = user['UserName']
             user_arn = user.get('Arn', f'arn:aws:iam::{account_id}:user/{user_name}')
-            
+
             try:
                 if suppress_test_resources and is_test_resource(user_name):
-                    continue
-                if suppress_demo_identities and is_demo_identity(user_name, scan_params):
-                    # Demo/lab identities are expected to be noncompliant; suppress to reduce noise.
                     continue
                 if not is_in_scope_by_name(user_name, scan_params):
                     continue
@@ -1198,71 +1242,71 @@ def scan_iam(region: str, scan_params: Dict[str, Any], scan_id: str) -> Dict[str
                         if not _tags_match(user_tags, str(scope_tag_key), str(scope_tag_value)):
                             continue
                     except ClientError:
-                        # If we can't read tags, fall back to name-only scoping.
-                        pass
+                        continue
 
-                # Check MFA
-                mfa_devices = iam.list_mfa_devices(UserName=user_name)
-                if not mfa_devices.get('MFADevices'):
-                    users_without_mfa += 1
-                    high_findings += 1
-                    findings.append({
-                        'severity': 'High',
-                        'type': 'user',
-                        'resource_name': user_name,
-                        'resource_arn': user_arn,
-                        'description': f'IAM user "{user_name}" does not have MFA enabled',
-                        'recommendation': 'Enable MFA for this user to enhance account security',
-                        'finding_type': 'missing_mfa'
-                    })
-                else:
-                    users_with_mfa += 1
-                
-                # Check access keys
-                access_keys = iam.list_access_keys(UserName=user_name)
-                key_metadata = access_keys.get('AccessKeyMetadata', [])
-                
-                for key in key_metadata:
-                    key_id = key.get('AccessKeyId')
-                    key_status = key.get('Status')
-                    create_date = key.get('CreateDate')
-                    
-                    # Check if key is old (over 90 days)
-                    if create_date:
-                        from datetime import datetime, timezone
-                        key_age = (datetime.now(timezone.utc) - create_date.replace(tzinfo=timezone.utc)).days
-                        if key_age > 90:
-                            medium_findings += 1
-                            findings.append({
-                                'severity': 'Medium',
-                                'type': 'access_key',
-                                'resource_name': mask_sensitive_data(f'{user_name}/{key_id}'),
-                                'resource_arn': mask_sensitive_data(user_arn),
-                                'description': mask_sensitive_data(f'Access key {key_id} for user "{user_name}" is {key_age} days old'),
-                                'recommendation': 'Rotate access keys every 90 days for security best practices',
-                                'finding_type': 'old_access_key'
-                            })
-                    
-                    # Check last used
-                    try:
-                        last_used = iam.get_access_key_last_used(AccessKeyId=key_id)
-                        last_used_date = last_used.get('AccessKeyLastUsed', {}).get('LastUsedDate')
-                        if last_used_date:
-                            days_since_use = (datetime.now(timezone.utc) - last_used_date.replace(tzinfo=timezone.utc)).days
-                            if days_since_use > 90:
-                                low_findings += 1
+                users_considered += 1
+                suppress_demo_noise = suppress_demo_identities and is_demo_identity(user_name, scan_params)
+
+                # MFA / access keys / inactive console use: suppress for configured demo identities only.
+                if not suppress_demo_noise:
+                    mfa_devices = iam.list_mfa_devices(UserName=user_name)
+                    if not mfa_devices.get('MFADevices'):
+                        users_without_mfa += 1
+                        high_findings += 1
+                        findings.append({
+                            'severity': 'High',
+                            'type': 'user',
+                            'resource_name': user_name,
+                            'resource_arn': user_arn,
+                            'description': f'IAM user "{user_name}" does not have MFA enabled',
+                            'recommendation': 'Enable MFA for this user to enhance account security',
+                            'finding_type': 'missing_mfa'
+                        })
+                    else:
+                        users_with_mfa += 1
+
+                    access_keys = iam.list_access_keys(UserName=user_name)
+                    key_metadata = access_keys.get('AccessKeyMetadata', [])
+
+                    for key in key_metadata:
+                        key_id = key.get('AccessKeyId')
+                        key_status = key.get('Status')
+                        create_date = key.get('CreateDate')
+
+                        if create_date:
+                            from datetime import datetime, timezone
+                            key_age = (datetime.now(timezone.utc) - create_date.replace(tzinfo=timezone.utc)).days
+                            if key_age > 90:
+                                medium_findings += 1
                                 findings.append({
-                                    'severity': 'Low',
+                                    'severity': 'Medium',
                                     'type': 'access_key',
                                     'resource_name': mask_sensitive_data(f'{user_name}/{key_id}'),
                                     'resource_arn': mask_sensitive_data(user_arn),
-                                    'description': mask_sensitive_data(f'Access key {key_id} has not been used in {days_since_use} days'),
-                                    'recommendation': 'Consider removing unused access keys',
-                                    'finding_type': 'unused_access_key'
+                                    'description': mask_sensitive_data(f'Access key {key_id} for user "{user_name}" is {key_age} days old'),
+                                    'recommendation': 'Rotate access keys every 90 days for security best practices',
+                                    'finding_type': 'old_access_key'
                                 })
-                    except ClientError:
-                        pass  # Skip if we can't get last used info
-                
+
+                        try:
+                            last_used = iam.get_access_key_last_used(AccessKeyId=key_id)
+                            last_used_date = last_used.get('AccessKeyLastUsed', {}).get('LastUsedDate')
+                            if last_used_date:
+                                days_since_use = (datetime.now(timezone.utc) - last_used_date.replace(tzinfo=timezone.utc)).days
+                                if days_since_use > 90:
+                                    low_findings += 1
+                                    findings.append({
+                                        'severity': 'Low',
+                                        'type': 'access_key',
+                                        'resource_name': mask_sensitive_data(f'{user_name}/{key_id}'),
+                                        'resource_arn': mask_sensitive_data(user_arn),
+                                        'description': mask_sensitive_data(f'Access key {key_id} has not been used in {days_since_use} days'),
+                                        'recommendation': 'Consider removing unused access keys',
+                                        'finding_type': 'unused_access_key'
+                                    })
+                        except ClientError:
+                            pass  # Skip if we can't get last used info
+
                 # Check for admin policies
                 try:
                     attached_policies = iam.list_attached_user_policies(UserName=user_name)
@@ -1284,9 +1328,8 @@ def scan_iam(region: str, scan_params: Dict[str, Any], scan_id: str) -> Dict[str
                             break
                 except ClientError:
                     pass  # Skip if we can't check policies
-                
-                # Check password last used
-                if user.get('PasswordLastUsed'):
+
+                if not suppress_demo_noise and user.get('PasswordLastUsed'):
                     from datetime import datetime, timezone
                     last_used = user['PasswordLastUsed'].replace(tzinfo=timezone.utc)
                     days_inactive = (datetime.now(timezone.utc) - last_used).days
@@ -1305,7 +1348,7 @@ def scan_iam(region: str, scan_params: Dict[str, Any], scan_id: str) -> Dict[str
             except ClientError as e:
                 logger.warning(f"Error analyzing user {user_name}: {str(e)}")
                 continue
-        
+
         # List roles
         roles = iam.list_roles()
         role_list = roles.get('Roles', [])
@@ -1326,12 +1369,13 @@ def scan_iam(region: str, scan_params: Dict[str, Any], scan_id: str) -> Dict[str
             'gitlab.com': 'GitLab CI',
             'circleci.com': 'CircleCI'
         }
-        
+
+        roles_considered = 0
         # Analyze roles for infrastructure security
         for role in role_list[:100]:  # Increased limit to analyze more roles
             role_name = role['RoleName']
             role_arn = role.get('Arn', f'arn:aws:iam::{account_id}:role/{role_name}')
-            
+
             try:
                 if suppress_test_resources and is_test_resource(role_name):
                     continue
@@ -1345,8 +1389,9 @@ def scan_iam(region: str, scan_params: Dict[str, Any], scan_id: str) -> Dict[str
                         if not _tags_match(role_tags, str(scope_tag_key), str(scope_tag_value)):
                             continue
                     except ClientError:
-                        pass
+                        continue
 
+                roles_considered += 1
                 # Get role details including trust policy
                 role_details = iam.get_role(RoleName=role_name)
                 assume_role_policy = role_details.get('Role', {}).get('AssumeRolePolicyDocument', {})
@@ -1519,13 +1564,13 @@ def scan_iam(region: str, scan_params: Dict[str, Any], scan_id: str) -> Dict[str
         return {
             'account_id': account_id,
             'users': {
-                'total': len(user_list),
+                'total': users_considered,
                 'with_mfa': users_with_mfa,
                 'without_mfa': users_without_mfa,
                 'inactive': inactive_users
             },
             'roles': {
-                'total': len(role_list)
+                'total': roles_considered
             },
             'policies': {
                 'total': len(policy_list)


### PR DESCRIPTION
Refines scanner logic and documents changes per the S1 false-positive audit: suppressions for AWS service-linked roles, test/demo resources, and demo identities; optional scope filters; updates in docs/security/SCANNERS.md and docs/security/FALSE_POSITIVES_CATALOG.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a False Positives Catalog listing six categories of IAM findings considered accepted-by-design or context-dependent.
  * Added an IAM scanner tuning guide describing suppression options, mapping categories to suppression/deduplication approaches, and analyst remediation guidance.

* **New Features**
  * Scanner now supports configurable suppression of service-linked roles, test/demo identities, and demo-identity findings with environment-aware defaults.
  * Added scope filtering by name prefixes and optional tag-based constraints to reduce scan noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->