### PR TITLE
D19: Lambda Code Signing with AWS Signer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,7 @@ jobs:
         echo "lambda_function=iam-dashboard-scanner" >> $GITHUB_OUTPUT
         echo "s3_bucket=iam-dashboard-project" >> $GITHUB_OUTPUT
         echo "cloudfront_id=" >> $GITHUB_OUTPUT
+        echo "artifacts_bucket=IAMDash-lambda-artifacts" >> $GITHUB_OUTPUT
 
     - name: Setup Node.js
       uses: actions/setup-node@v4
@@ -84,15 +85,71 @@ jobs:
         docker buildx rm lambda-builder 2>/dev/null || true
         echo "Lambda package: lambda-out/lambda_function.zip"
 
-    - name: Deploy Lambda Function
+    - name: Upload Lambda artifact to S3
+      id: upload-artifact
       run: |
-        LAMBDA_FUNCTION_NAME="${{ steps.deployment-vars.outputs.lambda_function }}"
-        if [ -z "$LAMBDA_FUNCTION_NAME" ]; then
-          echo "No Lambda function name found, using default: iam-dashboard-scanner"
-          LAMBDA_FUNCTION_NAME="iam-dashboard-scanner"
+        BUCKET="${{ steps.deployment-vars.outputs.artifacts_bucket }}"
+        KEY="unsigned/lambda_function_$(date +%Y%m%d%H%M%S).zip"
+        echo "Uploading unsigned Lambda package to s3://${BUCKET}/${KEY}"
+        aws s3 cp lambda-out/lambda_function.zip "s3://${BUCKET}/${KEY}"
+        VERSION_ID=$(aws s3api head-object \
+          --bucket "${BUCKET}" --key "${KEY}" \
+          --query 'VersionId' --output text)
+        echo "s3_key=${KEY}" >> $GITHUB_OUTPUT
+        echo "s3_version_id=${VERSION_ID}" >> $GITHUB_OUTPUT
+
+    - name: Sign Lambda artifact with AWS Signer
+      id: sign-artifact
+      run: |
+        BUCKET="${{ steps.deployment-vars.outputs.artifacts_bucket }}"
+        KEY="${{ steps.upload-artifact.outputs.s3_key }}"
+        VERSION="${{ steps.upload-artifact.outputs.s3_version_id }}"
+
+        # Discover the signing profile
+        PROFILE=$(aws signer list-signing-profiles \
+          --query "profiles[?platformId=='AWSLambda-SHA384-ECDSA'].profileName | [0]" \
+          --output text)
+        echo "Using signing profile: ${PROFILE}"
+
+        # Start signing job
+        JOB_ID=$(aws signer start-signing-job \
+          --source "s3={bucketName=${BUCKET},key=${KEY},version=${VERSION}}" \
+          --destination "s3={bucketName=${BUCKET},prefix=signed/}" \
+          --profile-name "${PROFILE}" \
+          --query 'jobId' --output text)
+        echo "Signing job started: ${JOB_ID}"
+
+        # Wait for signing to complete (up to 150s)
+        for i in $(seq 1 30); do
+          STATUS=$(aws signer describe-signing-job --job-id "${JOB_ID}" \
+            --query 'status' --output text)
+          echo "  Attempt ${i}: status=${STATUS}"
+          if [ "${STATUS}" = "Succeeded" ]; then
+            SIGNED_KEY=$(aws signer describe-signing-job --job-id "${JOB_ID}" \
+              --query 'signedObject.s3.key' --output text)
+            echo "signed_s3_key=${SIGNED_KEY}" >> $GITHUB_OUTPUT
+            break
+          elif [ "${STATUS}" = "Failed" ]; then
+            echo "::error::Signing job failed"
+            aws signer describe-signing-job --job-id "${JOB_ID}"
+            exit 1
+          fi
+          sleep 5
+        done
+
+        if [ "${STATUS}" != "Succeeded" ]; then
+          echo "::error::Signing job timed out after 150 seconds"
+          exit 1
         fi
-        echo "Updating Lambda function $LAMBDA_FUNCTION_NAME"
+
+    - name: Deploy signed Lambda function
+      run: |
+        BUCKET="${{ steps.deployment-vars.outputs.artifacts_bucket }}"
+        SIGNED_KEY="${{ steps.sign-artifact.outputs.signed_s3_key }}"
+        FUNCTION="${{ steps.deployment-vars.outputs.lambda_function }}"
+        echo "Deploying signed artifact from s3://${BUCKET}/${SIGNED_KEY}"
         aws lambda update-function-code \
-          --function-name "$LAMBDA_FUNCTION_NAME" \
-          --zip-file fileb://lambda-out/lambda_function.zip
-        echo "Lambda function deployed successfully"
+          --function-name "${FUNCTION}" \
+          --s3-bucket "${BUCKET}" \
+          --s3-key "${SIGNED_KEY}"
+        echo "Lambda function deployed with signed code successfully"

--- a/DevSecOps/.checkov.yml
+++ b/DevSecOps/.checkov.yml
@@ -35,7 +35,6 @@ skip-check:
   - CKV_AWS_3
   - CKV_AWS_309 # API Gateway Authorization type. Ignored temporarily until Cognito is added
   - CKV_AWS_117 # Mandates that Lambda is launched in a VPC. Less security and more architectural preference
-  - CKV_AWS_272 # Enforces Lambda to use Code Signing. This is a large architecture change, and isn't strictly necessary. Might add in the future.
   - CKV_AWS_116 # Forces Lambda to be connected an SQS Dead Letter Queue. Since Lambda is connected to APIGateway, this isn't strictly necessary.
   - CKV_AWS_144 # Cross-region replication is an architecture/DR roadmap item and is not required for the current project.
   - CKV_AWS_70  # Public read is required for S3 static website hosting in this architecture (no CloudFront).

--- a/infra/github-actions/main.tf
+++ b/infra/github-actions/main.tf
@@ -72,7 +72,8 @@ resource "aws_iam_role_policy" "github_actions_s3_policy" {
         ]
         Resource = [
           "arn:aws:s3:::${var.frontend_s3_bucket_name}",
-          "arn:aws:s3:::${var.scan_results_s3_bucket_name}"
+          "arn:aws:s3:::${var.scan_results_s3_bucket_name}",
+          "arn:aws:s3:::${var.lambda_artifacts_s3_bucket_name}"
         ]
       },
       {
@@ -88,7 +89,8 @@ resource "aws_iam_role_policy" "github_actions_s3_policy" {
         ]
         Resource = [
           "arn:aws:s3:::${var.frontend_s3_bucket_name}/*",
-          "arn:aws:s3:::${var.scan_results_s3_bucket_name}/*"
+          "arn:aws:s3:::${var.scan_results_s3_bucket_name}/*",
+          "arn:aws:s3:::${var.lambda_artifacts_s3_bucket_name}/*"
         ]
       }
     ]
@@ -128,6 +130,28 @@ resource "aws_iam_role_policy" "github_actions_lambda_policy" {
           "arn:aws:lambda:${var.aws_region}:*:function:${var.lambda_function_name}",
           "arn:aws:lambda:${var.aws_region}:*:function:${var.lambda_function_name}:*"
         ]
+      }
+    ]
+  })
+}
+
+# Policy for AWS Signer (Lambda code signing)
+resource "aws_iam_role_policy" "github_actions_signer_policy" {
+  name = "${var.github_actions_role_name}-signer-policy"
+  role = aws_iam_role.github_actions_deployer.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "signer:StartSigningJob",
+          "signer:DescribeSigningJob",
+          "signer:GetSigningProfile",
+          "signer:ListSigningProfiles"
+        ]
+        Resource = "*"
       }
     ]
   })

--- a/infra/github-actions/variables.tf
+++ b/infra/github-actions/variables.tf
@@ -58,6 +58,12 @@ variable "dynamodb_table_name" {
   default     = "iam-dashboard-scan-results"
 }
 
+variable "lambda_artifacts_s3_bucket_name" {
+  description = "S3 bucket name for Lambda deployment artifacts (code signing)"
+  type        = string
+  default     = "iam-dashboard-lambda-artifacts"
+}
+
 variable "terraform_state_bucket" {
   description = "S3 bucket name for Terraform state (optional)"
   type        = string

--- a/infra/lambda/main.tf
+++ b/infra/lambda/main.tf
@@ -96,5 +96,94 @@ resource "aws_lambda_function" "scanner" {
     Service   = "scanner"
   }
 
+  code_signing_config_arn = aws_lambda_code_signing_config.scanner.arn
+
   depends_on = [aws_iam_role_policy.lambda_policy]
+}
+
+# ── Code Signing (CKV_AWS_272) ──────────────────────────────────────────────
+
+# AWS Signer signing profile for Lambda deployments
+resource "aws_signer_signing_profile" "lambda" {
+  platform_id = "AWSLambda-SHA384-ECDSA"
+  name_prefix = "iam_dashboard_"
+
+  signature_validity_period {
+    value = 135
+    type  = "MONTHS"
+  }
+
+  tags = {
+    Name      = "${var.project_name}-lambda-signing"
+    Project   = var.project_name
+    Env       = var.environment
+    ManagedBy = "terraform"
+  }
+}
+
+# Code signing config — only code signed by the profile above can run
+resource "aws_lambda_code_signing_config" "scanner" {
+  description = "Code signing for IAM Dashboard Lambda"
+
+  allowed_publishers {
+    signing_profile_version_arns = [aws_signer_signing_profile.lambda.version_arn]
+  }
+
+  policies {
+    untrusted_artifact_on_deployment = "Warn"
+  }
+}
+
+# ── Lambda Artifacts S3 Bucket (required by AWS Signer) ─────────────────────
+
+resource "aws_s3_bucket" "lambda_artifacts" {
+  bucket = "${var.project_name}-lambda-artifacts"
+
+  tags = {
+    Name      = "${var.project_name}-lambda-artifacts"
+    Project   = var.project_name
+    Env       = var.environment
+    ManagedBy = "terraform"
+  }
+}
+
+resource "aws_s3_bucket_versioning" "lambda_artifacts" {
+  bucket = aws_s3_bucket.lambda_artifacts.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "lambda_artifacts" {
+  bucket = aws_s3_bucket.lambda_artifacts.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "lambda_artifacts" {
+  bucket                  = aws_s3_bucket.lambda_artifacts.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "lambda_artifacts" {
+  bucket = aws_s3_bucket.lambda_artifacts.id
+
+  rule {
+    id     = "expire-old-artifacts"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
 }

--- a/infra/lambda/outputs.tf
+++ b/infra/lambda/outputs.tf
@@ -23,3 +23,13 @@ output "lambda_role_name" {
   value       = aws_iam_role.lambda_role.name
 }
 
+output "signing_profile_name" {
+  description = "Name of the AWS Signer signing profile for Lambda"
+  value       = aws_signer_signing_profile.lambda.name
+}
+
+output "lambda_artifacts_bucket" {
+  description = "S3 bucket for Lambda deployment artifacts (code signing)"
+  value       = aws_s3_bucket.lambda_artifacts.bucket
+}
+

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -82,17 +82,17 @@ module "api_gateway" {
 module "github_actions" {
   source = "./github-actions"
 
-  aws_region                       = var.aws_region
-  environment                      = var.environment
-  project_name                     = var.project_name
-  github_repo_owner                = var.github_repo_owner
-  github_repo_name                 = var.github_repo_name
-  frontend_s3_bucket_name          = var.s3_bucket_name
-  scan_results_s3_bucket_name      = var.scan_results_s3_bucket_name
-  lambda_function_name             = var.lambda_function_name
-  dynamodb_table_name              = var.dynamodb_table_name
-  lambda_artifacts_s3_bucket_name  = module.lambda.lambda_artifacts_bucket
+  aws_region                      = var.aws_region
+  environment                     = var.environment
+  project_name                    = var.project_name
+  github_repo_owner               = var.github_repo_owner
+  github_repo_name                = var.github_repo_name
+  frontend_s3_bucket_name         = var.s3_bucket_name
+  scan_results_s3_bucket_name     = var.scan_results_s3_bucket_name
+  lambda_function_name            = var.lambda_function_name
+  dynamodb_table_name             = var.dynamodb_table_name
+  lambda_artifacts_s3_bucket_name = module.lambda.lambda_artifacts_bucket
   # So CI can use Terraform backend (state bucket + lock table)
-  terraform_state_bucket           = "iam-dashboard-terraform-state"
-  terraform_state_lock_table       = "terraform-state-lock"
+  terraform_state_bucket          = "iam-dashboard-terraform-state"
+  terraform_state_lock_table      = "terraform-state-lock"
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -89,7 +89,8 @@ module "github_actions" {
   frontend_s3_bucket_name     = var.s3_bucket_name
   scan_results_s3_bucket_name = var.scan_results_s3_bucket_name
   lambda_function_name        = var.lambda_function_name
-  dynamodb_table_name         = var.dynamodb_table_name
+  dynamodb_table_name             = var.dynamodb_table_name
+  lambda_artifacts_s3_bucket_name = module.lambda.lambda_artifacts_bucket
   # So CI can use Terraform backend (state bucket + lock table)
   terraform_state_bucket     = "iam-dashboard-terraform-state"
   terraform_state_lock_table = "terraform-state-lock"

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -82,17 +82,17 @@ module "api_gateway" {
 module "github_actions" {
   source = "./github-actions"
 
-  aws_region                  = var.aws_region
-  environment                 = var.environment
-  project_name                = var.project_name
-  github_repo_owner           = var.github_repo_owner
-  github_repo_name            = var.github_repo_name
-  frontend_s3_bucket_name     = var.s3_bucket_name
-  scan_results_s3_bucket_name = var.scan_results_s3_bucket_name
-  lambda_function_name        = var.lambda_function_name
-  dynamodb_table_name             = var.dynamodb_table_name
-  lambda_artifacts_s3_bucket_name = module.lambda.lambda_artifacts_bucket
+  aws_region                       = var.aws_region
+  environment                      = var.environment
+  project_name                     = var.project_name
+  github_repo_owner                = var.github_repo_owner
+  github_repo_name                 = var.github_repo_name
+  frontend_s3_bucket_name          = var.s3_bucket_name
+  scan_results_s3_bucket_name      = var.scan_results_s3_bucket_name
+  lambda_function_name             = var.lambda_function_name
+  dynamodb_table_name              = var.dynamodb_table_name
+  lambda_artifacts_s3_bucket_name  = module.lambda.lambda_artifacts_bucket
   # So CI can use Terraform backend (state bucket + lock table)
-  terraform_state_bucket     = "iam-dashboard-terraform-state"
-  terraform_state_lock_table = "terraform-state-lock"
+  terraform_state_bucket           = "iam-dashboard-terraform-state"
+  terraform_state_lock_table       = "terraform-state-lock"
 }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -93,6 +93,6 @@ module "github_actions" {
   dynamodb_table_name             = var.dynamodb_table_name
   lambda_artifacts_s3_bucket_name = module.lambda.lambda_artifacts_bucket
   # So CI can use Terraform backend (state bucket + lock table)
-  terraform_state_bucket          = "iam-dashboard-terraform-state"
-  terraform_state_lock_table      = "terraform-state-lock"
+  terraform_state_bucket     = "iam-dashboard-terraform-state"
+  terraform_state_lock_table = "terraform-state-lock"
 }


### PR DESCRIPTION
Adds AWS Signer signing profile, Lambda code signing config, and a dedicated private S3 artifacts bucket. The deploy pipeline now uploads the Lambda zip to S3, signs it via AWS Signer, and deploys the signed artifact. Removes the global CKV_AWS_272 skip from Checkov. Key Note: Policy set to Warn initially.

Only remaining change needed is switching from Warn to Enforce in infra/lambda/main.tf:133

After our first successful signed deployment runs thru pipeline (without errors), we should change it to Enforce afterwards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lambda function deployments now include cryptographic code signing verification for enhanced security assurance.

* **Security & Infrastructure**
  * Deployment pipeline updated to sign all artifacts before Lambda function updates.
  * Infrastructure enhanced to support artifact management and signature validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->