### PR TITLE
resolved #194: Add scan history API and Grafana dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,7 @@ temp/
 *.tfstate
 *.tfstate.*
 .terraform/
+**/.terraform/
 
 # Lambda vendored deps (install at build: pip install -r requirements.txt -t .)
 infra/lambda/boto3/

--- a/backend/api/scan_history.py
+++ b/backend/api/scan_history.py
@@ -1,0 +1,147 @@
+"""
+Scan history API endpoint for scanner performance dashboards.
+"""
+
+import logging
+import os
+from datetime import datetime
+
+import psycopg2
+from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError
+from flask_restful import Resource, reqparse
+from werkzeug.exceptions import InternalServerError
+
+from services.dynamodb_service import DynamoDBService
+
+logger = logging.getLogger(__name__)
+
+
+class ScanHistoryResource(Resource):
+    """Returns recent scan records for dashboarding."""
+
+    def __init__(self):
+        self.dynamodb_service = DynamoDBService()
+        self.parser = reqparse.RequestParser()
+        self.parser.add_argument("limit", type=int, default=100, location="args")
+        self.parser.add_argument("scanner_type", type=str, required=False, location="args")
+        self.parser.add_argument("status", type=str, required=False, location="args")
+
+    def get(self):
+        """Get scan history records from DynamoDB with PostgreSQL fallback."""
+        args = self.parser.parse_args()
+        limit = max(1, min(args.get("limit", 100), 500))
+        scanner_type_filter = args.get("scanner_type")
+        status_filter = args.get("status")
+
+        try:
+            # Fetch all records, filter in Python, then slice so totals are accurate.
+            raw_records = self.dynamodb_service.list_scan_records(limit=None)
+            normalized = [self._normalize_record(item) for item in raw_records]
+
+            if scanner_type_filter:
+                normalized = [r for r in normalized if r["scanner_type"] == scanner_type_filter]
+            if status_filter:
+                normalized = [r for r in normalized if r["status"] == status_filter]
+
+            normalized.sort(key=lambda r: r["timestamp"], reverse=True)
+
+            return {"items": normalized[:limit], "total": len(normalized)}, 200
+
+        except (NoCredentialsError, ClientError, BotoCoreError) as error:
+            logger.warning("AWS unavailable, trying PostgreSQL: %s", str(error))
+            return self._get_from_postgres(limit, scanner_type_filter, status_filter)
+
+        except Exception as error:
+            logger.error("Unexpected error in scan history: %s", str(error), exc_info=True)
+            raise InternalServerError("Unexpected error fetching scan history.") from error
+
+    def _get_from_postgres(self, limit, scanner_type_filter=None, status_filter=None):
+        """Fallback to PostgreSQL for scan history."""
+        dsn = os.environ.get("DATABASE_URL")
+        if not dsn:
+            logger.error("DATABASE_URL not set; cannot fall back to PostgreSQL.")
+            raise InternalServerError("Database unavailable.")
+
+        try:
+            with psycopg2.connect(dsn) as conn:
+                with conn.cursor() as cur:
+                    conditions = []
+                    params = []
+
+                    if scanner_type_filter:
+                        conditions.append("scanner_type = %s")
+                        params.append(scanner_type_filter)
+                    if status_filter:
+                        conditions.append("status = %s")
+                        params.append(status_filter)
+
+                    where_clause = ("WHERE " + " AND ".join(conditions)) if conditions else ""
+
+                    cur.execute(f"SELECT COUNT(*) FROM scan_history {where_clause}", params)
+                    total = cur.fetchone()[0]
+
+                    cur.execute(
+                        f"""SELECT scan_id, scanner_type, status,
+                                   timestamp::text, started_at::text,
+                                   completed_at::text, duration_sec
+                            FROM scan_history
+                            {where_clause}
+                            ORDER BY timestamp DESC
+                            LIMIT %s""",
+                        params + [limit],
+                    )
+                    rows = cur.fetchall()
+
+            cols = [
+                "scan_id",
+                "scanner_type",
+                "status",
+                "timestamp",
+                "started_at",
+                "completed_at",
+                "duration_sec",
+            ]
+            items = [dict(zip(cols, row, strict=True)) for row in rows]
+            return {"items": items, "total": total}, 200
+
+        except Exception as db_error:
+            logger.error("PostgreSQL fallback failed: %s", str(db_error), exc_info=True)
+            raise InternalServerError("Database fallback failed.") from db_error
+
+    def _normalize_record(self, item):
+        """Normalize scan record shape for dashboard consumption."""
+        scanner_type = item.get("scanner_type") or item.get("scan_type", "")
+
+        timestamp = item.get("timestamp") or datetime.utcnow().isoformat()
+        results = item.get("results") if isinstance(item.get("results"), dict) else {}
+        started_at = item.get("started_at") or results.get("started_at") or timestamp
+        completed_at = item.get("completed_at") or results.get("completed_at") or timestamp
+        duration_sec = self._duration_seconds(started_at, completed_at)
+
+        return {
+            "scan_id": item.get("scan_id", ""),
+            "scanner_type": scanner_type,
+            "status": item.get("status") or results.get("status") or "unknown",
+            "timestamp": timestamp,
+            "started_at": started_at,
+            "completed_at": completed_at,
+            "duration_sec": duration_sec,
+        }
+
+    def _duration_seconds(self, started_at, completed_at):
+        """Compute duration in seconds from ISO timestamps."""
+        started_dt = self._parse_iso_datetime(started_at)
+        completed_dt = self._parse_iso_datetime(completed_at)
+        if not started_dt or not completed_dt:
+            return 0.0
+        return float(max((completed_dt - started_dt).total_seconds(), 0.0))
+
+    def _parse_iso_datetime(self, value):
+        """Best-effort parser for ISO timestamp strings."""
+        if not isinstance(value, str) or not value:
+            return None
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+

--- a/backend/app.py
+++ b/backend/app.py
@@ -20,6 +20,7 @@ from api.grafana import GrafanaResource
 from api.dashboard import DashboardResource
 from api.health import HealthResource
 from api.metrics import MetricsResource, register_metrics_hooks
+from api.scan_history import ScanHistoryResource
 from api.ir import (
     LLMTriageResource,
     LLMRootCauseResource,
@@ -86,6 +87,7 @@ def create_app():
     # Register API resources
     api.add_resource(HealthResource, '/health')
     api.add_resource(MetricsResource, '/metrics')
+    api.add_resource(ScanHistoryResource, '/scan-history')
     api.add_resource(DashboardResource, '/dashboard')
     api.add_resource(IAMResource, '/aws/iam')
     api.add_resource(EC2Resource, '/aws/ec2')

--- a/backend/services/dynamodb_service.py
+++ b/backend/services/dynamodb_service.py
@@ -101,7 +101,7 @@ class DynamoDBService:
             return items
         except ClientError as e:
             logger.error(f"DynamoDB error listing scan records: {str(e)}")
-            return []
+            raise
 
     def create_iam_finding(self, finding_data: Dict[str, Any]) -> bool:
         """Create a new IAM finding"""

--- a/backend/services/dynamodb_service.py
+++ b/backend/services/dynamodb_service.py
@@ -73,11 +73,32 @@ class DynamoDBService:
             logger.error(f"DynamoDB error getting scan record: {str(e)}")
             return None
 
-    def list_scan_records(self, limit: int = 100) -> List[Dict]:
-        """List recent scan records"""
+    def list_scan_records(self, limit: Optional[int] = 100) -> List[Dict]:
+        """List scan records using paginated DynamoDB scan.
+
+        If limit is None, fetches all records.
+        """
         try:
-            response = self.scan_results.scan(Limit=limit)
-            return response.get('Items', [])
+            items: List[Dict[str, Any]] = []
+
+            scan_kwargs: Dict[str, Any] = {}
+            if limit is not None:
+                scan_kwargs["Limit"] = max(1, int(limit))
+
+            response = self.scan_results.scan(**scan_kwargs)
+            items.extend(response.get('Items', []))
+
+            while response.get("LastEvaluatedKey"):
+                if limit is not None and len(items) >= scan_kwargs["Limit"]:
+                    break
+
+                scan_kwargs["ExclusiveStartKey"] = response["LastEvaluatedKey"]
+                response = self.scan_results.scan(**scan_kwargs)
+                items.extend(response.get('Items', []))
+
+            if limit is not None:
+                return items[: scan_kwargs["Limit"]]
+            return items
         except ClientError as e:
             logger.error(f"DynamoDB error listing scan records: {str(e)}")
             return []

--- a/config/grafana/dashboards/scanner-performance-dashboard.json
+++ b/config/grafana/dashboards/scanner-performance-dashboard.json
@@ -1,0 +1,74 @@
+{
+  "title": "Scanner Performance Dashboard",
+  "uid": "scanner-performance-a11",
+  "panels": [
+    {
+      "title": "Recent Scans",
+      "type": "table",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+      "datasource": "PostgreSQL",
+      "targets": [
+        {
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, scan_id, scanner_type, status, duration_sec FROM scan_history WHERE $__timeFilter(timestamp) ORDER BY timestamp DESC LIMIT 100",
+          "format": "table"
+        }
+      ]
+    },
+    {
+      "title": "Scan Duration by Scanner Type",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "datasource": "PostgreSQL",
+      "targets": [
+        {
+          "rawQuery": true,
+          "rawSql": "SELECT timestamp AS time, duration_sec, scanner_type FROM scan_history WHERE $__timeFilter(timestamp) ORDER BY timestamp",
+          "format": "time_series"
+        }
+      ]
+    },
+    {
+      "title": "Scan Success Rate",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 16 },
+      "datasource": "PostgreSQL",
+      "targets": [
+        {
+          "rawQuery": true,
+          "rawSql": "SELECT NOW() AS time, ROUND(100.0 * COUNT(*) FILTER (WHERE status = 'completed') / NULLIF(COUNT(*), 0), 1) AS success_rate FROM scan_history WHERE $__timeFilter(timestamp)",
+          "format": "table"
+        }
+      ]
+    },
+    {
+      "title": "Scan Failure Rate",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 16 },
+      "datasource": "PostgreSQL",
+      "targets": [
+        {
+          "rawQuery": true,
+          "rawSql": "SELECT NOW() AS time, ROUND(100.0 * COUNT(*) FILTER (WHERE status = 'failed') / NULLIF(COUNT(*), 0), 1) AS failure_rate FROM scan_history WHERE $__timeFilter(timestamp)",
+          "format": "table"
+        }
+      ]
+    },
+    {
+      "title": "Scanner Service Health",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 16 },
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "up{job=\"backend\"}"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 36,
+  "version": 2,
+  "refresh": "30s",
+  "time": { "from": "now-24h", "to": "now" }
+}
+


### PR DESCRIPTION
**Summary**

- Adds a new backend endpoint GET /api/v1/scan-history to support the Scanner Performance Dashboard.

- Uses DynamoDB paginated scans for history retrieval with accurate filtering + totals; includes a PostgreSQL fallback when AWS is unavailable.

- Provisions Grafana with the Scanner Performance Dashboard JSON (config/grafana/dashboards/scanner-performance-dashboard.json).

**Scope control**

- This PR intentionally contains only the dashboard-related changes (no local environment artifacts like .claude/ or Terraform state). .gitignore is tightened with **/.terraform/.

**Test plan**

- docker compose up (or existing dev flow)

- Hit GET http://localhost:5001/api/v1/scan-history?limit=50

- Open Grafana and confirm “Scanner Performance Dashboard” loads and panels query successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scan History API: view historical scans with filtering by scanner type/status and configurable limits (1–500).
  * Scanner Performance Dashboard: monitor success/failure rates, duration trends, recent scans table, and backend health.

* **Bug Fixes**
  * Improved reliability of scan history retrieval to provide consistent results when primary retrieval faces issues.

* **Chores**
  * .gitignore: expanded to ignore .terraform directories at any depth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->