### PR TITLE
Issue B11 - Multi account scanning for Flask app

### DIFF
--- a/backend/api/accounts.py
+++ b/backend/api/accounts.py
@@ -1,0 +1,39 @@
+"""
+Accounts API endpoint — exposes the list of AWS Organization accounts.
+
+GET /api/v1/accounts
+  Returns all active accounts in the organization, including the management account.
+  Response shape: [{id, name, email, is_management}, ...]
+
+  HTTP 502 is returned if the Organizations API call fails, so the frontend
+  always receives a clear error rather than an empty list.
+"""
+
+import logging
+from flask_restful import Resource
+from services.organizations_service import OrganizationsService
+
+logger = logging.getLogger(__name__)
+
+
+class AccountsResource(Resource):
+    """Accounts listing endpoint backed by AWS Organizations."""
+
+    def __init__(self):
+        self.org_service = OrganizationsService()
+
+    def get(self):
+        """Return all active accounts in the AWS Organization."""
+        try:
+            accounts = self.org_service.list_accounts()
+            return accounts, 200
+
+        except RuntimeError as e:
+            # Organizations API failure — surface a clear 502 so the frontend
+            # knows the account list is unavailable, not just empty
+            logger.error(f"Failed to list accounts: {str(e)}")
+            return {'error': str(e)}, 502
+
+        except Exception as e:
+            logger.error(f"Unexpected error in accounts endpoint: {str(e)}")
+            return {'error': 'Failed to retrieve accounts'}, 500

--- a/backend/api/aws_config.py
+++ b/backend/api/aws_config.py
@@ -1,122 +1,117 @@
 """
-AWS Config API endpoints for compliance and configuration management
+AWS Config API endpoints for compliance and configuration management.
+Supports multi-account scanning via optional account_id query parameter.
+When account_id is provided, an assumed-role session is used for that account.
 """
 
+import logging
 from flask_restful import Resource, reqparse
 from services.aws_service import AWSService
-import logging
+from services.organizations_service import OrganizationsService
 
 logger = logging.getLogger(__name__)
 
+
 class ConfigResource(Resource):
     """AWS Config analysis endpoint"""
-    
+
     def __init__(self):
-        self.aws_service = AWSService()
+        self.org_service = OrganizationsService()
         self.parser = reqparse.RequestParser()
-        self.parser.add_argument('region', type=str, help='AWS region')
-        self.parser.add_argument('resource_type', type=str, help='AWS resource type')
-        self.parser.add_argument('compliance_type', type=str, choices=['COMPLIANT', 'NON_COMPLIANT', 'NOT_APPLICABLE'])
-    
+        self.parser.add_argument('region', type=str, location='args', help='AWS region')
+        self.parser.add_argument('resource_type', type=str, location='args',
+                                 help='AWS resource type')
+        self.parser.add_argument('compliance_type', type=str, location='args',
+                                 choices=['COMPLIANT', 'NON_COMPLIANT', 'NOT_APPLICABLE'])
+        # account_id is optional — defaults to management account (backward compatible)
+        self.parser.add_argument('account_id', type=str, location='args',
+                                 help='Target AWS account ID')
+
     def get(self):
-        """Get AWS Config compliance data"""
+        """Get AWS Config compliance data, optionally scoped to a specific account."""
         try:
             args = self.parser.parse_args()
             region = args.get('region', 'us-east-1')
             resource_type = args.get('resource_type')
             compliance_type = args.get('compliance_type')
-            
-            # Get Config data
+            account_id = args.get('account_id')
+
+            # Resolve the boto3 session — assumed-role session for member accounts,
+            # default session for the management account or when no account_id given
+            session = self.org_service.get_session_for_account(account_id) \
+                if account_id else None
+            aws_service = AWSService(session=session)  # noqa: F841 — used when methods are wired
+
             config_data = {
+                'account_id': account_id,
                 'compliance_summary': self._get_compliance_summary(region),
                 'resource_inventory': self._get_resource_inventory(region, resource_type),
                 'configuration_changes': self._get_configuration_changes(region),
                 'compliance_rules': self._get_compliance_rules(region),
                 'recommendations': self._get_recommendations(region)
             }
-            
+
             return config_data, 200
-            
+
+        except RuntimeError as e:
+            # STS AssumeRole failure — return 403 per spec
+            logger.error(f"Account session error: {str(e)}")
+            return {'error': str(e)}, 403
         except Exception as e:
             logger.error(f"Error getting Config data: {str(e)}")
             return {'error': 'Failed to fetch Config data'}, 500
-    
+
     def _get_compliance_summary(self, region):
         """Get compliance summary from AWS Config"""
-        try:
-            # This would use boto3 to get compliance summary
-            return {
-                'total_resources': 0,
-                'compliant_resources': 0,
-                'non_compliant_resources': 0,
-                'not_applicable_resources': 0,
-                'compliance_percentage': 0
-            }
-        except Exception as e:
-            logger.error(f"Error getting compliance summary: {str(e)}")
-            return {}
-    
+        return {
+            'total_resources': 0,
+            'compliant_resources': 0,
+            'non_compliant_resources': 0,
+            'not_applicable_resources': 0,
+            'compliance_percentage': 0
+        }
+
     def _get_resource_inventory(self, region, resource_type=None):
         """Get resource inventory from AWS Config"""
-        try:
-            # This would use boto3 to get resource inventory
-            return {
-                'total_resources': 0,
-                'resource_types': {},
-                'resources_by_region': {},
-                'resources_by_account': {}
-            }
-        except Exception as e:
-            logger.error(f"Error getting resource inventory: {str(e)}")
-            return {}
-    
+        return {
+            'total_resources': 0,
+            'resource_types': {},
+            'resources_by_region': {},
+            'resources_by_account': {}
+        }
+
     def _get_configuration_changes(self, region):
         """Get configuration changes from AWS Config"""
-        try:
-            # This would use boto3 to get configuration changes
-            return {
-                'total_changes': 0,
-                'changes_by_resource_type': {},
-                'changes_by_severity': {},
-                'recent_changes': []
-            }
-        except Exception as e:
-            logger.error(f"Error getting configuration changes: {str(e)}")
-            return {}
-    
+        return {
+            'total_changes': 0,
+            'changes_by_resource_type': {},
+            'changes_by_severity': {},
+            'recent_changes': []
+        }
+
     def _get_compliance_rules(self, region):
         """Get compliance rules from AWS Config"""
-        try:
-            # This would use boto3 to get compliance rules
-            return {
-                'total_rules': 0,
-                'enabled_rules': 0,
-                'disabled_rules': 0,
-                'rules_by_category': {},
-                'rules_by_severity': {}
-            }
-        except Exception as e:
-            logger.error(f"Error getting compliance rules: {str(e)}")
-            return {}
-    
+        return {
+            'total_rules': 0,
+            'enabled_rules': 0,
+            'disabled_rules': 0,
+            'rules_by_category': {},
+            'rules_by_severity': {}
+        }
+
     def _get_recommendations(self, region):
         """Get compliance recommendations"""
-        try:
-            # This would provide compliance recommendations
-            return [
-                {
-                    'type': 'Configuration Management',
-                    'priority': 'High',
-                    'description': 'Enable AWS Config for all resources',
-                    'impact': 'Provides compliance monitoring'
-                },
-                {
-                    'type': 'Rule Management',
-                    'priority': 'Medium',
-                    'description': 'Review and update compliance rules',
-                    'impact': 'Ensures effective compliance monitoring'
-                }
-            ]
-        except Exception as e:
-            logger.error(f"Error getting recommendations: {str(e)}")
-            return []
+        return [
+            {
+                'type': 'Configuration Management',
+                'priority': 'High',
+                'description': 'Enable AWS Config for all resources',
+                'impact': 'Provides compliance monitoring'
+            },
+            {
+                'type': 'Rule Management',
+                'priority': 'Medium',
+                'description': 'Review and update compliance rules',
+                'impact': 'Ensures effective compliance monitoring'
+            }
+        ]

--- a/backend/api/aws_config.py
+++ b/backend/api/aws_config.py
@@ -6,7 +6,6 @@ When account_id is provided, an assumed-role session is used for that account.
 
 import logging
 from flask_restful import Resource, reqparse
-from services.aws_service import AWSService
 from services.organizations_service import OrganizationsService
 
 logger = logging.getLogger(__name__)
@@ -37,10 +36,10 @@ class ConfigResource(Resource):
             account_id = args.get('account_id')
 
             # Resolve the boto3 session — assumed-role session for member accounts,
-            # default session for the management account or when no account_id given
-            session = self.org_service.get_session_for_account(account_id) \
-                if account_id else None
-            aws_service = AWSService(session=session)  # noqa: F841 — used when methods are wired
+            # default session for the management account or when no account_id given.
+            # aws_service will be used here once Config API methods are wired up.
+            if account_id:
+                self.org_service.get_session_for_account(account_id)
 
             config_data = {
                 'account_id': account_id,

--- a/backend/api/aws_ec2.py
+++ b/backend/api/aws_ec2.py
@@ -39,14 +39,18 @@ class EC2Resource(Resource):
                 if account_id else None
             aws_service = AWSService(session=session)
 
+            # Fetch EC2 analysis once and pass the result to helpers to avoid
+            # making redundant API calls for each sub-section
+            ec2_analysis = aws_service.get_ec2_analysis(region)
+
             ec2_data = {
                 'account_id': account_id,
-                'instances': self._analyze_instances(aws_service, region, instance_id),
-                'security_groups': self._analyze_security_groups(aws_service, region),
-                'volumes': self._analyze_volumes(aws_service, region),
-                'snapshots': self._analyze_snapshots(region),
+                'instances': self._analyze_instances(ec2_analysis, instance_id),
+                'security_groups': self._analyze_security_groups(ec2_analysis),
+                'volumes': self._analyze_volumes(ec2_analysis),
+                'snapshots': self._analyze_snapshots(),
                 'security_findings': self._get_security_findings(aws_service, region),
-                'recommendations': self._get_recommendations(region)
+                'recommendations': self._get_recommendations()
             }
 
             return ec2_data, 200
@@ -59,31 +63,31 @@ class EC2Resource(Resource):
             logger.error(f"Error analyzing EC2: {str(e)}")
             return {'error': 'Failed to analyze EC2 configuration'}, 500
 
-    def _analyze_instances(self, aws_service, region, instance_id=None):
-        """Analyze EC2 instances for security issues"""
+    def _analyze_instances(self, ec2_analysis, instance_id=None):
+        """Extract instance metrics from the pre-fetched EC2 analysis result"""
         try:
-            return aws_service.get_ec2_analysis(region).get('instances', {})
+            return ec2_analysis.get('instances', {})
         except Exception as e:
             logger.error(f"Error analyzing instances: {str(e)}")
             return {}
 
-    def _analyze_security_groups(self, aws_service, region):
-        """Analyze security groups for security issues"""
+    def _analyze_security_groups(self, ec2_analysis):
+        """Extract security group metrics from the pre-fetched EC2 analysis result"""
         try:
-            return aws_service.get_ec2_analysis(region).get('security_groups', {})
+            return ec2_analysis.get('security_groups', {})
         except Exception as e:
             logger.error(f"Error analyzing security groups: {str(e)}")
             return {}
 
-    def _analyze_volumes(self, aws_service, region):
-        """Analyze EBS volumes for security issues"""
+    def _analyze_volumes(self, ec2_analysis):
+        """Extract volume metrics from the pre-fetched EC2 analysis result"""
         try:
-            return aws_service.get_ec2_analysis(region).get('volumes', {})
+            return ec2_analysis.get('volumes', {})
         except Exception as e:
             logger.error(f"Error analyzing volumes: {str(e)}")
             return {}
 
-    def _analyze_snapshots(self, region):
+    def _analyze_snapshots(self):
         """Snapshots analysis placeholder"""
         return {
             'total_snapshots': 0,
@@ -94,14 +98,24 @@ class EC2Resource(Resource):
         }
 
     def _get_security_findings(self, aws_service, region):
-        """Get EC2-related security findings via Security Hub"""
+        """
+        Get EC2-specific security findings from Security Hub.
+        Filters to AWS::EC2 resource types only to avoid mixing in IAM/S3 findings.
+        """
         try:
-            return aws_service.get_security_hub_findings(region)
+            all_findings = aws_service.get_security_hub_findings(region)
+            # Filter to EC2 resource types only
+            return [
+                f for f in all_findings
+                if isinstance(f, dict) and
+                any('EC2' in str(r.get('Type', ''))
+                    for r in f.get('Resources', []))
+            ]
         except Exception as e:
-            logger.error(f"Error getting security findings: {str(e)}")
+            logger.error(f"Error getting EC2 security findings: {str(e)}")
             return []
 
-    def _get_recommendations(self, region):
+    def _get_recommendations(self):
         """Get EC2 security recommendations"""
         return [
             {

--- a/backend/api/aws_ec2.py
+++ b/backend/api/aws_ec2.py
@@ -1,134 +1,119 @@
 """
-AWS EC2 API endpoints for compute security analysis
+AWS EC2 API endpoints for compute security analysis.
+Supports multi-account scanning via optional account_id query parameter.
+When account_id is provided, an assumed-role session is used for that account.
 """
 
+import logging
 from flask_restful import Resource, reqparse
 from services.aws_service import AWSService
-import logging
+from services.organizations_service import OrganizationsService
 
 logger = logging.getLogger(__name__)
 
+
 class EC2Resource(Resource):
     """EC2 security analysis endpoint"""
-    
+
     def __init__(self):
-        self.aws_service = AWSService()
+        self.org_service = OrganizationsService()
         self.parser = reqparse.RequestParser()
-        self.parser.add_argument('region', type=str, help='AWS region')
-        self.parser.add_argument('instance_id', type=str, help='Specific instance ID')
-    
+        self.parser.add_argument('region', type=str, location='args', help='AWS region')
+        self.parser.add_argument('instance_id', type=str, location='args',
+                                 help='Specific instance ID')
+        # account_id is optional — defaults to management account (backward compatible)
+        self.parser.add_argument('account_id', type=str, location='args',
+                                 help='Target AWS account ID')
+
     def get(self):
-        """Get EC2 security analysis"""
+        """Get EC2 security analysis, optionally scoped to a specific account."""
         try:
             args = self.parser.parse_args()
             region = args.get('region', 'us-east-1')
             instance_id = args.get('instance_id')
-            
-            # Get EC2 analysis data
+            account_id = args.get('account_id')
+
+            # Resolve the boto3 session — assumed-role session for member accounts,
+            # default session for the management account or when no account_id given
+            session = self.org_service.get_session_for_account(account_id) \
+                if account_id else None
+            aws_service = AWSService(session=session)
+
             ec2_data = {
-                'instances': self._analyze_instances(region, instance_id),
-                'security_groups': self._analyze_security_groups(region),
-                'volumes': self._analyze_volumes(region),
+                'account_id': account_id,
+                'instances': self._analyze_instances(aws_service, region, instance_id),
+                'security_groups': self._analyze_security_groups(aws_service, region),
+                'volumes': self._analyze_volumes(aws_service, region),
                 'snapshots': self._analyze_snapshots(region),
-                'security_findings': self._get_security_findings(region),
+                'security_findings': self._get_security_findings(aws_service, region),
                 'recommendations': self._get_recommendations(region)
             }
-            
+
             return ec2_data, 200
-            
+
+        except RuntimeError as e:
+            # STS AssumeRole failure — return 403 per spec
+            logger.error(f"Account session error: {str(e)}")
+            return {'error': str(e)}, 403
         except Exception as e:
             logger.error(f"Error analyzing EC2: {str(e)}")
             return {'error': 'Failed to analyze EC2 configuration'}, 500
-    
-    def _analyze_instances(self, region, instance_id=None):
+
+    def _analyze_instances(self, aws_service, region, instance_id=None):
         """Analyze EC2 instances for security issues"""
         try:
-            # This would use boto3 to analyze EC2 instances
-            return {
-                'total_instances': 0,
-                'running_instances': 0,
-                'stopped_instances': 0,
-                'instances_without_encryption': 0,
-                'instances_with_public_ip': 0,
-                'instances_without_imdsv2': 0,
-                'instances_with_ssm_agent': 0
-            }
+            return aws_service.get_ec2_analysis(region).get('instances', {})
         except Exception as e:
             logger.error(f"Error analyzing instances: {str(e)}")
             return {}
-    
-    def _analyze_security_groups(self, region):
+
+    def _analyze_security_groups(self, aws_service, region):
         """Analyze security groups for security issues"""
         try:
-            # This would use boto3 to analyze security groups
-            return {
-                'total_security_groups': 0,
-                'security_groups_with_open_ports': 0,
-                'security_groups_with_0_0_0_0_0': 0,
-                'unused_security_groups': 0,
-                'security_groups_with_ssh_open': 0
-            }
+            return aws_service.get_ec2_analysis(region).get('security_groups', {})
         except Exception as e:
             logger.error(f"Error analyzing security groups: {str(e)}")
             return {}
-    
-    def _analyze_volumes(self, region):
+
+    def _analyze_volumes(self, aws_service, region):
         """Analyze EBS volumes for security issues"""
         try:
-            # This would use boto3 to analyze EBS volumes
-            return {
-                'total_volumes': 0,
-                'encrypted_volumes': 0,
-                'unencrypted_volumes': 0,
-                'unattached_volumes': 0,
-                'volumes_without_snapshots': 0
-            }
+            return aws_service.get_ec2_analysis(region).get('volumes', {})
         except Exception as e:
             logger.error(f"Error analyzing volumes: {str(e)}")
             return {}
-    
+
     def _analyze_snapshots(self, region):
-        """Analyze EBS snapshots for security issues"""
+        """Snapshots analysis placeholder"""
+        return {
+            'total_snapshots': 0,
+            'public_snapshots': 0,
+            'private_snapshots': 0,
+            'old_snapshots': 0,
+            'snapshots_without_encryption': 0
+        }
+
+    def _get_security_findings(self, aws_service, region):
+        """Get EC2-related security findings via Security Hub"""
         try:
-            # This would use boto3 to analyze EBS snapshots
-            return {
-                'total_snapshots': 0,
-                'public_snapshots': 0,
-                'private_snapshots': 0,
-                'old_snapshots': 0,
-                'snapshots_without_encryption': 0
-            }
-        except Exception as e:
-            logger.error(f"Error analyzing snapshots: {str(e)}")
-            return {}
-    
-    def _get_security_findings(self, region):
-        """Get EC2 security findings"""
-        try:
-            # This would integrate with AWS Security Hub and Inspector
-            return []
+            return aws_service.get_security_hub_findings(region)
         except Exception as e:
             logger.error(f"Error getting security findings: {str(e)}")
             return []
-    
+
     def _get_recommendations(self, region):
         """Get EC2 security recommendations"""
-        try:
-            # This would provide security recommendations
-            return [
-                {
-                    'type': 'Encryption',
-                    'priority': 'High',
-                    'description': 'Enable encryption for all EBS volumes',
-                    'impact': 'Protects data at rest'
-                },
-                {
-                    'type': 'Security Groups',
-                    'priority': 'Medium',
-                    'description': 'Review and restrict security group rules',
-                    'impact': 'Reduces attack surface'
-                }
-            ]
-        except Exception as e:
-            logger.error(f"Error getting recommendations: {str(e)}")
-            return []
+        return [
+            {
+                'type': 'Encryption',
+                'priority': 'High',
+                'description': 'Enable encryption for all EBS volumes',
+                'impact': 'Protects data at rest'
+            },
+            {
+                'type': 'Security Groups',
+                'priority': 'Medium',
+                'description': 'Review and restrict security group rules',
+                'impact': 'Reduces attack surface'
+            }
+        ]

--- a/backend/api/aws_ec2.py
+++ b/backend/api/aws_ec2.py
@@ -88,27 +88,20 @@ class EC2Resource(Resource):
             return {}
 
     def _analyze_snapshots(self):
-        """Snapshots analysis placeholder"""
-        return {
-            'total_snapshots': 0,
-            'public_snapshots': 0,
-            'private_snapshots': 0,
-            'old_snapshots': 0,
-            'snapshots_without_encryption': 0
-        }
+        """Snapshots analysis — not yet implemented, returns unsupported marker"""
+        return {'unsupported': True}
 
     def _get_security_findings(self, aws_service, region):
         """
         Get EC2-specific security findings from Security Hub.
-        Filters to AWS::EC2 resource types only to avoid mixing in IAM/S3 findings.
+        Uses AwsEc2 prefix to match all EC2 resource types (AwsEc2Instance, AwsEc2Volume, etc.)
         """
         try:
             all_findings = aws_service.get_security_hub_findings(region)
-            # Filter to EC2 resource types only
             return [
                 f for f in all_findings
                 if isinstance(f, dict) and
-                any('EC2' in str(r.get('Type', ''))
+                any(str(r.get('Type', '')).startswith('AwsEc2')
                     for r in f.get('Resources', []))
             ]
         except Exception as e:

--- a/backend/api/aws_iam.py
+++ b/backend/api/aws_iam.py
@@ -98,11 +98,21 @@ class IAMResource(Resource):
             return {}
 
     def _get_security_findings(self, aws_service, region):
-        """Get IAM-related security findings via Security Hub"""
+        """
+        Get IAM-specific security findings from Security Hub.
+        Filters to AWS::IAM resource types only to avoid mixing in EC2/S3 findings.
+        """
         try:
-            return aws_service.get_security_hub_findings(region)
+            all_findings = aws_service.get_security_hub_findings(region)
+            # Filter to IAM resource types only
+            return [
+                f for f in all_findings
+                if isinstance(f, dict) and
+                any('IAM' in str(r.get('Type', ''))
+                    for r in f.get('Resources', []))
+            ]
         except Exception as e:
-            logger.error(f"Error getting security findings: {str(e)}")
+            logger.error(f"Error getting IAM security findings: {str(e)}")
             return []
 
     def _get_recommendations(self, region):

--- a/backend/api/aws_iam.py
+++ b/backend/api/aws_iam.py
@@ -38,14 +38,18 @@ class IAMResource(Resource):
                 if account_id else None
             aws_service = AWSService(session=session)
 
+            # Fetch IAM analysis once and pass the cached result to helpers to
+            # avoid making redundant API calls for each sub-section
+            iam_report = aws_service.get_iam_analysis(region)
+
             iam_data = {
                 'account_id': account_id,
-                'users': self._analyze_users(aws_service, region),
-                'roles': self._analyze_roles(aws_service, region),
-                'policies': self._analyze_policies(aws_service, region),
-                'access_keys': self._analyze_access_keys(aws_service, region),
+                'users': self._analyze_users(iam_report),
+                'roles': self._analyze_roles(iam_report),
+                'policies': self._analyze_policies(iam_report),
+                'access_keys': self._analyze_access_keys(),
                 'security_findings': self._get_security_findings(aws_service, region),
-                'recommendations': self._get_recommendations(region)
+                'recommendations': self._get_recommendations()
             }
 
             return iam_data, 200
@@ -58,64 +62,58 @@ class IAMResource(Resource):
             logger.error(f"Error analyzing IAM: {str(e)}")
             return {'error': 'Failed to analyze IAM configuration'}, 500
 
-    def _analyze_users(self, aws_service, region):
-        """Analyze IAM users for security issues"""
+    def _analyze_users(self, iam_report):
+        """Extract user metrics from the pre-fetched IAM analysis result"""
         try:
-            return aws_service.get_iam_analysis(region).get('users', {})
+            return iam_report.get('users', {})
         except Exception as e:
             logger.error(f"Error analyzing users: {str(e)}")
             return {}
 
-    def _analyze_roles(self, aws_service, region):
-        """Analyze IAM roles for security issues"""
+    def _analyze_roles(self, iam_report):
+        """Extract role metrics from the pre-fetched IAM analysis result"""
         try:
-            return aws_service.get_iam_analysis(region).get('roles', {})
+            return iam_report.get('roles', {})
         except Exception as e:
             logger.error(f"Error analyzing roles: {str(e)}")
             return {}
 
-    def _analyze_policies(self, aws_service, region):
-        """Analyze IAM policies for security issues"""
+    def _analyze_policies(self, iam_report):
+        """Extract policy metrics from the pre-fetched IAM analysis result"""
         try:
-            return aws_service.get_iam_analysis(region).get('policies', {})
+            return iam_report.get('policies', {})
         except Exception as e:
             logger.error(f"Error analyzing policies: {str(e)}")
             return {}
 
-    def _analyze_access_keys(self, aws_service, region):
-        """Analyze access keys for security issues"""
-        try:
-            # Access key analysis uses the same IAM client via AWSService
-            return {
-                'total_access_keys': 0,
-                'active_access_keys': 0,
-                'inactive_access_keys': 0,
-                'old_access_keys': 0,
-                'unused_access_keys': 0
-            }
-        except Exception as e:
-            logger.error(f"Error analyzing access keys: {str(e)}")
-            return {}
+    def _analyze_access_keys(self):
+        """Access key analysis placeholder — not yet available from get_iam_analysis"""
+        return {
+            'total_access_keys': 0,
+            'active_access_keys': 0,
+            'inactive_access_keys': 0,
+            'old_access_keys': 0,
+            'unused_access_keys': 0
+        }
 
     def _get_security_findings(self, aws_service, region):
         """
         Get IAM-specific security findings from Security Hub.
-        Filters to AWS::IAM resource types only to avoid mixing in EC2/S3 findings.
+        Uses AwsIam prefix to match all IAM resource types (AwsIamUser, AwsIamRole, etc.)
         """
         try:
             all_findings = aws_service.get_security_hub_findings(region)
-            # Filter to IAM resource types only
             return [
                 f for f in all_findings
                 if isinstance(f, dict) and
-                any('IAM' in str(r.get('Type', ''))
+                any(str(r.get('Type', '')).startswith('AwsIam')
                     for r in f.get('Resources', []))
             ]
         except Exception as e:
             logger.error(f"Error getting IAM security findings: {str(e)}")
             return []
 
-    def _get_recommendations(self, region):
+    def _get_recommendations(self):
         """Get IAM security recommendations"""
         return [
             {

--- a/backend/api/aws_iam.py
+++ b/backend/api/aws_iam.py
@@ -1,95 +1,91 @@
 """
-AWS IAM API endpoints for identity and access management analysis
+AWS IAM API endpoints for identity and access management analysis.
+Supports multi-account scanning via optional account_id query parameter.
+When account_id is provided, an assumed-role session is used for that account.
 """
 
+import logging
 from flask_restful import Resource, reqparse
 from services.aws_service import AWSService
-import logging
+from services.organizations_service import OrganizationsService
 
 logger = logging.getLogger(__name__)
 
+
 class IAMResource(Resource):
     """IAM analysis and security endpoint"""
-    
+
     def __init__(self):
-        self.aws_service = AWSService()
+        self.org_service = OrganizationsService()
         self.parser = reqparse.RequestParser()
-        self.parser.add_argument('region', type=str, help='AWS region')
-        self.parser.add_argument('scan_type', type=str, choices=['full', 'quick'], default='quick')
-    
+        self.parser.add_argument('region', type=str, location='args', help='AWS region')
+        self.parser.add_argument('scan_type', type=str, location='args',
+                                 choices=['full', 'quick'], default='quick')
+        # account_id is optional — defaults to management account (backward compatible)
+        self.parser.add_argument('account_id', type=str, location='args',
+                                 help='Target AWS account ID')
+
     def get(self):
-        """Get IAM security analysis"""
+        """Get IAM security analysis, optionally scoped to a specific account."""
         try:
             args = self.parser.parse_args()
             region = args.get('region', 'us-east-1')
-            scan_type = args.get('scan_type', 'quick')
-            
-            # Get IAM analysis data
+            account_id = args.get('account_id')
+
+            # Resolve the boto3 session — assumed-role session for member accounts,
+            # default session for the management account or when no account_id given
+            session = self.org_service.get_session_for_account(account_id) \
+                if account_id else None
+            aws_service = AWSService(session=session)
+
             iam_data = {
-                'users': self._analyze_users(region),
-                'roles': self._analyze_roles(region),
-                'policies': self._analyze_policies(region),
-                'access_keys': self._analyze_access_keys(region),
-                'security_findings': self._get_security_findings(region),
+                'account_id': account_id,
+                'users': self._analyze_users(aws_service, region),
+                'roles': self._analyze_roles(aws_service, region),
+                'policies': self._analyze_policies(aws_service, region),
+                'access_keys': self._analyze_access_keys(aws_service, region),
+                'security_findings': self._get_security_findings(aws_service, region),
                 'recommendations': self._get_recommendations(region)
             }
-            
+
             return iam_data, 200
-            
+
+        except RuntimeError as e:
+            # STS AssumeRole failure — return 403 per spec
+            logger.error(f"Account session error: {str(e)}")
+            return {'error': str(e)}, 403
         except Exception as e:
             logger.error(f"Error analyzing IAM: {str(e)}")
             return {'error': 'Failed to analyze IAM configuration'}, 500
-    
-    def _analyze_users(self, region):
+
+    def _analyze_users(self, aws_service, region):
         """Analyze IAM users for security issues"""
         try:
-            # This would use boto3 to analyze IAM users
-            return {
-                'total_users': 0,
-                'users_with_mfa': 0,
-                'users_without_mfa': 0,
-                'inactive_users': 0,
-                'users_with_admin_access': 0,
-                'users_with_console_access': 0
-            }
+            return aws_service.get_iam_analysis(region).get('users', {})
         except Exception as e:
             logger.error(f"Error analyzing users: {str(e)}")
             return {}
-    
-    def _analyze_roles(self, region):
+
+    def _analyze_roles(self, aws_service, region):
         """Analyze IAM roles for security issues"""
         try:
-            # This would use boto3 to analyze IAM roles
-            return {
-                'total_roles': 0,
-                'cross_account_roles': 0,
-                'roles_with_excessive_permissions': 0,
-                'unused_roles': 0,
-                'roles_with_external_trust': 0
-            }
+            return aws_service.get_iam_analysis(region).get('roles', {})
         except Exception as e:
             logger.error(f"Error analyzing roles: {str(e)}")
             return {}
-    
-    def _analyze_policies(self, region):
+
+    def _analyze_policies(self, aws_service, region):
         """Analyze IAM policies for security issues"""
         try:
-            # This would use boto3 to analyze IAM policies
-            return {
-                'total_policies': 0,
-                'inline_policies': 0,
-                'managed_policies': 0,
-                'policies_with_wildcards': 0,
-                'overly_permissive_policies': 0
-            }
+            return aws_service.get_iam_analysis(region).get('policies', {})
         except Exception as e:
             logger.error(f"Error analyzing policies: {str(e)}")
             return {}
-    
-    def _analyze_access_keys(self, region):
+
+    def _analyze_access_keys(self, aws_service, region):
         """Analyze access keys for security issues"""
         try:
-            # This would use boto3 to analyze access keys
+            # Access key analysis uses the same IAM client via AWSService
             return {
                 'total_access_keys': 0,
                 'active_access_keys': 0,
@@ -100,34 +96,28 @@ class IAMResource(Resource):
         except Exception as e:
             logger.error(f"Error analyzing access keys: {str(e)}")
             return {}
-    
-    def _get_security_findings(self, region):
-        """Get IAM security findings"""
+
+    def _get_security_findings(self, aws_service, region):
+        """Get IAM-related security findings via Security Hub"""
         try:
-            # This would integrate with AWS Security Hub and Access Analyzer
-            return []
+            return aws_service.get_security_hub_findings(region)
         except Exception as e:
             logger.error(f"Error getting security findings: {str(e)}")
             return []
-    
+
     def _get_recommendations(self, region):
         """Get IAM security recommendations"""
-        try:
-            # This would provide security recommendations
-            return [
-                {
-                    'type': 'MFA',
-                    'priority': 'High',
-                    'description': 'Enable MFA for all users',
-                    'impact': 'Reduces risk of unauthorized access'
-                },
-                {
-                    'type': 'Access Keys',
-                    'priority': 'Medium',
-                    'description': 'Rotate access keys regularly',
-                    'impact': 'Reduces risk of compromised credentials'
-                }
-            ]
-        except Exception as e:
-            logger.error(f"Error getting recommendations: {str(e)}")
-            return []
+        return [
+            {
+                'type': 'MFA',
+                'priority': 'High',
+                'description': 'Enable MFA for all users',
+                'impact': 'Reduces risk of unauthorized access'
+            },
+            {
+                'type': 'Access Keys',
+                'priority': 'Medium',
+                'description': 'Rotate access keys regularly',
+                'impact': 'Reduces risk of compromised credentials'
+            }
+        ]

--- a/backend/api/aws_s3.py
+++ b/backend/api/aws_s3.py
@@ -70,24 +70,20 @@ class S3Resource(Resource):
             return {'error': 'Failed to analyze S3 configuration'}, 500
 
     def _analyze_logging(self):
-        """S3 logging analysis placeholder"""
-        return {
-            'buckets_with_logging': 0,
-            'buckets_without_logging': 0
-        }
+        """S3 logging analysis — not yet implemented, returns unsupported marker"""
+        return {'unsupported': True}
 
     def _get_security_findings(self, aws_service, region):
         """
         Get S3-specific security findings from Security Hub.
-        Filters to AWS::S3 resource types only to avoid mixing in IAM/EC2 findings.
+        Uses AwsS3 prefix to match all S3 resource types (AwsS3Bucket, AwsS3Object, etc.)
         """
         try:
             all_findings = aws_service.get_security_hub_findings(region)
-            # Filter to S3 resource types only
             return [
                 f for f in all_findings
                 if isinstance(f, dict) and
-                any('S3' in str(r.get('Type', ''))
+                any(str(r.get('Type', '')).startswith('AwsS3')
                     for r in f.get('Resources', []))
             ]
         except Exception as e:

--- a/backend/api/aws_s3.py
+++ b/backend/api/aws_s3.py
@@ -30,7 +30,6 @@ class S3Resource(Resource):
         try:
             args = self.parser.parse_args()
             region = args.get('region', 'us-east-1')
-            bucket_name = args.get('bucket_name')
             account_id = args.get('account_id')
 
             # Resolve the boto3 session — assumed-role session for member accounts,
@@ -39,14 +38,25 @@ class S3Resource(Resource):
                 if account_id else None
             aws_service = AWSService(session=session)
 
+            # Fetch S3 analysis once and pass the result to helpers to avoid
+            # making redundant API calls for each sub-section
+            s3_analysis = aws_service.get_s3_analysis(region)
+            buckets = s3_analysis.get('buckets', {})
+
             s3_data = {
                 'account_id': account_id,
-                'buckets': self._analyze_buckets(aws_service, region, bucket_name),
-                'encryption': self._analyze_encryption(aws_service, region),
-                'versioning': self._analyze_versioning(aws_service, region),
-                'logging': self._analyze_logging(aws_service, region),
+                'buckets': buckets,
+                'encryption': {
+                    'buckets_with_encryption': buckets.get('with_encryption', 0),
+                    'buckets_without_encryption': buckets.get('without_encryption', 0)
+                },
+                'versioning': {
+                    'buckets_with_versioning': buckets.get('with_versioning', 0),
+                    'buckets_without_versioning': buckets.get('without_versioning', 0)
+                },
+                'logging': self._analyze_logging(),
                 'security_findings': self._get_security_findings(aws_service, region),
-                'recommendations': self._get_recommendations(region)
+                'recommendations': self._get_recommendations()
             }
 
             return s3_data, 200
@@ -59,54 +69,32 @@ class S3Resource(Resource):
             logger.error(f"Error analyzing S3: {str(e)}")
             return {'error': 'Failed to analyze S3 configuration'}, 500
 
-    def _analyze_buckets(self, aws_service, region, bucket_name=None):
-        """Analyze S3 buckets for security issues"""
-        try:
-            return aws_service.get_s3_analysis(region).get('buckets', {})
-        except Exception as e:
-            logger.error(f"Error analyzing buckets: {str(e)}")
-            return {}
-
-    def _analyze_encryption(self, aws_service, region):
-        """Analyze S3 encryption configuration"""
-        try:
-            buckets = aws_service.get_s3_analysis(region).get('buckets', {})
-            return {
-                'buckets_with_encryption': buckets.get('with_encryption', 0),
-                'buckets_without_encryption': buckets.get('without_encryption', 0)
-            }
-        except Exception as e:
-            logger.error(f"Error analyzing encryption: {str(e)}")
-            return {}
-
-    def _analyze_versioning(self, aws_service, region):
-        """Analyze S3 versioning configuration"""
-        try:
-            buckets = aws_service.get_s3_analysis(region).get('buckets', {})
-            return {
-                'buckets_with_versioning': buckets.get('with_versioning', 0),
-                'buckets_without_versioning': buckets.get('without_versioning', 0)
-            }
-        except Exception as e:
-            logger.error(f"Error analyzing versioning: {str(e)}")
-            return {}
-
-    def _analyze_logging(self, aws_service, region):
-        """Analyze S3 logging configuration — placeholder"""
+    def _analyze_logging(self):
+        """S3 logging analysis placeholder"""
         return {
             'buckets_with_logging': 0,
             'buckets_without_logging': 0
         }
 
     def _get_security_findings(self, aws_service, region):
-        """Get S3-related security findings via Security Hub"""
+        """
+        Get S3-specific security findings from Security Hub.
+        Filters to AWS::S3 resource types only to avoid mixing in IAM/EC2 findings.
+        """
         try:
-            return aws_service.get_security_hub_findings(region)
+            all_findings = aws_service.get_security_hub_findings(region)
+            # Filter to S3 resource types only
+            return [
+                f for f in all_findings
+                if isinstance(f, dict) and
+                any('S3' in str(r.get('Type', ''))
+                    for r in f.get('Resources', []))
+            ]
         except Exception as e:
-            logger.error(f"Error getting security findings: {str(e)}")
+            logger.error(f"Error getting S3 security findings: {str(e)}")
             return []
 
-    def _get_recommendations(self, region):
+    def _get_recommendations(self):
         """Get S3 security recommendations"""
         return [
             {

--- a/backend/api/aws_s3.py
+++ b/backend/api/aws_s3.py
@@ -1,147 +1,124 @@
 """
-AWS S3 API endpoints for storage security analysis
+AWS S3 API endpoints for storage security analysis.
+Supports multi-account scanning via optional account_id query parameter.
+When account_id is provided, an assumed-role session is used for that account.
 """
 
+import logging
 from flask_restful import Resource, reqparse
 from services.aws_service import AWSService
-import logging
+from services.organizations_service import OrganizationsService
 
 logger = logging.getLogger(__name__)
 
+
 class S3Resource(Resource):
     """S3 security analysis endpoint"""
-    
+
     def __init__(self):
-        self.aws_service = AWSService()
+        self.org_service = OrganizationsService()
         self.parser = reqparse.RequestParser()
-        self.parser.add_argument('region', type=str, help='AWS region')
-        self.parser.add_argument('bucket_name', type=str, help='Specific bucket name')
-    
+        self.parser.add_argument('region', type=str, location='args', help='AWS region')
+        self.parser.add_argument('bucket_name', type=str, location='args',
+                                 help='Specific bucket name')
+        # account_id is optional — defaults to management account (backward compatible)
+        self.parser.add_argument('account_id', type=str, location='args',
+                                 help='Target AWS account ID')
+
     def get(self):
-        """Get S3 security analysis"""
+        """Get S3 security analysis, optionally scoped to a specific account."""
         try:
             args = self.parser.parse_args()
             region = args.get('region', 'us-east-1')
             bucket_name = args.get('bucket_name')
-            
-            # Get S3 analysis data
+            account_id = args.get('account_id')
+
+            # Resolve the boto3 session — assumed-role session for member accounts,
+            # default session for the management account or when no account_id given
+            session = self.org_service.get_session_for_account(account_id) \
+                if account_id else None
+            aws_service = AWSService(session=session)
+
             s3_data = {
-                'buckets': self._analyze_buckets(region, bucket_name),
-                'bucket_policies': self._analyze_bucket_policies(region),
-                'encryption': self._analyze_encryption(region),
-                'versioning': self._analyze_versioning(region),
-                'logging': self._analyze_logging(region),
-                'security_findings': self._get_security_findings(region),
+                'account_id': account_id,
+                'buckets': self._analyze_buckets(aws_service, region, bucket_name),
+                'encryption': self._analyze_encryption(aws_service, region),
+                'versioning': self._analyze_versioning(aws_service, region),
+                'logging': self._analyze_logging(aws_service, region),
+                'security_findings': self._get_security_findings(aws_service, region),
                 'recommendations': self._get_recommendations(region)
             }
-            
+
             return s3_data, 200
-            
+
+        except RuntimeError as e:
+            # STS AssumeRole failure — return 403 per spec
+            logger.error(f"Account session error: {str(e)}")
+            return {'error': str(e)}, 403
         except Exception as e:
             logger.error(f"Error analyzing S3: {str(e)}")
             return {'error': 'Failed to analyze S3 configuration'}, 500
-    
-    def _analyze_buckets(self, region, bucket_name=None):
+
+    def _analyze_buckets(self, aws_service, region, bucket_name=None):
         """Analyze S3 buckets for security issues"""
         try:
-            # This would use boto3 to analyze S3 buckets
-            return {
-                'total_buckets': 0,
-                'public_buckets': 0,
-                'private_buckets': 0,
-                'buckets_without_encryption': 0,
-                'buckets_without_versioning': 0,
-                'buckets_without_logging': 0
-            }
+            return aws_service.get_s3_analysis(region).get('buckets', {})
         except Exception as e:
             logger.error(f"Error analyzing buckets: {str(e)}")
             return {}
-    
-    def _analyze_bucket_policies(self, region):
-        """Analyze S3 bucket policies for security issues"""
-        try:
-            # This would use boto3 to analyze bucket policies
-            return {
-                'total_buckets_with_policies': 0,
-                'buckets_with_public_read': 0,
-                'buckets_with_public_write': 0,
-                'buckets_with_restrictive_policies': 0,
-                'buckets_without_policies': 0
-            }
-        except Exception as e:
-            logger.error(f"Error analyzing bucket policies: {str(e)}")
-            return {}
-    
-    def _analyze_encryption(self, region):
+
+    def _analyze_encryption(self, aws_service, region):
         """Analyze S3 encryption configuration"""
         try:
-            # This would use boto3 to analyze encryption
+            buckets = aws_service.get_s3_analysis(region).get('buckets', {})
             return {
-                'buckets_with_sse': 0,
-                'buckets_with_sse_kms': 0,
-                'buckets_with_sse_s3': 0,
-                'buckets_without_encryption': 0,
-                'buckets_with_encryption_at_rest': 0
+                'buckets_with_encryption': buckets.get('with_encryption', 0),
+                'buckets_without_encryption': buckets.get('without_encryption', 0)
             }
         except Exception as e:
             logger.error(f"Error analyzing encryption: {str(e)}")
             return {}
-    
-    def _analyze_versioning(self, region):
+
+    def _analyze_versioning(self, aws_service, region):
         """Analyze S3 versioning configuration"""
         try:
-            # This would use boto3 to analyze versioning
+            buckets = aws_service.get_s3_analysis(region).get('buckets', {})
             return {
-                'buckets_with_versioning': 0,
-                'buckets_without_versioning': 0,
-                'buckets_with_mfa_delete': 0,
-                'buckets_with_lifecycle_policies': 0
+                'buckets_with_versioning': buckets.get('with_versioning', 0),
+                'buckets_without_versioning': buckets.get('without_versioning', 0)
             }
         except Exception as e:
             logger.error(f"Error analyzing versioning: {str(e)}")
             return {}
-    
-    def _analyze_logging(self, region):
-        """Analyze S3 logging configuration"""
+
+    def _analyze_logging(self, aws_service, region):
+        """Analyze S3 logging configuration — placeholder"""
+        return {
+            'buckets_with_logging': 0,
+            'buckets_without_logging': 0
+        }
+
+    def _get_security_findings(self, aws_service, region):
+        """Get S3-related security findings via Security Hub"""
         try:
-            # This would use boto3 to analyze logging
-            return {
-                'buckets_with_logging': 0,
-                'buckets_without_logging': 0,
-                'buckets_with_access_logging': 0,
-                'buckets_with_cloudtrail_logging': 0
-            }
-        except Exception as e:
-            logger.error(f"Error analyzing logging: {str(e)}")
-            return {}
-    
-    def _get_security_findings(self, region):
-        """Get S3 security findings"""
-        try:
-            # This would integrate with AWS Security Hub and Macie
-            return []
+            return aws_service.get_security_hub_findings(region)
         except Exception as e:
             logger.error(f"Error getting security findings: {str(e)}")
             return []
-    
+
     def _get_recommendations(self, region):
         """Get S3 security recommendations"""
-        try:
-            # This would provide security recommendations
-            return [
-                {
-                    'type': 'Public Access',
-                    'priority': 'High',
-                    'description': 'Block public access to S3 buckets',
-                    'impact': 'Prevents unauthorized access to data'
-                },
-                {
-                    'type': 'Encryption',
-                    'priority': 'High',
-                    'description': 'Enable encryption for all S3 buckets',
-                    'impact': 'Protects data at rest'
-                }
-            ]
-        except Exception as e:
-            logger.error(f"Error getting recommendations: {str(e)}")
-            return []
+        return [
+            {
+                'type': 'Public Access',
+                'priority': 'High',
+                'description': 'Block public access to S3 buckets',
+                'impact': 'Prevents unauthorized access to data'
+            },
+            {
+                'type': 'Encryption',
+                'priority': 'High',
+                'description': 'Enable encryption for all S3 buckets',
+                'impact': 'Protects data at rest'
+            }
+        ]

--- a/backend/api/aws_security_hub.py
+++ b/backend/api/aws_security_hub.py
@@ -1,118 +1,117 @@
 """
-AWS Security Hub API endpoints for centralized security findings
+AWS Security Hub API endpoints for centralized security findings.
+Supports multi-account scanning via optional account_id query parameter.
+When account_id is provided, an assumed-role session is used for that account.
 """
 
+import logging
 from flask_restful import Resource, reqparse
 from services.aws_service import AWSService
-import logging
+from services.organizations_service import OrganizationsService
 
 logger = logging.getLogger(__name__)
 
+
 class SecurityHubResource(Resource):
     """Security Hub analysis endpoint"""
-    
+
     def __init__(self):
-        self.aws_service = AWSService()
+        self.org_service = OrganizationsService()
         self.parser = reqparse.RequestParser()
-        self.parser.add_argument('region', type=str, help='AWS region')
-        self.parser.add_argument('severity', type=str, choices=['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFORMATIONAL'])
-        self.parser.add_argument('status', type=str, choices=['NEW', 'NOTIFIED', 'SUPPRESSED', 'RESOLVED'])
-        self.parser.add_argument('limit', type=int, default=100, help='Maximum number of findings to return')
-    
+        self.parser.add_argument('region', type=str, location='args', help='AWS region')
+        self.parser.add_argument('severity', type=str, location='args',
+                                 choices=['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFORMATIONAL'])
+        self.parser.add_argument('status', type=str, location='args',
+                                 choices=['NEW', 'NOTIFIED', 'SUPPRESSED', 'RESOLVED'])
+        self.parser.add_argument('limit', type=int, location='args', default=100)
+        # account_id is optional — defaults to management account (backward compatible)
+        self.parser.add_argument('account_id', type=str, location='args',
+                                 help='Target AWS account ID')
+
     def get(self):
-        """Get Security Hub findings"""
+        """Get Security Hub findings, optionally scoped to a specific account."""
         try:
             args = self.parser.parse_args()
             region = args.get('region', 'us-east-1')
             severity = args.get('severity')
             status = args.get('status')
             limit = args.get('limit', 100)
-            
-            # Get Security Hub data
+            account_id = args.get('account_id')
+
+            # Resolve the boto3 session — assumed-role session for member accounts,
+            # default session for the management account or when no account_id given
+            session = self.org_service.get_session_for_account(account_id) \
+                if account_id else None
+            aws_service = AWSService(session=session)
+
             security_hub_data = {
-                'findings': self._get_findings(region, severity, status, limit),
+                'account_id': account_id,
+                'findings': self._get_findings(aws_service, region, limit),
                 'summary': self._get_findings_summary(region),
                 'compliance': self._get_compliance_status(region),
                 'insights': self._get_security_insights(region),
                 'recommendations': self._get_recommendations(region)
             }
-            
+
             return security_hub_data, 200
-            
+
+        except RuntimeError as e:
+            # STS AssumeRole failure — return 403 per spec
+            logger.error(f"Account session error: {str(e)}")
+            return {'error': str(e)}, 403
         except Exception as e:
             logger.error(f"Error getting Security Hub data: {str(e)}")
             return {'error': 'Failed to fetch Security Hub data'}, 500
-    
-    def _get_findings(self, region, severity=None, status=None, limit=100):
-        """Get Security Hub findings"""
+
+    def _get_findings(self, aws_service, region, limit=100):
+        """Get Security Hub findings via AWSService"""
         try:
-            # This would use boto3 to get Security Hub findings
-            return []
+            return aws_service.get_security_hub_findings(region)[:limit]
         except Exception as e:
             logger.error(f"Error getting findings: {str(e)}")
             return []
-    
+
     def _get_findings_summary(self, region):
         """Get Security Hub findings summary"""
-        try:
-            # This would use boto3 to get findings summary
-            return {
-                'total_findings': 0,
-                'critical_findings': 0,
-                'high_findings': 0,
-                'medium_findings': 0,
-                'low_findings': 0,
-                'informational_findings': 0,
-                'new_findings': 0,
-                'resolved_findings': 0
-            }
-        except Exception as e:
-            logger.error(f"Error getting findings summary: {str(e)}")
-            return {}
-    
+        return {
+            'total_findings': 0,
+            'critical_findings': 0,
+            'high_findings': 0,
+            'medium_findings': 0,
+            'low_findings': 0,
+            'informational_findings': 0,
+            'new_findings': 0,
+            'resolved_findings': 0
+        }
+
     def _get_compliance_status(self, region):
         """Get compliance status from Security Hub"""
-        try:
-            # This would use boto3 to get compliance status
-            return {
-                'overall_score': 0,
-                'frameworks': {
-                    'CIS_AWS_Foundations': {'score': 0, 'status': 'Not Assessed'},
-                    'PCI_DSS': {'score': 0, 'status': 'Not Assessed'},
-                    'SOC2': {'score': 0, 'status': 'Not Assessed'}
-                }
+        return {
+            'overall_score': 0,
+            'frameworks': {
+                'CIS_AWS_Foundations': {'score': 0, 'status': 'Not Assessed'},
+                'PCI_DSS': {'score': 0, 'status': 'Not Assessed'},
+                'SOC2': {'score': 0, 'status': 'Not Assessed'}
             }
-        except Exception as e:
-            logger.error(f"Error getting compliance status: {str(e)}")
-            return {}
-    
+        }
+
     def _get_security_insights(self, region):
         """Get security insights from Security Hub"""
-        try:
-            # This would use boto3 to get security insights
-            return []
-        except Exception as e:
-            logger.error(f"Error getting security insights: {str(e)}")
-            return []
-    
+        return []
+
     def _get_recommendations(self, region):
         """Get security recommendations"""
-        try:
-            # This would provide security recommendations
-            return [
-                {
-                    'type': 'Vulnerability Management',
-                    'priority': 'High',
-                    'description': 'Implement automated vulnerability scanning',
-                    'impact': 'Reduces security risks'
-                },
-                {
-                    'type': 'Compliance',
-                    'priority': 'Medium',
-                    'description': 'Enable compliance monitoring',
-                    'impact': 'Ensures regulatory compliance'
-                }
-            ]
-        except Exception as e:
-            logger.error(f"Error getting recommendations: {str(e)}")
-            return []
+        return [
+            {
+                'type': 'Vulnerability Management',
+                'priority': 'High',
+                'description': 'Implement automated vulnerability scanning',
+                'impact': 'Reduces security risks'
+            },
+            {
+                'type': 'Compliance',
+                'priority': 'Medium',
+                'description': 'Enable compliance monitoring',
+                'impact': 'Ensures regulatory compliance'
+            }
+        ]

--- a/backend/api/dashboard.py
+++ b/backend/api/dashboard.py
@@ -1,112 +1,106 @@
 """
-Dashboard API endpoints for overview data and metrics
+Dashboard API endpoints for overview data and metrics.
+Supports multi-account context via optional account_id query parameter.
+When account_id is provided, an assumed-role session is used for that account.
 """
 
+import logging
 from flask_restful import Resource, reqparse
 from services.aws_service import AWSService
 from services.grafana_service import GrafanaService
-import logging
+from services.organizations_service import OrganizationsService
 
 logger = logging.getLogger(__name__)
 
+
 class DashboardResource(Resource):
     """Dashboard overview and metrics endpoint"""
-    
+
     def __init__(self):
-        self.aws_service = AWSService()
+        self.org_service = OrganizationsService()
         self.grafana_service = GrafanaService()
         self.parser = reqparse.RequestParser()
-        self.parser.add_argument('region', type=str, help='AWS region')
-        self.parser.add_argument('time_range', type=str, default='24h', help='Time range for metrics')
-    
+        self.parser.add_argument('region', type=str, location='args', help='AWS region')
+        self.parser.add_argument('time_range', type=str, location='args',
+                                 default='24h', help='Time range for metrics')
+        # account_id is optional — defaults to management account (backward compatible)
+        self.parser.add_argument('account_id', type=str, location='args',
+                                 help='Target AWS account ID')
+
     def get(self):
-        """Get dashboard overview data"""
+        """Get dashboard overview data, optionally scoped to a specific account."""
         try:
             args = self.parser.parse_args()
             region = args.get('region', 'us-east-1')
             time_range = args.get('time_range', '24h')
-            
-            # Get overview metrics
+            account_id = args.get('account_id')
+
+            # Resolve the boto3 session — assumed-role session for member accounts,
+            # default session for the management account or when no account_id given
+            session = self.org_service.get_session_for_account(account_id) \
+                if account_id else None
+            aws_service = AWSService(session=session)  # noqa: F841 — used when methods are wired
+
             overview_data = {
+                'account_id': account_id,
                 'summary': self._get_security_summary(region),
                 'alerts': self._get_recent_alerts(region),
                 'compliance': self._get_compliance_status(region),
                 'cost_analysis': self._get_cost_analysis(region),
                 'performance_metrics': self._get_performance_metrics(time_range)
             }
-            
+
             return overview_data, 200
-            
+
+        except RuntimeError as e:
+            # STS AssumeRole failure — return 403 per spec
+            logger.error(f"Account session error: {str(e)}")
+            return {'error': str(e)}, 403
         except Exception as e:
             logger.error(f"Error getting dashboard data: {str(e)}")
             return {'error': 'Failed to fetch dashboard data'}, 500
-    
+
     def _get_security_summary(self, region):
         """Get security summary metrics"""
-        try:
-            # This would integrate with AWS Security Hub, Config, etc.
-            return {
-                'total_findings': 0,
-                'critical_findings': 0,
-                'high_findings': 0,
-                'medium_findings': 0,
-                'low_findings': 0,
-                'compliant_resources': 0,
-                'non_compliant_resources': 0
-            }
-        except Exception as e:
-            logger.error(f"Error getting security summary: {str(e)}")
-            return {}
-    
+        return {
+            'total_findings': 0,
+            'critical_findings': 0,
+            'high_findings': 0,
+            'medium_findings': 0,
+            'low_findings': 0,
+            'compliant_resources': 0,
+            'non_compliant_resources': 0
+        }
+
     def _get_recent_alerts(self, region):
         """Get recent security alerts"""
-        try:
-            # This would integrate with CloudWatch, Security Hub, etc.
-            return []
-        except Exception as e:
-            logger.error(f"Error getting recent alerts: {str(e)}")
-            return []
-    
+        return []
+
     def _get_compliance_status(self, region):
         """Get compliance status"""
-        try:
-            # This would integrate with AWS Config
-            return {
-                'overall_score': 0,
-                'frameworks': {
-                    'SOC2': {'score': 0, 'status': 'Not Assessed'},
-                    'PCI_DSS': {'score': 0, 'status': 'Not Assessed'},
-                    'HIPAA': {'score': 0, 'status': 'Not Assessed'}
-                }
+        return {
+            'overall_score': 0,
+            'frameworks': {
+                'SOC2': {'score': 0, 'status': 'Not Assessed'},
+                'PCI_DSS': {'score': 0, 'status': 'Not Assessed'},
+                'HIPAA': {'score': 0, 'status': 'Not Assessed'}
             }
-        except Exception as e:
-            logger.error(f"Error getting compliance status: {str(e)}")
-            return {}
-    
+        }
+
     def _get_cost_analysis(self, region):
         """Get cost analysis data"""
-        try:
-            # This would integrate with AWS Cost Explorer
-            return {
-                'monthly_cost': 0,
-                'cost_trend': 'stable',
-                'top_services': [],
-                'recommendations': []
-            }
-        except Exception as e:
-            logger.error(f"Error getting cost analysis: {str(e)}")
-            return {}
-    
+        return {
+            'monthly_cost': 0,
+            'cost_trend': 'stable',
+            'top_services': [],
+            'recommendations': []
+        }
+
     def _get_performance_metrics(self, time_range):
         """Get performance metrics from Grafana"""
-        try:
-            # This would integrate with Grafana API
-            return {
-                'response_time': 0,
-                'throughput': 0,
-                'error_rate': 0,
-                'availability': 0
-            }
-        except Exception as e:
-            logger.error(f"Error getting performance metrics: {str(e)}")
-            return {}
+        return {
+            'response_time': 0,
+            'throughput': 0,
+            'error_rate': 0,
+            'availability': 0
+        }

--- a/backend/api/dashboard.py
+++ b/backend/api/dashboard.py
@@ -6,7 +6,6 @@ When account_id is provided, an assumed-role session is used for that account.
 
 import logging
 from flask_restful import Resource, reqparse
-from services.aws_service import AWSService
 from services.grafana_service import GrafanaService
 from services.organizations_service import OrganizationsService
 
@@ -36,10 +35,10 @@ class DashboardResource(Resource):
             account_id = args.get('account_id')
 
             # Resolve the boto3 session — assumed-role session for member accounts,
-            # default session for the management account or when no account_id given
-            session = self.org_service.get_session_for_account(account_id) \
-                if account_id else None
-            aws_service = AWSService(session=session)  # noqa: F841 — used when methods are wired
+            # default session for the management account or when no account_id given.
+            # aws_service will be used here once dashboard methods are wired up.
+            if account_id:
+                self.org_service.get_session_for_account(account_id)
 
             overview_data = {
                 'account_id': account_id,

--- a/backend/app.py
+++ b/backend/app.py
@@ -21,6 +21,7 @@ from api.dashboard import DashboardResource
 from api.health import HealthResource
 from api.metrics import MetricsResource, register_metrics_hooks
 from api.scan_history import ScanHistoryResource
+from api.accounts import AccountsResource
 from api.ir import (
     LLMTriageResource,
     LLMRootCauseResource,
@@ -41,6 +42,7 @@ from api.ir import (
 from services.aws_service import AWSService
 from services.grafana_service import GrafanaService
 from services.database_service import DatabaseService
+from services.organizations_service import OrganizationsService
 
 # Configure logging
 logging.basicConfig(
@@ -61,6 +63,10 @@ def create_app():
         'DATABASE_URL', 'sqlite:///cybersecurity.db')
     app.config['REDIS_URL'] = os.environ.get(
         'REDIS_URL', 'redis://localhost:6379/0')
+    app.config['AWS_MANAGEMENT_ACCOUNT_ID'] = os.environ.get(
+        'AWS_MANAGEMENT_ACCOUNT_ID', '')
+    app.config['CROSS_ACCOUNT_ROLE_NAME'] = os.environ.get(
+        'CROSS_ACCOUNT_ROLE_NAME', 'SecurityAuditRole-test')
 
     # Browser origins allowed to call this Flask API (local Docker + optional prod SPA).
     # Match infra var.allowed_urls; see docs/security/CORS.md. Override with CORS_ALLOWED_ORIGINS (comma-separated).
@@ -83,11 +89,13 @@ def create_app():
     aws_service = AWSService()
     grafana_service = GrafanaService()
     database_service = DatabaseService()
+    organizations_service = OrganizationsService()
 
     # Register API resources
     api.add_resource(HealthResource, '/health')
     api.add_resource(MetricsResource, '/metrics')
     api.add_resource(ScanHistoryResource, '/scan-history')
+    api.add_resource(AccountsResource, '/accounts')
     api.add_resource(DashboardResource, '/dashboard')
     api.add_resource(IAMResource, '/aws/iam')
     api.add_resource(EC2Resource, '/aws/ec2')

--- a/backend/services/aws_service.py
+++ b/backend/services/aws_service.py
@@ -12,8 +12,10 @@ logger = logging.getLogger(__name__)
 class AWSService:
     """Service for AWS integrations"""
     
-    def __init__(self):
-        self.session = boto3.Session()
+    def __init__(self, session: boto3.Session = None):
+        # Accept an optional pre-built session (e.g. from STS AssumeRole).
+        # Falls back to the default boto3 session (management account creds from env).
+        self.session = session or boto3.Session()
         self.regions = ['us-east-1', 'us-west-2', 'eu-west-1', 'ap-southeast-1']
         
     def get_client(self, service_name: str, region: str = 'us-east-1'):

--- a/backend/services/organizations_service.py
+++ b/backend/services/organizations_service.py
@@ -1,0 +1,124 @@
+"""
+Organizations Service — AWS Organizations and STS integration.
+
+Responsibilities:
+  - list_accounts()              : fetch all active accounts from the Organizations API
+  - get_session_for_account()    : return a boto3 Session scoped to a specific account
+                                   (management account → default session, member account →
+                                   STS AssumeRole using the cross-account role)
+"""
+
+import os
+import boto3
+import logging
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+# Role name that must exist in every member account, granting read-only scan permissions.
+# Matches the role name used by the Lambda scanner (CROSS_ACCOUNT_ROLE_NAME env var).
+CROSS_ACCOUNT_ROLE_NAME = os.environ.get(
+    'CROSS_ACCOUNT_ROLE_NAME', 'SecurityAuditRole-test'
+)
+
+# The AWS account ID of the management account (set in env).
+# Used to decide whether role assumption is needed.
+MANAGEMENT_ACCOUNT_ID = os.environ.get('AWS_MANAGEMENT_ACCOUNT_ID', '')
+
+
+class OrganizationsService:
+    """Service for AWS Organizations account discovery and cross-account session management."""
+
+    def __init__(self):
+        # Use the default session — management account creds from env
+        self.session = boto3.Session()
+
+    def list_accounts(self) -> list:
+        """
+        Fetch all ACTIVE accounts in the AWS Organization, including the management account.
+
+        Paginates automatically through the Organizations API.
+        Raises RuntimeError (never returns an empty list silently) if the API call fails.
+
+        Returns:
+            List of dicts: {id, name, email, is_management}
+        """
+        try:
+            org_client = self.session.client('organizations')
+            accounts = []
+            paginator = org_client.get_paginator('list_accounts')
+
+            for page in paginator.paginate():
+                for account in page.get('Accounts', []):
+                    # Only include accounts that are fully active in the org
+                    if account.get('Status') != 'ACTIVE':
+                        continue
+
+                    accounts.append({
+                        'id': account['Id'],
+                        'name': account['Name'],
+                        'email': account.get('Email', ''),
+                        'is_management': account['Id'] == MANAGEMENT_ACCOUNT_ID,
+                    })
+
+            logger.info(f"Listed {len(accounts)} active accounts from AWS Organizations")
+            return accounts
+
+        except ClientError as e:
+            error_code = e.response['Error']['Code']
+            logger.error(f"Organizations API error ({error_code}): {str(e)}")
+            # Raise explicitly — callers must not treat a failure as an empty org
+            raise RuntimeError(
+                f"Failed to list accounts from AWS Organizations: {error_code}"
+            ) from e
+        except Exception as e:
+            logger.error(f"Unexpected error listing accounts: {str(e)}")
+            raise RuntimeError(f"Failed to list accounts: {str(e)}") from e
+
+    def get_session_for_account(self, account_id: str) -> boto3.Session:
+        """
+        Return a boto3 Session scoped to the given account.
+
+        - Management account → returns the default session (no role assumption needed).
+        - Member account     → assumes the cross-account role via STS and returns a
+                               new session built from the temporary credentials.
+                               Session name: DashboardScan-{account_id}.
+
+        Args:
+            account_id: 12-digit AWS account ID to scope the session to.
+
+        Returns:
+            boto3.Session configured for the target account.
+
+        Raises:
+            RuntimeError: if STS AssumeRole fails (HTTP 403 to the caller).
+        """
+        # Management account — no role assumption needed
+        if account_id == MANAGEMENT_ACCOUNT_ID:
+            logger.info(f"Using default session for management account {account_id}")
+            return self.session
+
+        # Member account — assume the cross-account role via STS
+        sts_client = self.session.client('sts')
+        role_arn = f"arn:aws:iam::{account_id}:role/{CROSS_ACCOUNT_ROLE_NAME}"
+
+        try:
+            response = sts_client.assume_role(
+                RoleArn=role_arn,
+                RoleSessionName=f"DashboardScan-{account_id}",
+            )
+        except ClientError as e:
+            logger.error(f"STS AssumeRole failed for account {account_id}: {str(e)}")
+            raise RuntimeError(
+                f"Cannot assume role in account {account_id} — check that "
+                f"{CROSS_ACCOUNT_ROLE_NAME} exists and trusts the management account"
+            ) from e
+
+        creds = response['Credentials']
+        logger.info(f"Successfully assumed role for account {account_id}")
+
+        return boto3.Session(
+            aws_access_key_id=creds['AccessKeyId'],
+            aws_secret_access_key=creds['SecretAccessKey'],
+            aws_session_token=creds['SessionToken'],
+        )

--- a/backend/services/organizations_service.py
+++ b/backend/services/organizations_service.py
@@ -25,6 +25,12 @@ CROSS_ACCOUNT_ROLE_NAME = os.environ.get(
 # Used to decide whether role assumption is needed.
 MANAGEMENT_ACCOUNT_ID = os.environ.get('AWS_MANAGEMENT_ACCOUNT_ID', '')
 
+if not MANAGEMENT_ACCOUNT_ID:
+    logger.warning(
+        "AWS_MANAGEMENT_ACCOUNT_ID is not set. Multi-account features will not work correctly — "
+        "all account_id values will trigger STS AssumeRole, including the management account."
+    )
+
 
 class OrganizationsService:
     """Service for AWS Organizations account discovery and cross-account session management."""
@@ -97,6 +103,14 @@ class OrganizationsService:
         if account_id == MANAGEMENT_ACCOUNT_ID:
             logger.info(f"Using default session for management account {account_id}")
             return self.session
+
+        # Fail fast if the management account ID is not configured — we cannot
+        # safely distinguish management from member accounts without it
+        if not MANAGEMENT_ACCOUNT_ID:
+            raise RuntimeError(
+                "AWS_MANAGEMENT_ACCOUNT_ID is not set. Cannot determine whether "
+                f"account {account_id} requires role assumption."
+            )
 
         # Member account — assume the cross-account role via STS
         sts_client = self.session.client('sts')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,9 @@ services:
       - AWS_REGION=${AWS_REGION:-us-east-1}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      # Multi-account support — set these to enable cross-account scanning
+      - AWS_MANAGEMENT_ACCOUNT_ID=${AWS_MANAGEMENT_ACCOUNT_ID:-}
+      - CROSS_ACCOUNT_ROLE_NAME=${CROSS_ACCOUNT_ROLE_NAME:-SecurityAuditRole-test}
       - SMTP_HOST=${SMTP_HOST:-mailhog}
       - SMTP_PORT=${SMTP_PORT:-1025}
       - SMTP_USERNAME=${SMTP_USERNAME:-}

--- a/env.example
+++ b/env.example
@@ -14,6 +14,12 @@ AWS_REGION=us-east-1
 AWS_ACCESS_KEY_ID=your-aws-access-key-id
 AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
 
+# Multi-account support — required for cross-account scanning
+# AWS_MANAGEMENT_ACCOUNT_ID: the 12-digit account ID of the management/root account
+# CROSS_ACCOUNT_ROLE_NAME: role that must exist in each member account (default shown)
+AWS_MANAGEMENT_ACCOUNT_ID=your-management-account-id
+CROSS_ACCOUNT_ROLE_NAME=SecurityAuditRole-test
+
 # SMTP Configuration (local test defaults)
 SMTP_HOST=mailhog
 SMTP_PORT=1025


### PR DESCRIPTION
Adds multi-account support to the Flask backend for local development. Introduces OrganizationsService for account discovery and STS AssumeRole session management, wires account_id as an optional parameter across all AWS API endpoints, and registers the new GET /api/v1/accounts endpoint. All backward compatible with single-account usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-account support — select an account for analysis across Dashboard, EC2, IAM, S3, and Security Hub
  * New endpoint to list available accounts
* **Configuration**
  * Added environment settings to configure management account ID and cross-account role name
* **Security**
  * Cross-account session handling for secure assumed-role access
* **Other**
  * Service now accepts injected AWS session to enable account-scoped operations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->