### PR TITLE
A17 - define and implement data retention policies for Prometheu…

### DIFF
--- a/.interface-design/system.md
+++ b/.interface-design/system.md
@@ -95,6 +95,12 @@ Amber:   #f59e0b   (chart-4)
 Red:     #ef4444   (destructive / shadcn)
 ```
 
+### ARGUS overlay accent
+```
+--argus-accent:  #00d4ff   (ARGUS Voice IR Agent identity color — panel borders, wordmark, active states)
+```
+Scoped exclusively to `VoiceIRAgent.tsx`. Do not use outside the ARGUS overlay.
+
 ---
 
 ## Typography

--- a/.interface-design/system.md
+++ b/.interface-design/system.md
@@ -96,8 +96,8 @@ Red:     #ef4444   (destructive / shadcn)
 ```
 
 ### ARGUS overlay accent
-```
---argus-accent:  #00d4ff   (ARGUS Voice IR Agent identity color — panel borders, wordmark, active states)
+```css
+--argus-accent:  #00d4ff;   /* ARGUS Voice IR Agent identity color — panel borders, wordmark, active states */
 ```
 Scoped exclusively to `VoiceIRAgent.tsx`. Do not use outside the ARGUS overlay.
 

--- a/backend/api/ir.py
+++ b/backend/api/ir.py
@@ -43,15 +43,13 @@ def _get_bedrock_client():
     api_key = os.environ.get("BEDROCK_API_KEY")
     region  = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
     if api_key:
-        return boto3.client(
-            "bedrock-runtime",
-            region_name=region,
-            aws_access_key_id=api_key,
-            aws_secret_access_key="bedrock-api-key",  # Bedrock API key auth
-        )
+        # Bedrock API key auth: boto3 reads AWS_BEARER_TOKEN_BEDROCK automatically.
+        # Do not stuff the key into SigV4 credential fields.
+        os.environ["AWS_BEARER_TOKEN_BEDROCK"] = api_key
+    # Without an API key, boto3 discovers credentials normally (env vars, IAM role, etc.)
     return boto3.client("bedrock-runtime", region_name=region)
 
-MODEL_ID = os.environ.get("BEDROCK_MODEL_ID", "anthropic.claude-haiku-4-5")
+MODEL_ID = os.environ.get("BEDROCK_MODEL_ID", "anthropic.claude-haiku-4-5-20251001")
 
 # ─── Runbook structured-output constants ──────────────────────────────────────
 
@@ -72,9 +70,6 @@ SYSTEM_RUNBOOK = (
 
 def _invoke_claude(prompt: str, system: str | None = None, max_tokens: int = 1024) -> str | None:
     """Call Claude via Bedrock and return the text response. Falls back to None if unavailable."""
-    api_key = os.environ.get("BEDROCK_API_KEY")
-    if not api_key:
-        return None  # No key = mock mode
     try:
         client = _get_bedrock_client()
         body_dict = {
@@ -130,7 +125,7 @@ def _parse_runbook_steps(raw: str | None) -> list[dict] | None:
             "phase": phase,
             "title": str(item.get("title", ""))[:80],
             "description": str(item.get("description", ""))[:400],
-            "commands": [str(c) for c in item.get("commands", []) if isinstance(c, str)][:6],
+            "commands": [str(c) for c in (item.get("commands") if isinstance(item.get("commands"), list) else []) if isinstance(c, str)][:6],
             "estimated_time": str(item.get("estimated_time", "30")),
         }
         validated.append(step)
@@ -263,13 +258,15 @@ class LLMTriageResource(Resource):
         job = _job_store[job_id]
         job["status"] = "succeeded"
         job["completed_at"] = _now_iso()
-        job["result"] = {
-            "triage_summary": llm_response or mock["triage_summary"],
-            "confidence_score": mock["confidence_score"],
-            "false_positive_probability": mock["false_positive_probability"],
-            "mitre_techniques": mock["mitre_techniques"],
-            "model": MODEL_ID if llm_response else "mock",
-        }
+        # When Bedrock returns real prose, omit mock confidence/MITRE fields — mixing
+        # fabricated metadata with real LLM text misleads the operator.
+        if llm_response:
+            job["result"] = {
+                "triage_summary": llm_response,
+                "model": MODEL_ID,
+            }
+        else:
+            job["result"] = {**mock, "model": "mock"}
 
         return {
             "job_id": job_id,
@@ -319,11 +316,14 @@ class LLMRootCauseResource(Resource):
         job = _job_store[job_id]
         job["status"] = "succeeded"
         job["completed_at"] = _now_iso()
-        job["result"] = {
-            "root_cause_narrative": llm_response or mock["root_cause_narrative"],
-            "mitre_techniques": mock["mitre_techniques"],
-            "model": MODEL_ID if llm_response else "mock",
-        }
+        # Same rule as triage: omit mock MITRE techniques when Bedrock returns real prose.
+        if llm_response:
+            job["result"] = {
+                "root_cause_narrative": llm_response,
+                "model": MODEL_ID,
+            }
+        else:
+            job["result"] = {**mock, "model": "mock"}
 
         return {
             "job_id": job_id,

--- a/backend/api/ir.py
+++ b/backend/api/ir.py
@@ -53,24 +53,88 @@ def _get_bedrock_client():
 
 MODEL_ID = os.environ.get("BEDROCK_MODEL_ID", "anthropic.claude-haiku-4-5")
 
-def _invoke_claude(prompt: str) -> str:
+# ─── Runbook structured-output constants ──────────────────────────────────────
+
+VALID_PHASES = {"IDENTIFY", "CONTAIN", "REMEDIATE", "VERIFY"}
+
+SYSTEM_RUNBOOK = (
+    "You are a cloud security incident responder. "
+    "You MUST respond with ONLY a valid JSON array — no markdown, no prose, no code fences, no explanation. "
+    "The array must contain exactly 4 objects matching this schema: "
+    '{"step": <int>, "phase": <"IDENTIFY"|"CONTAIN"|"REMEDIATE"|"VERIFY">, '
+    '"title": <string max 60 chars>, "description": <string max 200 chars>, '
+    '"commands": [<bash strings, 1-4 items>], "estimated_time": <numeric string in minutes>}. '
+    "Steps must be in phase order: IDENTIFY first, then CONTAIN, REMEDIATE, VERIFY. "
+    "Every command must be a real AWS CLI command or a bash comment starting with #. "
+    "Do not include any text before or after the JSON array."
+)
+
+
+def _invoke_claude(prompt: str, system: str | None = None, max_tokens: int = 1024) -> str | None:
     """Call Claude via Bedrock and return the text response. Falls back to None if unavailable."""
     api_key = os.environ.get("BEDROCK_API_KEY")
     if not api_key:
         return None  # No key = mock mode
     try:
         client = _get_bedrock_client()
-        body = json.dumps({
+        body_dict = {
             "anthropic_version": "bedrock-2023-05-31",
-            "max_tokens": 1024,
+            "max_tokens": max_tokens,
             "messages": [{"role": "user", "content": prompt}],
-        })
+        }
+        if system:
+            body_dict["system"] = system
+        body = json.dumps(body_dict)
         response = client.invoke_model(modelId=MODEL_ID, body=body)
         result = json.loads(response["body"].read())
         return result["content"][0]["text"]
     except Exception as e:
         logger.error("Bedrock invocation failed: %s", e)
         return None  # Fall back to mock
+
+
+def _parse_runbook_steps(raw: str | None) -> list[dict] | None:
+    """
+    Parse Claude's JSON response into a validated list of PlaybookStep dicts.
+    Returns None if parsing or validation fails — caller falls back to mock steps.
+    """
+    if not raw:
+        return None
+    text = raw.strip()
+    # Strip accidental code fences Claude sometimes emits despite instruction
+    if text.startswith("```"):
+        lines = text.splitlines()
+        text = "\n".join(
+            line for line in lines[1:]
+            if not line.strip().startswith("```")
+        ).strip()
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        logger.warning("Runbook JSON parse failed: %s | raw=%r", exc, raw[:200])
+        return None
+    if not isinstance(data, list) or len(data) == 0:
+        logger.warning("Runbook JSON is not a non-empty list")
+        return None
+    validated = []
+    for i, item in enumerate(data):
+        if not isinstance(item, dict):
+            logger.warning("Runbook step %d is not a dict", i)
+            return None
+        phase = item.get("phase", "")
+        if phase not in VALID_PHASES:
+            logger.warning("Runbook step %d has invalid phase: %r", i, phase)
+            return None
+        step = {
+            "step": int(item.get("step", i + 1)),
+            "phase": phase,
+            "title": str(item.get("title", ""))[:80],
+            "description": str(item.get("description", ""))[:400],
+            "commands": [str(c) for c in item.get("commands", []) if isinstance(c, str)][:6],
+            "estimated_time": str(item.get("estimated_time", "30")),
+        }
+        validated.append(step)
+    return validated if validated else None
 
 # ─── In-memory job store (replace with DynamoDB in production) ────────────────
 
@@ -293,25 +357,26 @@ class LLMRunbookResource(Resource):
         _register_idempotency(idempotency_key, job_id)
         _write_audit(finding_id, "system", "system", "LLM runbook generation triggered", idempotency_key=idempotency_key)
 
-        prompt = (
-            f"You are a cloud security incident responder. Generate a step-by-step IR runbook for:\n"
+        user_prompt = (
+            f"Generate a 4-step IR playbook for this AWS security finding.\n"
             f"Finding ID: {finding_id}\n"
-            f"Severity: {data.get('severity', 'Unknown')}\n"
+            f"Severity: {data.get('severity', 'MEDIUM')}\n"
             f"Type: {data.get('finding_type', 'Unknown')}\n"
             f"Resource: {data.get('resource_name', 'Unknown')}\n"
+            f"Resource ARN: {data.get('resource_arn', 'arn:aws:iam::123456789012:resource/unknown')}\n"
             f"Description: {data.get('description', 'No description provided')}\n\n"
-            f"Format as markdown with phases: IDENTIFY, CONTAIN, ERADICATE, RECOVER, LESSONS LEARNED. "
-            f"Include specific AWS CLI commands where applicable. Be concise and actionable."
+            f"Return only the JSON array as instructed."
         )
-        llm_response = _invoke_claude(prompt)
+        llm_response = _invoke_claude(user_prompt, system=SYSTEM_RUNBOOK, max_tokens=2048)
+        parsed_steps = _parse_runbook_steps(llm_response)
         mock = _mock_result("llm_runbook")
 
         job = _job_store[job_id]
         job["status"] = "succeeded"
         job["completed_at"] = _now_iso()
         job["result"] = {
-            "runbook_markdown": llm_response or mock["runbook_markdown"],
-            "model": MODEL_ID if llm_response else "mock",
+            "runbook_steps": parsed_steps if parsed_steps is not None else mock["runbook_steps"],
+            "model": MODEL_ID if (llm_response and parsed_steps is not None) else "mock",
         }
 
         return {
@@ -536,7 +601,62 @@ def _mock_result(action_type: str) -> dict:
             "mitre_techniques": ["T1078", "T1580"],
         },
         "llm_runbook": {
-            "runbook_markdown": "## IR Runbook\n\n### Phase 1 — IDENTIFY\n1. Validate finding via CloudTrail.\n",
+            "runbook_steps": [
+                {
+                    "step": 1,
+                    "phase": "IDENTIFY",
+                    "title": "Validate Finding via CloudTrail",
+                    "description": "Confirm true positive by querying CloudTrail for API calls from the suspicious principal within the finding window. Cross-reference source IPs against threat intel.",
+                    "commands": [
+                        "# Lookup events by access key or resource",
+                        "aws cloudtrail lookup-events --lookup-attributes AttributeKey=AccessKeyId,AttributeValue=AKIA_REPLACE --start-time $(date -u -d '-24 hours' +%FT%TZ) --max-results 50",
+                        "# Check for anomalous IAM activity",
+                        "aws iam generate-service-last-accessed-details --arn RESOURCE_ARN",
+                    ],
+                    "estimated_time": "15",
+                },
+                {
+                    "step": 2,
+                    "phase": "CONTAIN",
+                    "title": "Revoke Compromised Credentials",
+                    "description": "Immediately disable the access key to stop ongoing access. Use the IR Engine contain actions for approval-gated permanent revocation.",
+                    "commands": [
+                        "# Disable key (reversible — safe first step)",
+                        "aws iam update-access-key --access-key-id AKIA_REPLACE --status Inactive --user-name USERNAME",
+                        "# Tag resource for IR tracking",
+                        "aws resourcegroupstaggingapi tag-resources --resource-arn-list RESOURCE_ARN --tags IncidentId=IR-REPLACE,ContainedAt=$(date -u +%FT%TZ)",
+                    ],
+                    "estimated_time": "10",
+                },
+                {
+                    "step": 3,
+                    "phase": "REMEDIATE",
+                    "title": "Rotate Credentials and Harden IAM",
+                    "description": "Issue a new key for legitimate workloads, apply least-privilege policy, enable MFA, and audit IAM trust boundaries to prevent recurrence.",
+                    "commands": [
+                        "# Create replacement key for the workload",
+                        "aws iam create-access-key --user-name USERNAME",
+                        "# Review and scope down attached policies",
+                        "aws iam list-attached-user-policies --user-name USERNAME",
+                        "# Enable virtual MFA",
+                        "aws iam create-virtual-mfa-device --virtual-mfa-device-name USERNAME-mfa --outfile /tmp/mfa-qr.png --bootstrap-method QRCodePNG",
+                    ],
+                    "estimated_time": "60",
+                },
+                {
+                    "step": 4,
+                    "phase": "VERIFY",
+                    "title": "Confirm Closure and Re-scan",
+                    "description": "Re-run the scanner, verify no active sessions from the suspicious principal, update the Security Hub finding status, and close the workflow ticket.",
+                    "commands": [
+                        "# Confirm no active sessions remain",
+                        "aws iam list-access-keys --user-name USERNAME",
+                        "# Resolve finding in Security Hub",
+                        "aws securityhub batch-update-findings --finding-identifiers ProductArn=PRODUCT_ARN,Id=FINDING_ID --note Text='Remediated by IR workflow',UpdatedBy=analyst --workflow Status=RESOLVED",
+                    ],
+                    "estimated_time": "20",
+                },
+            ],
         },
         "aws_ec2_isolate": {
             "isolation_sg_id": f"sg-{uuid.uuid4().hex[:8]}",

--- a/backend/api/ir.py
+++ b/backend/api/ir.py
@@ -29,11 +29,48 @@ import json
 import logging
 import uuid
 import time
+import os
+import boto3
 from datetime import datetime, timezone, timedelta
 from flask import request, jsonify
 from flask_restful import Resource
 
 logger = logging.getLogger(__name__)
+
+# ─── Bedrock client ───────────────────────────────────────────────────────────
+
+def _get_bedrock_client():
+    api_key = os.environ.get("BEDROCK_API_KEY")
+    region  = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
+    if api_key:
+        return boto3.client(
+            "bedrock-runtime",
+            region_name=region,
+            aws_access_key_id=api_key,
+            aws_secret_access_key="bedrock-api-key",  # Bedrock API key auth
+        )
+    return boto3.client("bedrock-runtime", region_name=region)
+
+MODEL_ID = os.environ.get("BEDROCK_MODEL_ID", "anthropic.claude-haiku-4-5")
+
+def _invoke_claude(prompt: str) -> str:
+    """Call Claude via Bedrock and return the text response. Falls back to None if unavailable."""
+    api_key = os.environ.get("BEDROCK_API_KEY")
+    if not api_key:
+        return None  # No key = mock mode
+    try:
+        client = _get_bedrock_client()
+        body = json.dumps({
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": prompt}],
+        })
+        response = client.invoke_model(modelId=MODEL_ID, body=body)
+        result = json.loads(response["body"].read())
+        return result["content"][0]["text"]
+    except Exception as e:
+        logger.error("Bedrock invocation failed: %s", e)
+        return None  # Fall back to mock
 
 # ─── In-memory job store (replace with DynamoDB in production) ────────────────
 
@@ -145,14 +182,38 @@ class LLMTriageResource(Resource):
         }
         _register_idempotency(idempotency_key, job_id)
         _write_audit(finding_id, "system", "system", "LLM triage triggered", idempotency_key=idempotency_key)
-        _mock_execute_job(job_id)
+
+        prompt = (
+            f"You are a cloud security incident responder. Triage this AWS security finding:\n"
+            f"Finding ID: {finding_id}\n"
+            f"Severity: {data.get('severity', 'Unknown')}\n"
+            f"Type: {data.get('finding_type', 'Unknown')}\n"
+            f"Resource: {data.get('resource_name', 'Unknown')}\n"
+            f"Description: {data.get('description', 'No description provided')}\n\n"
+            f"Respond with: 1) TRUE/FALSE POSITIVE assessment, 2) confidence score 0-1, "
+            f"3) MITRE ATT&CK techniques, 4) immediate recommended actions. Be concise."
+        )
+        llm_response = _invoke_claude(prompt)
+        mock = _mock_result("llm_triage")
+
+        job = _job_store[job_id]
+        job["status"] = "succeeded"
+        job["completed_at"] = _now_iso()
+        job["result"] = {
+            "triage_summary": llm_response or mock["triage_summary"],
+            "confidence_score": mock["confidence_score"],
+            "false_positive_probability": mock["false_positive_probability"],
+            "mitre_techniques": mock["mitre_techniques"],
+            "model": MODEL_ID if llm_response else "mock",
+        }
 
         return {
             "job_id": job_id,
             "finding_id": finding_id,
             "action_type": "llm_triage",
-            "status": "queued",
+            "status": "succeeded",
             "approval_required": False,
+            "result": job["result"],
         }, 202
 
 
@@ -177,14 +238,36 @@ class LLMRootCauseResource(Resource):
         }
         _register_idempotency(idempotency_key, job_id)
         _write_audit(finding_id, "system", "system", "LLM root-cause analysis triggered", idempotency_key=idempotency_key)
-        _mock_execute_job(job_id)
+
+        prompt = (
+            f"You are a cloud security expert. Perform root cause analysis for this AWS finding:\n"
+            f"Finding ID: {finding_id}\n"
+            f"Severity: {data.get('severity', 'Unknown')}\n"
+            f"Type: {data.get('finding_type', 'Unknown')}\n"
+            f"Resource: {data.get('resource_name', 'Unknown')}\n"
+            f"Description: {data.get('description', 'No description provided')}\n\n"
+            f"Provide: 1) Root cause narrative, 2) Attack chain reconstruction, "
+            f"3) MITRE ATT&CK mapping, 4) Contributing factors. Be concise and technical."
+        )
+        llm_response = _invoke_claude(prompt)
+        mock = _mock_result("llm_root_cause")
+
+        job = _job_store[job_id]
+        job["status"] = "succeeded"
+        job["completed_at"] = _now_iso()
+        job["result"] = {
+            "root_cause_narrative": llm_response or mock["root_cause_narrative"],
+            "mitre_techniques": mock["mitre_techniques"],
+            "model": MODEL_ID if llm_response else "mock",
+        }
 
         return {
             "job_id": job_id,
             "finding_id": finding_id,
             "action_type": "llm_root_cause",
-            "status": "queued",
+            "status": "succeeded",
             "approval_required": False,
+            "result": job["result"],
         }, 202
 
 
@@ -209,14 +292,35 @@ class LLMRunbookResource(Resource):
         }
         _register_idempotency(idempotency_key, job_id)
         _write_audit(finding_id, "system", "system", "LLM runbook generation triggered", idempotency_key=idempotency_key)
-        _mock_execute_job(job_id)
+
+        prompt = (
+            f"You are a cloud security incident responder. Generate a step-by-step IR runbook for:\n"
+            f"Finding ID: {finding_id}\n"
+            f"Severity: {data.get('severity', 'Unknown')}\n"
+            f"Type: {data.get('finding_type', 'Unknown')}\n"
+            f"Resource: {data.get('resource_name', 'Unknown')}\n"
+            f"Description: {data.get('description', 'No description provided')}\n\n"
+            f"Format as markdown with phases: IDENTIFY, CONTAIN, ERADICATE, RECOVER, LESSONS LEARNED. "
+            f"Include specific AWS CLI commands where applicable. Be concise and actionable."
+        )
+        llm_response = _invoke_claude(prompt)
+        mock = _mock_result("llm_runbook")
+
+        job = _job_store[job_id]
+        job["status"] = "succeeded"
+        job["completed_at"] = _now_iso()
+        job["result"] = {
+            "runbook_markdown": llm_response or mock["runbook_markdown"],
+            "model": MODEL_ID if llm_response else "mock",
+        }
 
         return {
             "job_id": job_id,
             "finding_id": finding_id,
             "action_type": "llm_runbook",
-            "status": "queued",
+            "status": "succeeded",
             "approval_required": False,
+            "result": job["result"],
         }, 202
 
 

--- a/backend/api/ir.py
+++ b/backend/api/ir.py
@@ -30,16 +30,25 @@ import logging
 import uuid
 import time
 import os
-import boto3
 from datetime import datetime, timezone, timedelta
 from flask import request, jsonify
 from flask_restful import Resource
+from api.text_utils import strip_code_fences
+
+try:
+    import boto3
+    _BOTO3_OK = True
+except ImportError as _boto3_err:
+    boto3 = None  # type: ignore[assignment]
+    _BOTO3_OK = False
 
 logger = logging.getLogger(__name__)
 
 # ─── Bedrock client ───────────────────────────────────────────────────────────
 
 def _get_bedrock_client():
+    if not _BOTO3_OK:
+        raise RuntimeError("boto3 is not installed — cannot create Bedrock client")
     api_key = os.environ.get("BEDROCK_API_KEY")
     region  = os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
     if api_key:
@@ -95,14 +104,7 @@ def _parse_runbook_steps(raw: str | None) -> list[dict] | None:
     """
     if not raw:
         return None
-    text = raw.strip()
-    # Strip accidental code fences Claude sometimes emits despite instruction
-    if text.startswith("```"):
-        lines = text.splitlines()
-        text = "\n".join(
-            line for line in lines[1:]
-            if not line.strip().startswith("```")
-        ).strip()
+    text = strip_code_fences(raw)
     try:
         data = json.loads(text)
     except json.JSONDecodeError as exc:
@@ -120,8 +122,12 @@ def _parse_runbook_steps(raw: str | None) -> list[dict] | None:
         if phase not in VALID_PHASES:
             logger.warning("Runbook step %d has invalid phase: %r", i, phase)
             return None
+        try:
+            step_num = int(item.get("step", i + 1))
+        except (TypeError, ValueError):
+            step_num = i + 1
         step = {
-            "step": int(item.get("step", i + 1)),
+            "step": step_num,
             "phase": phase,
             "title": str(item.get("title", ""))[:80],
             "description": str(item.get("description", ""))[:400],

--- a/backend/api/retention.py
+++ b/backend/api/retention.py
@@ -36,6 +36,7 @@ class RetentionCleanupResource(Resource):
     """POST /api/v1/system/retention — on-demand retention (requires RETENTION_RUN_KEY)."""
 
     def post(self):
+        """Run a retention pass when ``X-Retention-Run-Key`` matches ``RETENTION_RUN_KEY``."""
         expected = os.environ.get("RETENTION_RUN_KEY", "").strip()
         if not expected:
             return {

--- a/backend/api/retention.py
+++ b/backend/api/retention.py
@@ -1,0 +1,55 @@
+"""
+Data retention: DynamoDB age-based deletes + PostgreSQL cleanup.
+
+Optional HTTP trigger (POST) when RETENTION_RUN_KEY is set.
+"""
+
+import logging
+import os
+
+from flask import request
+from flask_restful import Resource
+
+from services.database_service import DatabaseService
+from services.dynamodb_service import DynamoDBService
+
+logger = logging.getLogger(__name__)
+
+
+def run_retention_pass(days: int = 90) -> dict:
+    """Run DynamoDB paginated deletes and PostgreSQL cleanup."""
+    dynamo = DynamoDBService()
+    db = DatabaseService()
+    scan_deleted = dynamo.delete_old_records(dynamo.scan_results_table, days)
+    findings_deleted = dynamo.delete_old_records(dynamo.iam_findings_table, days)
+    sql_counts = db.cleanup_old_records(days)
+    result = {
+        "dynamo_scan_results_deleted": scan_deleted,
+        "dynamo_iam_findings_deleted": findings_deleted,
+        "postgres": sql_counts,
+    }
+    logger.info("Retention pass complete: %s", result)
+    return result
+
+
+class RetentionCleanupResource(Resource):
+    """POST /api/v1/system/retention — on-demand retention (requires RETENTION_RUN_KEY)."""
+
+    def post(self):
+        expected = os.environ.get("RETENTION_RUN_KEY", "").strip()
+        if not expected:
+            return {
+                "error": "disabled",
+                "message": "Set RETENTION_RUN_KEY to enable HTTP-triggered retention runs.",
+            }, 503
+        supplied = request.headers.get("X-Retention-Run-Key", "").strip()
+        if supplied != expected:
+            return {"error": "forbidden"}, 403
+        try:
+            days = int(request.args.get("days", "90"))
+            if days < 1 or days > 3650:
+                days = 90
+        except ValueError:
+            days = 90
+        result = run_retention_pass(days=days)
+        return result, 200

--- a/backend/api/retention.py
+++ b/backend/api/retention.py
@@ -4,6 +4,7 @@ Data retention: DynamoDB age-based deletes + PostgreSQL cleanup.
 Optional HTTP trigger (POST) when RETENTION_RUN_KEY is set.
 """
 
+import hmac
 import logging
 import os
 
@@ -44,7 +45,7 @@ class RetentionCleanupResource(Resource):
                 "message": "Set RETENTION_RUN_KEY to enable HTTP-triggered retention runs.",
             }, 503
         supplied = request.headers.get("X-Retention-Run-Key", "").strip()
-        if supplied != expected:
+        if not hmac.compare_digest(supplied, expected):
             return {"error": "forbidden"}, 403
         try:
             days = int(request.args.get("days", "90"))
@@ -52,5 +53,9 @@ class RetentionCleanupResource(Resource):
                 days = 90
         except ValueError:
             days = 90
-        result = run_retention_pass(days=days)
-        return result, 200
+        try:
+            result = run_retention_pass(days=days)
+            return result, 200
+        except Exception:
+            logger.exception("Retention pass failed")
+            return {"error": "Retention pass failed"}, 500

--- a/backend/api/text_utils.py
+++ b/backend/api/text_utils.py
@@ -1,0 +1,21 @@
+"""
+text_utils.py — shared text-processing helpers for backend API modules.
+"""
+
+
+def strip_code_fences(text: str) -> str:
+    """
+    Remove accidental markdown code fences from model output.
+
+    Claude occasionally wraps JSON in ```json ... ``` or ``` ... ``` blocks
+    despite being instructed not to. Strip the opening fence line and any
+    closing fence lines so the caller gets clean JSON.
+    """
+    stripped = text.strip()
+    if not stripped.startswith("```"):
+        return stripped
+    lines = stripped.splitlines()
+    return "\n".join(
+        line for line in lines[1:]
+        if not line.strip().startswith("```")
+    ).strip()

--- a/backend/api/tts.py
+++ b/backend/api/tts.py
@@ -1,0 +1,84 @@
+"""
+TTS endpoint — AWS Polly Neural TTS → audio/mpeg
+
+POST /api/v1/tts/synthesize
+  Body: { "text": "...", "voice": "Matthew", "engine": "neural" }
+  Response: audio/mpeg binary on success, JSON {error, fallback:true} on failure
+
+In mock/dev mode (DATA_MODE=mock) returns 503 fallback so the frontend
+falls back to the browser's Web Speech API automatically.
+"""
+
+import os
+import logging
+
+from flask import request, Response
+from flask_restful import Resource
+
+logger = logging.getLogger(__name__)
+
+try:
+    import boto3
+    from botocore.exceptions import BotoCoreError, ClientError
+    _BOTO3_OK = True
+except ImportError:
+    _BOTO3_OK = False
+
+# Voices supported by Polly Neural engine that are appropriate for SOC tooling.
+_ALLOWED_VOICES = {"Matthew", "Joanna", "Stephen", "Ruth", "Brian", "Emma"}
+_MAX_CHARS = 3_000
+
+
+def _is_mock_mode() -> bool:
+    for key in ("DATA_MODE", "VITE_DATA_MODE"):
+        if (os.getenv(key) or "").strip().lower() == "mock":
+            return True
+    return False
+
+
+class TTSSynthesizeResource(Resource):
+    """POST /api/v1/tts/synthesize — Polly Neural TTS."""
+
+    def post(self):
+        data = request.get_json(silent=True) or {}
+        text: str = (data.get("text") or "").strip()
+        voice: str = data.get("voice", "Matthew")
+        engine: str = data.get("engine", "neural")
+
+        if not text:
+            return {"error": "text is required"}, 400
+
+        # Sanitise inputs
+        if voice not in _ALLOWED_VOICES:
+            voice = "Matthew"
+        if engine not in ("neural", "standard"):
+            engine = "neural"
+        if len(text) > _MAX_CHARS:
+            text = text[:_MAX_CHARS]
+
+        # Return fallback signal in mock/dev mode so frontend uses Web Speech API
+        if _is_mock_mode():
+            return {"error": "mock mode — use browser TTS fallback", "fallback": True}, 503
+
+        if not _BOTO3_OK:
+            return {"error": "boto3 not installed", "fallback": True}, 503
+
+        try:
+            region = os.getenv("AWS_DEFAULT_REGION", "us-east-1")
+            polly = boto3.client("polly", region_name=region)
+            resp = polly.synthesize_speech(
+                Text=text,
+                OutputFormat="mp3",
+                VoiceId=voice,
+                Engine=engine,
+            )
+            audio_bytes: bytes = resp["AudioStream"].read()
+            return Response(audio_bytes, mimetype="audio/mpeg", status=200)
+
+        except (BotoCoreError, ClientError) as exc:
+            logger.warning("Polly synthesis failed: %s", exc)
+            return {"error": str(exc), "fallback": True}, 503
+
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.error("Unexpected TTS error: %s", exc)
+            return {"error": "internal error", "fallback": True}, 503

--- a/backend/api/tts.py
+++ b/backend/api/tts.py
@@ -77,7 +77,7 @@ class TTSSynthesizeResource(Resource):
 
         except (BotoCoreError, ClientError) as exc:
             logger.warning("Polly synthesis failed: %s", exc)
-            return {"error": str(exc), "fallback": True}, 503
+            return {"error": "synthesis unavailable", "fallback": True}, 503
 
         except Exception as exc:  # pylint: disable=broad-except
             logger.error("Unexpected TTS error: %s", exc)

--- a/backend/api/voice_intent.py
+++ b/backend/api/voice_intent.py
@@ -15,6 +15,7 @@ import logging
 from flask import request, jsonify
 from flask_restful import Resource
 from api.ir import _invoke_claude
+from api.text_utils import strip_code_fences
 
 logger = logging.getLogger(__name__)
 
@@ -85,14 +86,7 @@ class VoiceIntentResource(Resource):
             logger.warning("VoiceIntent: _invoke_claude returned None for utterance %r", utterance[:80])
             return _BEDROCK_UNAVAILABLE, 503
 
-        # Strip accidental code fences (same guard used in _parse_runbook_steps)
-        text = raw.strip()
-        if text.startswith("```"):
-            lines = text.splitlines()
-            text = "\n".join(
-                line for line in lines[1:]
-                if not line.strip().startswith("```")
-            ).strip()
+        text = strip_code_fences(raw)
 
         try:
             result = json.loads(text)

--- a/backend/api/voice_intent.py
+++ b/backend/api/voice_intent.py
@@ -11,7 +11,6 @@ POST /api/v1/voice/intent
 
 import json
 import logging
-import os
 
 from flask import request, jsonify
 from flask_restful import Resource
@@ -47,10 +46,8 @@ class VoiceIntentResource(Resource):
     """POST /api/v1/voice/intent — Bedrock intent classification fallback."""
 
     def post(self):
-        if not os.environ.get("BEDROCK_API_KEY"):
-            logger.warning("VoiceIntent: BEDROCK_API_KEY not set — returning fallback")
-            return _BEDROCK_UNAVAILABLE, 503
-
+        # Do not gate on BEDROCK_API_KEY here — _invoke_claude() handles credential
+        # discovery (API key, IAM role, env vars) and returns None if unavailable.
         data = request.get_json(force=True, silent=True) or {}
         utterance: str = (data.get("utterance") or "").strip()
         if not utterance:
@@ -101,6 +98,10 @@ class VoiceIntentResource(Resource):
             result = json.loads(text)
         except json.JSONDecodeError as exc:
             logger.warning("VoiceIntent JSON parse failed: %s | raw=%r", exc, raw[:200])
+            return _BEDROCK_UNAVAILABLE, 503
+
+        if not isinstance(result, dict):
+            logger.warning("VoiceIntent: model returned non-object JSON — raw=%r", raw[:200])
             return _BEDROCK_UNAVAILABLE, 503
 
         intent = str(result.get("intent", "unknown"))

--- a/backend/api/voice_intent.py
+++ b/backend/api/voice_intent.py
@@ -1,0 +1,130 @@
+"""
+voice_intent.py — Bedrock intent fallback for Argus Voice IR Agent
+
+POST /api/v1/voice/intent
+  Called only when client-side regex matchIntent() returns "unknown".
+
+  Request:  { utterance, context_turns[{role, text}], finding_context }
+  Response: { intent, spoken_reply, args, confidence }
+  Fallback: { error: "bedrock_unavailable", fallback: true } → 503
+"""
+
+import json
+import logging
+import os
+
+from flask import request, jsonify
+from flask_restful import Resource
+from api.ir import _invoke_claude
+
+logger = logging.getLogger(__name__)
+
+VALID_INTENTS = {
+    "briefing", "critical", "threat", "sla", "latest",
+    "show_findings", "compliance", "scan", "help", "high",
+    "isolate", "revoke", "disable_key", "navigate", "unknown",
+}
+
+SYSTEM_VOICE_INTENT = (
+    "You are Argus, a voice-driven cloud security IR agent for an AWS security operations dashboard. "
+    "The user has spoken a command that the regex intent matcher could not classify. "
+    "Classify the utterance into exactly one of these intents: "
+    "briefing, critical, threat, sla, latest, show_findings, compliance, scan, "
+    "help, high, isolate, revoke, disable_key, navigate, unknown. "
+    "You MUST respond with ONLY a valid JSON object — no markdown, no prose, no code fences. "
+    'Schema: {"intent": <string>, "spoken_reply": <string|null>, "args": <object|null>, "confidence": <float 0-1>}. '
+    "spoken_reply: a short, direct military-style spoken response (max 2 sentences) for TTS. "
+    "Set to null if intent is unknown. Reference the finding context if relevant to the operator's goal. "
+    "args: structured parameters extracted from the utterance (e.g. {\"resource\": \"i-0abc123\"}) or null if none. "
+    "High-impact intents (isolate, revoke) must only be returned if the utterance contains clear containment language. "
+    "Do not include any text outside the JSON object."
+)
+
+_BEDROCK_UNAVAILABLE = {"error": "bedrock_unavailable", "fallback": True}
+
+
+class VoiceIntentResource(Resource):
+    """POST /api/v1/voice/intent — Bedrock intent classification fallback."""
+
+    def post(self):
+        if not os.environ.get("BEDROCK_API_KEY"):
+            logger.warning("VoiceIntent: BEDROCK_API_KEY not set — returning fallback")
+            return _BEDROCK_UNAVAILABLE, 503
+
+        data = request.get_json(force=True, silent=True) or {}
+        utterance: str = (data.get("utterance") or "").strip()
+        if not utterance:
+            return {"error": "utterance is required"}, 400
+
+        context_turns = (data.get("context_turns") or [])[-3:]
+        finding_context = data.get("finding_context") or None
+
+        # Build user prompt
+        parts = []
+
+        if finding_context:
+            sev   = (finding_context.get("severity") or "UNKNOWN").upper()
+            ftype = finding_context.get("finding_type") or "Unknown finding"
+            rsrc  = finding_context.get("resource_name") or "Unknown resource"
+            svc   = finding_context.get("service") or "aws"
+            parts.append(
+                f"Active finding context: severity={sev}, type={ftype!r}, "
+                f"resource={rsrc!r}, service={svc}."
+            )
+
+        if context_turns:
+            parts.append("Recent conversation (oldest first):")
+            for t in context_turns:
+                role = t.get("role", "user")
+                text = (t.get("text") or "").strip()
+                if text:
+                    parts.append(f"  [{role}]: {text}")
+
+        parts.append(f'Classify: "{utterance}"')
+        prompt = "\n".join(parts)
+
+        raw = _invoke_claude(prompt, system=SYSTEM_VOICE_INTENT, max_tokens=256)
+        if not raw:
+            logger.warning("VoiceIntent: _invoke_claude returned None for utterance %r", utterance[:80])
+            return _BEDROCK_UNAVAILABLE, 503
+
+        # Strip accidental code fences (same guard used in _parse_runbook_steps)
+        text = raw.strip()
+        if text.startswith("```"):
+            lines = text.splitlines()
+            text = "\n".join(
+                line for line in lines[1:]
+                if not line.strip().startswith("```")
+            ).strip()
+
+        try:
+            result = json.loads(text)
+        except json.JSONDecodeError as exc:
+            logger.warning("VoiceIntent JSON parse failed: %s | raw=%r", exc, raw[:200])
+            return _BEDROCK_UNAVAILABLE, 503
+
+        intent = str(result.get("intent", "unknown"))
+        if intent not in VALID_INTENTS:
+            logger.warning("VoiceIntent returned unmapped intent %r — coercing to unknown", intent)
+            intent = "unknown"
+
+        spoken_reply = result.get("spoken_reply") or None
+        if spoken_reply:
+            spoken_reply = str(spoken_reply)[:500]
+
+        args = result.get("args")
+        if args and not isinstance(args, dict):
+            args = None
+
+        try:
+            confidence = float(result.get("confidence", 0.0))
+            confidence = max(0.0, min(1.0, confidence))
+        except (TypeError, ValueError):
+            confidence = 0.0
+
+        return {
+            "intent":       intent,
+            "spoken_reply": spoken_reply,
+            "args":         args,
+            "confidence":   confidence,
+        }, 200

--- a/backend/app.py
+++ b/backend/app.py
@@ -40,6 +40,7 @@ from api.ir import (
 )
 from api.retention import RetentionCleanupResource, run_retention_pass
 from api.tts import TTSSynthesizeResource
+from api.voice_intent import VoiceIntentResource
 
 # Import services
 from services.aws_service import AWSService
@@ -116,6 +117,7 @@ def create_app():
     api.add_resource(IREvidenceResource,          '/ir/evidence/<string:finding_id>')
     api.add_resource(IRAuditResource,             '/ir/audit')
     api.add_resource(TTSSynthesizeResource,       '/tts/synthesize')
+    api.add_resource(VoiceIntentResource,         '/voice/intent')
 
     # Serve static files (React frontend)
     @app.route('/')

--- a/backend/app.py
+++ b/backend/app.py
@@ -39,6 +39,7 @@ from api.ir import (
     IRAuditResource,
 )
 from api.retention import RetentionCleanupResource, run_retention_pass
+from api.tts import TTSSynthesizeResource
 
 # Import services
 from services.aws_service import AWSService
@@ -114,6 +115,7 @@ def create_app():
     api.add_resource(IRForensicsResource,         '/ir/forensics/<string:finding_id>')
     api.add_resource(IREvidenceResource,          '/ir/evidence/<string:finding_id>')
     api.add_resource(IRAuditResource,             '/ir/audit')
+    api.add_resource(TTSSynthesizeResource,       '/tts/synthesize')
 
     # Serve static files (React frontend)
     @app.route('/')

--- a/backend/app.py
+++ b/backend/app.py
@@ -151,7 +151,13 @@ def create_app():
         ):
             logger.info("Retention scheduler disabled (RETENTION_SCHEDULER_ENABLED).")
             return
-        interval = int(os.environ.get("RETENTION_SCHEDULER_INTERVAL_SEC", "86400"))
+        raw_interval = os.environ.get("RETENTION_SCHEDULER_INTERVAL_SEC", "86400")
+        try:
+            interval = int(raw_interval)
+        except (TypeError, ValueError):
+            interval = 86400
+        if interval <= 0:
+            interval = 86400
 
         def _worker():
             """Run retention on startup delay, then loop with ``interval`` sleeps."""
@@ -174,7 +180,10 @@ def create_app():
             interval,
         )
 
-    _start_retention_scheduler(app)
+    if not os.environ.get("AWS_LAMBDA_FUNCTION_NAME") and os.environ.get(
+        "WERKZEUG_RUN_MAIN", "false"
+    ) != "true":
+        _start_retention_scheduler(app)
 
     return app
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -5,6 +5,8 @@ Main application entry point with API endpoints for AWS integrations
 
 import os
 import logging
+import threading
+import time
 from flask import Flask, jsonify, request, send_from_directory
 from flask_cors import CORS
 from flask_restful import Api
@@ -36,6 +38,7 @@ from api.ir import (
     IREvidenceResource,
     IRAuditResource,
 )
+from api.retention import RetentionCleanupResource, run_retention_pass
 
 # Import services
 from services.aws_service import AWSService
@@ -95,6 +98,7 @@ def create_app():
     api.add_resource(SecurityHubResource, '/aws/security-hub')
     api.add_resource(ConfigResource, '/aws/config')
     api.add_resource(GrafanaResource, '/grafana')
+    api.add_resource(RetentionCleanupResource, '/system/retention')
 
     # IR Action Engine routes
     api.add_resource(LLMTriageResource,           '/llm/triage')
@@ -133,6 +137,38 @@ def create_app():
     with app.app_context():
         database_service.init_db()
         logger.info("Database initialized")
+
+    def _start_retention_scheduler(flask_app: Flask) -> None:
+        if os.environ.get("RETENTION_SCHEDULER_ENABLED", "true").lower() not in (
+            "1",
+            "true",
+            "yes",
+        ):
+            logger.info("Retention scheduler disabled (RETENTION_SCHEDULER_ENABLED).")
+            return
+        interval = int(os.environ.get("RETENTION_SCHEDULER_INTERVAL_SEC", "86400"))
+
+        def _worker():
+            time.sleep(60)
+            while True:
+                try:
+                    with flask_app.app_context():
+                        run_retention_pass()
+                except Exception:
+                    logger.exception("Scheduled retention pass failed")
+                time.sleep(interval)
+
+        threading.Thread(
+            target=_worker,
+            daemon=True,
+            name="retention-scheduler",
+        ).start()
+        logger.info(
+            "Retention scheduler started (interval=%ss, first run after 60s startup delay).",
+            interval,
+        )
+
+    _start_retention_scheduler(app)
 
     return app
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -55,6 +55,65 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
+def _parse_retention_interval_seconds() -> int:
+    """Parse RETENTION_SCHEDULER_INTERVAL_SEC with a safe minimum."""
+    raw_interval = os.environ.get("RETENTION_SCHEDULER_INTERVAL_SEC", "86400")
+    try:
+        interval = int(raw_interval)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid RETENTION_SCHEDULER_INTERVAL_SEC=%r; defaulting to 86400s",
+            raw_interval,
+        )
+        interval = 86400
+    if interval <= 0:
+        logger.warning(
+            "Non-positive RETENTION_SCHEDULER_INTERVAL_SEC=%r; defaulting to 86400s",
+            raw_interval,
+        )
+        interval = 86400
+    if interval < 60:
+        logger.warning(
+            "RETENTION_SCHEDULER_INTERVAL_SEC=%r too small; clamping to 60s",
+            raw_interval,
+        )
+        interval = 60
+    return interval
+
+
+def start_retention_scheduler(flask_app: Flask) -> None:
+    """Start a daemon thread that runs ``run_retention_pass`` on a fixed interval."""
+    if os.environ.get("RETENTION_SCHEDULER_ENABLED", "true").lower() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        logger.info("Retention scheduler disabled (RETENTION_SCHEDULER_ENABLED).")
+        return
+    interval = _parse_retention_interval_seconds()
+
+    def _worker():
+        """Run retention on startup delay, then loop with ``interval`` sleeps."""
+        time.sleep(60)
+        while True:
+            try:
+                with flask_app.app_context():
+                    run_retention_pass()
+            except Exception:
+                logger.exception("Scheduled retention pass failed")
+            time.sleep(interval)
+
+    threading.Thread(
+        target=_worker,
+        daemon=True,
+        name="retention-scheduler",
+    ).start()
+    logger.info(
+        "Retention scheduler started (interval=%ss, first run after 60s startup delay).",
+        interval,
+    )
+
+
 def create_app():
     """Create and configure the Flask application"""
     app = Flask(__name__, static_folder='../static')
@@ -146,48 +205,10 @@ def create_app():
         database_service.init_db()
         logger.info("Database initialized")
 
-    def _start_retention_scheduler(flask_app: Flask) -> None:
-        """Start a daemon thread that runs ``run_retention_pass`` on a fixed interval."""
-        if os.environ.get("RETENTION_SCHEDULER_ENABLED", "true").lower() not in (
-            "1",
-            "true",
-            "yes",
-        ):
-            logger.info("Retention scheduler disabled (RETENTION_SCHEDULER_ENABLED).")
-            return
-        raw_interval = os.environ.get("RETENTION_SCHEDULER_INTERVAL_SEC", "86400")
-        try:
-            interval = int(raw_interval)
-        except (TypeError, ValueError):
-            interval = 86400
-        if interval <= 0:
-            interval = 86400
-
-        def _worker():
-            """Run retention on startup delay, then loop with ``interval`` sleeps."""
-            time.sleep(60)
-            while True:
-                try:
-                    with flask_app.app_context():
-                        run_retention_pass()
-                except Exception:
-                    logger.exception("Scheduled retention pass failed")
-                time.sleep(interval)
-
-        threading.Thread(
-            target=_worker,
-            daemon=True,
-            name="retention-scheduler",
-        ).start()
-        logger.info(
-            "Retention scheduler started (interval=%ss, first run after 60s startup delay).",
-            interval,
-        )
-
     if not os.environ.get("AWS_LAMBDA_FUNCTION_NAME") and os.environ.get(
         "WERKZEUG_RUN_MAIN", "false"
     ) != "true":
-        _start_retention_scheduler(app)
+        start_retention_scheduler(app)
 
     return app
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -118,19 +118,23 @@ def create_app():
     # Serve static files (React frontend)
     @app.route('/')
     def serve_frontend():
+        """Serve the React SPA entry (``index.html``) at ``/``."""
         return send_from_directory(app.static_folder, 'index.html')
 
     @app.route('/<path:path>')
     def serve_static(path):
+        """Serve built static assets for client-side routes."""
         return send_from_directory(app.static_folder, path)
 
     # Error handlers
     @app.errorhandler(404)
     def not_found(error):
+        """Return a JSON body for HTTP 404 responses."""
         return jsonify({'error': 'Not found'}), 404
 
     @app.errorhandler(500)
     def internal_error(error):
+        """Return a JSON body for HTTP 500 responses."""
         return jsonify({'error': 'Internal server error'}), 500
 
     # Initialize database
@@ -139,6 +143,7 @@ def create_app():
         logger.info("Database initialized")
 
     def _start_retention_scheduler(flask_app: Flask) -> None:
+        """Start a daemon thread that runs ``run_retention_pass`` on a fixed interval."""
         if os.environ.get("RETENTION_SCHEDULER_ENABLED", "true").lower() not in (
             "1",
             "true",
@@ -149,6 +154,7 @@ def create_app():
         interval = int(os.environ.get("RETENTION_SCHEDULER_INTERVAL_SEC", "86400"))
 
         def _worker():
+            """Run retention on startup delay, then loop with ``interval`` sleeps."""
             time.sleep(60)
             while True:
                 try:

--- a/backend/services/database_service.py
+++ b/backend/services/database_service.py
@@ -61,6 +61,7 @@ class DatabaseService:
     """Service for database operations"""
     
     def __init__(self):
+        """Create SQLAlchemy engine and session factory from ``DATABASE_URL``."""
         self.database_url = os.environ.get('DATABASE_URL', 'sqlite:///cybersecurity.db')
         self.engine = create_engine(self.database_url)
         self.SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=self.engine)

--- a/backend/services/database_service.py
+++ b/backend/services/database_service.py
@@ -180,6 +180,8 @@ class DatabaseService:
     
     def cleanup_old_records(self, days: int = 90) -> dict:
         """Delete rows older than ``days`` from security_findings and performance_metrics."""
+        if days <= 0:
+            raise ValueError("days must be positive")
         cutoff = datetime.utcnow() - timedelta(days=days)
         session = None
         try:
@@ -206,11 +208,7 @@ class DatabaseService:
                     session.rollback()
                 except Exception:
                     pass
-            return {
-                "security_findings_deleted": 0,
-                "performance_metrics_deleted": 0,
-                "error": str(e),
-            }
+            raise
         finally:
             if session is not None:
                 try:

--- a/backend/services/database_service.py
+++ b/backend/services/database_service.py
@@ -209,6 +209,7 @@ class DatabaseService:
                 except Exception:
                     pass
             raise
+            raise
         finally:
             if session is not None:
                 try:

--- a/backend/services/database_service.py
+++ b/backend/services/database_service.py
@@ -7,7 +7,7 @@ import logging
 from sqlalchemy import create_engine, Column, Integer, String, DateTime, Boolean, Text, Float
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-from datetime import datetime
+from datetime import datetime, timedelta
 
 logger = logging.getLogger(__name__)
 
@@ -177,6 +177,46 @@ class DatabaseService:
             logger.error(f"Error getting performance metrics: {str(e)}")
             return []
     
+    def cleanup_old_records(self, days: int = 90) -> dict:
+        """Delete rows older than ``days`` from security_findings and performance_metrics."""
+        cutoff = datetime.utcnow() - timedelta(days=days)
+        session = None
+        try:
+            session = self.get_session()
+            n_findings = (
+                session.query(SecurityFinding)
+                .filter(SecurityFinding.created_at < cutoff)
+                .delete(synchronize_session=False)
+            )
+            n_metrics = (
+                session.query(PerformanceMetric)
+                .filter(PerformanceMetric.timestamp < cutoff)
+                .delete(synchronize_session=False)
+            )
+            session.commit()
+            return {
+                "security_findings_deleted": n_findings,
+                "performance_metrics_deleted": n_metrics,
+            }
+        except Exception as e:
+            logger.error(f"Error during cleanup_old_records: {str(e)}")
+            if session is not None:
+                try:
+                    session.rollback()
+                except Exception:
+                    pass
+            return {
+                "security_findings_deleted": 0,
+                "performance_metrics_deleted": 0,
+                "error": str(e),
+            }
+        finally:
+            if session is not None:
+                try:
+                    session.close()
+                except Exception:
+                    pass
+
     def get_dashboard_summary(self) -> dict:
         """Get dashboard summary data"""
         try:

--- a/backend/services/dynamodb_service.py
+++ b/backend/services/dynamodb_service.py
@@ -22,6 +22,7 @@ def _compute_expires_at_epoch(days: int = _DEFAULT_RETENTION_DAYS) -> int:
 
 
 def _parse_item_time_epoch(value: Any) -> Optional[float]:
+    """Parse DynamoDB item timestamp fields to UTC epoch seconds, or None if unparseable."""
     if value is None:
         return None
     if isinstance(value, (int, float)):

--- a/backend/services/dynamodb_service.py
+++ b/backend/services/dynamodb_service.py
@@ -5,12 +5,34 @@ DynamoDB Service for data persistence and management
 import os
 import logging
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Any
 import boto3
 from botocore.exceptions import ClientError
 
 logger = logging.getLogger(__name__)
+
+# Default TTL window for new items (must match data retention policy)
+_DEFAULT_RETENTION_DAYS = 90
+
+
+def _compute_expires_at_epoch(days: int = _DEFAULT_RETENTION_DAYS) -> int:
+    """Unix epoch seconds for DynamoDB TTL (expires_at)."""
+    return int((datetime.utcnow() + timedelta(days=days)).timestamp())
+
+
+def _parse_item_time_epoch(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    s = str(value).strip()
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
 
 
 class DynamoDBService:
@@ -49,7 +71,8 @@ class DynamoDBService:
                 'findings_count': scan_data.get('findings_count', 0),
                 'metadata': scan_data.get('metadata', {}),
                 'created_at': datetime.utcnow().isoformat(),
-                'updated_at': datetime.utcnow().isoformat()
+                'updated_at': datetime.utcnow().isoformat(),
+                'expires_at': scan_data.get('expires_at', _compute_expires_at_epoch()),
             }
             
             self.scan_results.put_item(Item=item)
@@ -120,7 +143,8 @@ class DynamoDBService:
                 'region': finding_data.get('region', 'us-east-1'),
                 'metadata': finding_data.get('metadata', {}),
                 'created_at': datetime.utcnow().isoformat(),
-                'updated_at': datetime.utcnow().isoformat()
+                'updated_at': datetime.utcnow().isoformat(),
+                'expires_at': finding_data.get('expires_at', _compute_expires_at_epoch()),
             }
             
             self.iam_findings.put_item(Item=item)
@@ -224,7 +248,8 @@ class DynamoDBService:
                             'region': finding.get('region', 'us-east-1'),
                             'metadata': finding.get('metadata', {}),
                             'created_at': datetime.utcnow().isoformat(),
-                            'updated_at': datetime.utcnow().isoformat()
+                            'updated_at': datetime.utcnow().isoformat(),
+                            'expires_at': finding.get('expires_at', _compute_expires_at_epoch()),
                         }
                         batch.put_item(Item=item)
                         success_count += 1
@@ -239,37 +264,62 @@ class DynamoDBService:
             return {'success': 0, 'failed': len(findings)}
 
     def delete_old_records(self, table_name: str, days: int = 90) -> int:
-        """Delete records older than specified days"""
+        """Delete records older than ``days`` using a paginated table scan.
+
+        Uses the correct primary key for scan results vs IAM findings tables.
+        """
+        cutoff_dt = datetime.utcnow().replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ) - timedelta(days=days)
+        cutoff_epoch = cutoff_dt.timestamp()
+
+        table = self.dynamodb.Table(table_name)
+        is_scan = table_name == self.scan_results_table
+        is_findings = table_name == self.iam_findings_table
+        if not is_scan and not is_findings:
+            logger.warning("delete_old_records: unsupported table name %s", table_name)
+            return 0
+
+        deleted_count = 0
+        scan_kwargs: Dict[str, Any] = {}
+
         try:
-            table = self.dynamodb.Table(table_name)
-            cutoff_date = datetime.utcnow().replace(
-                hour=0, minute=0, second=0, microsecond=0
-            ).timestamp() - (days * 86400)
-            
-            response = table.scan()
-            deleted_count = 0
-            
-            with table.batch_writer() as batch:
-                for item in response.get('Items', []):
-                    # Check if timestamp is older than cutoff
-                    if 'timestamp' in item:
-                        item_timestamp = item['timestamp']
-                        # Convert ISO timestamp to epoch for comparison
-                        item_epoch = datetime.fromisoformat(item_timestamp.replace('Z', '+00:00')).timestamp()
-                        
-                        if item_epoch < cutoff_date:
-                            batch.delete_item(
-                                Key={
-                                    'scan_id': item['scan_id'],
-                                    'timestamp': item['timestamp']
-                                }
-                            )
+            while True:
+                response = table.scan(**scan_kwargs)
+                with table.batch_writer() as batch:
+                    for item in response.get("Items", []):
+                        if is_scan:
+                            item_epoch = _parse_item_time_epoch(item.get("timestamp"))
+                            if item_epoch is None or item_epoch >= cutoff_epoch:
+                                continue
+                            sid = item.get("scan_id")
+                            ts = item.get("timestamp")
+                            if sid is None or ts is None:
+                                continue
+                            batch.delete_item(Key={"scan_id": sid, "timestamp": ts})
                             deleted_count += 1
-            
-            logger.info(f"Deleted {deleted_count} old records from {table_name}")
+                        else:
+                            item_epoch = _parse_item_time_epoch(
+                                item.get("detected_at") or item.get("created_at")
+                            )
+                            if item_epoch is None or item_epoch >= cutoff_epoch:
+                                continue
+                            fid = item.get("finding_id")
+                            det = item.get("detected_at")
+                            if fid is None or det is None:
+                                continue
+                            batch.delete_item(Key={"finding_id": fid, "detected_at": det})
+                            deleted_count += 1
+
+                lek = response.get("LastEvaluatedKey")
+                if not lek:
+                    break
+                scan_kwargs["ExclusiveStartKey"] = lek
+
+            logger.info("Deleted %s old records from %s", deleted_count, table_name)
             return deleted_count
-        
+
         except ClientError as e:
-            logger.error(f"DynamoDB error deleting old records: {str(e)}")
+            logger.error("DynamoDB error deleting old records from %s: %s", table_name, str(e))
             return 0
 

--- a/backend/services/dynamodb_service.py
+++ b/backend/services/dynamodb_service.py
@@ -276,6 +276,8 @@ class DynamoDBService:
 
         Uses the correct primary key for scan results vs IAM findings tables.
         """
+        if days <= 0:
+            raise ValueError("days must be positive")
         cutoff_dt = datetime.now(timezone.utc).replace(
             hour=0, minute=0, second=0, microsecond=0
         ) - timedelta(days=days)
@@ -287,7 +289,6 @@ class DynamoDBService:
         if not is_scan and not is_findings:
             logger.warning("delete_old_records: unsupported table name %s", table_name)
             return 0
-
         deleted_count = 0
         scan_kwargs: Dict[str, Any] = {}
 

--- a/backend/services/dynamodb_service.py
+++ b/backend/services/dynamodb_service.py
@@ -5,7 +5,7 @@ DynamoDB Service for data persistence and management
 import os
 import logging
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Any
 import boto3
 from botocore.exceptions import ClientError
@@ -18,7 +18,9 @@ _DEFAULT_RETENTION_DAYS = 90
 
 def _compute_expires_at_epoch(days: int = _DEFAULT_RETENTION_DAYS) -> int:
     """Unix epoch seconds for DynamoDB TTL (expires_at)."""
-    return int((datetime.utcnow() + timedelta(days=days)).timestamp())
+    if days <= 0:
+        raise ValueError("days must be positive")
+    return int((datetime.now(timezone.utc) + timedelta(days=days)).timestamp())
 
 
 def _parse_item_time_epoch(value: Any) -> Optional[float]:
@@ -31,7 +33,12 @@ def _parse_item_time_epoch(value: Any) -> Optional[float]:
     if not s:
         return None
     try:
-        return datetime.fromisoformat(s.replace("Z", "+00:00")).timestamp()
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
+        return dt.timestamp()
     except ValueError:
         return None
 
@@ -269,7 +276,7 @@ class DynamoDBService:
 
         Uses the correct primary key for scan results vs IAM findings tables.
         """
-        cutoff_dt = datetime.utcnow().replace(
+        cutoff_dt = datetime.now(timezone.utc).replace(
             hour=0, minute=0, second=0, microsecond=0
         ) - timedelta(days=days)
         cutoff_epoch = cutoff_dt.timestamp()
@@ -322,5 +329,5 @@ class DynamoDBService:
 
         except ClientError as e:
             logger.error("DynamoDB error deleting old records from %s: %s", table_name, str(e))
-            return 0
+            raise
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,9 +13,12 @@ services:
     environment:
       # Dev-only mode switch for frontend data sources:
       # - mock: UI uses local fixtures (no backend required)
-      # - live: UI calls backend API (default http://localhost:3001)
+      # - live: /scan → API Gateway via Vite proxy; IR/LLM → Flask via /api/v1 proxy (see vite.config)
       - VITE_DATA_MODE=${VITE_DATA_MODE:-live}
       - VITE_API_URL=${VITE_API_URL:-http://localhost:3001}
+      - VITE_IR_API_BASE=${VITE_IR_API_BASE:-http://localhost:3001/api/v1}
+      - VITE_FLASK_PROXY_TARGET=${VITE_FLASK_PROXY_TARGET:-http://app:5000}
+      - VITE_LLM_MAX_CONCURRENT=${VITE_LLM_MAX_CONCURRENT:-2}
       # Keep compatibility with older env naming if someone still exports it.
       - VITE_API_GATEWAY_URL=${VITE_API_GATEWAY_URL:-}
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,8 +38,13 @@ services:
       - DATABASE_URL=postgresql://postgres:password@db:5432/cybersecurity_db
       - REDIS_URL=redis://redis:6379/0
       - AWS_REGION=${AWS_REGION:-us-east-1}
+      # Bedrock + Polly: boto/ir.py read AWS_DEFAULT_REGION; align with AWS_REGION if unset
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-${AWS_REGION:-us-east-1}}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      # Required for /api/v1/llm/* and /api/v1/voice/intent in Docker — set in host .env (never commit)
+      - BEDROCK_API_KEY=${BEDROCK_API_KEY:-}
+      - BEDROCK_MODEL_ID=${BEDROCK_MODEL_ID:-anthropic.claude-haiku-4-5}
       - SMTP_HOST=${SMTP_HOST:-mailhog}
       - SMTP_PORT=${SMTP_PORT:-1025}
       - SMTP_USERNAME=${SMTP_USERNAME:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,9 @@ services:
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_ALERTING_MAX_ANNOTATIONS_TO_KEEP=1000
+      - GF_ANNOTATIONS_CLEANUPJOB_BATCHSIZE=100
+      - GF_SNAPSHOTS_EXTERNAL_ENABLED=false
     ports:
       - "3000:3000"
     volumes:
@@ -129,7 +132,7 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--web.console.libraries=/etc/prometheus/console_libraries'
       - '--web.console.templates=/etc/prometheus/consoles'
-      - '--storage.tsdb.retention.time=200h'
+      - '--storage.tsdb.retention.time=15d'
       - '--web.enable-lifecycle'
     networks:
       - cybersecurity-network

--- a/docs/AI-Team_Documentation/Voice-Incident-Response-Agent.md
+++ b/docs/AI-Team_Documentation/Voice-Incident-Response-Agent.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-A voice-driven incident response agent that allows security engineers to interact with the IAM Dashboard hands-free during active incidents. The agent uses the browser's built-in **Web Speech API** to listen for the wake word **"Hey Argus"**, then pulls live scan findings from the backend, passes them to **Claude via Amazon Bedrock** for summarization and remediation guidance, and speaks back a structured response via **Amazon Polly**.
+A voice-driven incident response agent that allows security engineers to interact with the IAM Dashboard hands-free during active incidents. The shipped UI (`VoiceIRAgent.tsx`) uses the browser **Web Speech API** for speech-to-text: **push-to-talk** by default (mic button or quick commands), and an optional **“Hey Argus”** mode that uses `continuous: true` and only runs the command pipeline after the wake phrase appears in the transcript. Live findings come from the dashboard context; **Claude via Amazon Bedrock** and **Amazon Polly** are planned upgrades in later phases.
 
-This extends the existing AI remediation engine (AI-3) with a real-time voice interface. No external wake word service needed — everything runs in the browser natively.
+This extends the existing AI remediation engine (AI-3) with a real-time voice interface. No external wake word SDK is required for the browser path — optional wake phrase filtering is done on recognition text.
 
 ---
 
@@ -18,28 +18,27 @@ Argus responds verbally with a Claude-generated incident summary and recommended
 
 ---
 
-## Wake Word — "Hey Argus"
+## Wake phrase — "Hey Argus" (optional)
 
-The browser continuously listens using the **Web Speech API** (built into Chrome/Edge, free, no AWS cost). It only activates the full pipeline when it detects the wake word **"Hey Argus"**.
+**Default:** `continuous: false` — one utterance per mic press (push-to-talk). Quick-command buttons bypass the mic and send text intents directly.
+
+**Optional:** With **HEY ARGUS ON** in the live panel, recognition uses `continuous: true` while the panel is open and in voice mode. Final transcript segments are buffered until the text matches **“Hey Argus”** (case-insensitive); the remainder after the last wake match is passed to the same intent router as typed or push-to-talk input. Listening pauses during processing and TTS to reduce picking up playback. This is **not** a dedicated wake-word engine (no on-device keyword model); it is phrase detection on Web Speech API results.
 
 ```
-Browser always listening (Web Speech API — free, runs locally)
+Panel open + HEY ARGUS ON → Web Speech API continuous (browser only)
         │
         ▼
-Detects "hey argus" wake word
+Final STT contains "hey argus" + command
         │
         ▼
-Full Argus pipeline activates
-        │
-        ▼
-User speaks command → captured and sent to backend
+Command text → intent match → buildResponse → browser TTS (today) / Polly (later)
 ```
 
 **Why Web Speech API:**
-- Built into Chrome and Edge — no install, no cost
-- Runs entirely in the browser, no audio sent to AWS until wake word is detected
-- Sufficient accuracy for a controlled dashboard environment
-- Can be upgraded to Porcupine (Picovoice) later if false triggers become an issue
+- Built into Chrome and Edge — no install, no cost for STT in the browser path
+- Runs in the browser; no AWS Transcribe usage until/unless you swap in Phase 4
+- Sufficient for a controlled dashboard environment; false triggers possible on similar-sounding phrases
+- Can be upgraded to Porcupine (Picovoice) or server-side verification later if needed
 
 ---
 
@@ -49,9 +48,9 @@ User speaks command → captured and sent to backend
 ┌─────────────────────────────────────────────────────────────────┐
 │                        FRONTEND (React)                         │
 │                                                                 │
-│   Web Speech API — always listening for "Hey Argus"            │
+│   Web Speech API — push-to-talk; optional continuous + "Hey Argus" filter │
 │        │                                                        │
-│        ▼  (wake word detected)                                  │
+│        ▼  (wake phrase in STT text, if HEY ARGUS mode on)      │
 │   Web Speech API captures full voice command                    │
 │        │                                                        │
 │        ▼                                                        │
@@ -105,7 +104,7 @@ User speaks command → captured and sent to backend
 
 | Service | Role |
 |---|---|
-| Web Speech API (browser) | Wake word detection + voice capture — free, no AWS |
+| Web Speech API (browser) | STT + optional wake phrase on transcript; push-to-talk — free, no AWS |
 | Amazon Transcribe | Confirms transcript server-side for accuracy |
 | Amazon Polly | Text-to-speech — Argus speaks back |
 | Amazon Bedrock (Claude) | LLM for incident summarization and remediation |
@@ -115,9 +114,9 @@ User speaks command → captured and sent to backend
 
 ## Full Cost Breakdown
 
-### Web Speech API (Wake Word)
+### Web Speech API (browser STT)
 
-**Free.** Runs entirely in the browser. No AWS usage, no API calls until wake word is detected.
+**Free** for the browser STT path. No AWS usage until you add Transcribe or other backend voice endpoints.
 
 ---
 
@@ -128,7 +127,7 @@ User speaks command → captured and sent to backend
 | Standard streaming/batch | $0.024 / minute |
 | Free tier (first 12 months) | 60 minutes / month free |
 
-Each voice command after wake word is ~5-10 seconds of audio.
+Each voice command is typically a few seconds of audio (push-to-talk or phrase after “Hey Argus”).
 
 - 100 queries/month ≈ **$0.04**
 - 1000 queries/month ≈ **$0.40**
@@ -176,7 +175,7 @@ Each voice query sends ~1500 tokens total (findings context + prompt + response)
 
 For a dev/demo environment this is essentially free. Free tiers on Transcribe and Polly cover the first 12 months of light usage entirely.
 
-> Note: Amazon Lex is not needed. Web Speech API handles wake word + capture. Simple Python intent matching handles routing. Lex would only be needed for complex multi-turn conversations.
+> Note: Amazon Lex is not needed for the current MVP. Web Speech API handles capture in-browser; optional “Hey Argus” is transcript filtering, not a Lex-style intent model. Lex would only be needed for complex multi-turn conversations.
 
 ---
 
@@ -243,27 +242,21 @@ CMD ["python", "voice_agent.py"]
 
 | Component | Description |
 |---|---|
-| `ArgusVoicePanel.tsx` | Main UI — wake word status indicator, transcript display, audio playback |
-| `useArgus.ts` | Hook — Web Speech API wake word listener, audio capture, pipeline trigger |
+| `VoiceIRAgent.tsx` | Main UI — ARGUS pill, live panel, optional **HEY ARGUS ON** toggle, push-to-talk mic, quick commands, audit log |
 
-### Wake Word Implementation (useArgus.ts)
+### Wake phrase filtering (`VoiceIRAgent.tsx`)
 
 ```ts
-// Simplified wake word detection using Web Speech API
-const recognition = new webkitSpeechRecognition();
-recognition.continuous = true;
-recognition.interimResults = true;
-
-recognition.onresult = (event) => {
-  const transcript = event.results[event.results.length - 1][0].transcript.toLowerCase();
-  if (transcript.includes("hey argus")) {
-    // Wake word detected — capture next command
-    activateArgus();
-  }
-};
+// Buffered final segments; command = text after last "hey argus" match
+const cmd = extractCommandAfterLastWake(passiveBuffer);
+if (cmd && !processing.current) {
+  passiveBuffer = "";
+  recognition.stop();
+  processCommand(cmd, confidence);
+}
 ```
 
-The UI shows a subtle indicator when Argus is listening vs active.
+Push-to-talk and quick commands call `processCommand` directly without requiring the wake phrase. The status line distinguishes passive wake listening vs push-to-talk.
 
 ---
 
@@ -291,11 +284,10 @@ The voice agent reuses the existing **AI-3 guardrails pipeline** (see `Guardrail
 
 ## MVP Scope
 
-- [ ] Wake word detection — "Hey Argus" via Web Speech API
+- [x] Optional wake phrase path — "Hey Argus" via Web Speech API (`continuous` + transcript filter in `VoiceIRAgent.tsx`)
 - [ ] `/api/voice/transcribe` endpoint using Amazon Transcribe
 - [ ] `/api/voice/respond` endpoint — intent routing + Claude (Bedrock) + Polly synthesis
-- [ ] `ArgusVoicePanel.tsx` — listening indicator + transcript + audio playback
-- [ ] `useArgus.ts` hook — Web Speech API wake word + capture
+- [x] `VoiceIRAgent.tsx` — listening indicators, transcript, optional Hey Argus mode, browser TTS
 - [ ] Docker service wired up with env vars
 - [ ] 4 core intents: summarize critical, filter by severity, scan stats, recommend fix
 
@@ -321,11 +313,93 @@ The voice agent reuses the existing **AI-3 guardrails pipeline** (see `Guardrail
 
 ---
 
+## Implementation Timeline
+
+### ✅ Phase 1 — UI/UX Placement (COMPLETE)
+- [x] `src/components/ir/VoiceIRAgent.tsx` built and placed
+- [x] "ARGUS" header pill with threat indicator and live status
+- [x] Waveform animation — active pulse when listening/speaking
+- [x] Live transcript panel with user/agent message bubbles
+- [x] Audit log tab — STT, TTS, intent entries with session dividers, export to `.log`
+- [x] Quick command buttons — SITREP, CRITICAL, THREAT, SLA, HIGH RISK, SCAN
+- [x] Text input fallback for non-mic environments
+- [x] Keyboard shortcut — backtick `` ` `` to toggle panel
+- [x] Web Speech API — push-to-talk + optional continuous listening with "Hey Argus" transcript filter (`webkitSpeechRecognition`)
+- [x] Browser TTS via `SpeechSynthesisUtterance` (Polly upgrade path ready)
+- [x] Intent router — 11 intents: briefing, critical, threat, sla, latest, compliance, scan, high, isolate, navigate, help
+- [x] Live findings data wired via `useActiveScanResults` hook
+- [x] SLA breach detection logic
+- [x] Confidence score display on STT entries
+
+**Status:** Frontend fully functional with local browser TTS and Web Speech API
+
+---
+
+### Phase 2 — AWS Setup (Next)
+- [ ] AWS Console → Bedrock → Model Access → enable Claude 3 Haiku (free, ~2 min)
+- [ ] Add IAM permissions to your role:
+  - `bedrock:InvokeModel`
+  - `transcribe:StartStreamTranscription`
+  - `polly:SynthesizeSpeech`
+- [ ] Check free tier status at `console.aws.amazon.com/billing/home#/freetier`
+- [ ] Add `BEDROCK_MODEL_ID` to `.env` and `env.example`
+- [ ] Verify: `aws bedrock list-foundation-models --region us-east-1`
+
+**Deliverable:** AWS permissions confirmed, Bedrock model accessible
+
+---
+
+### Phase 3 — Backend Endpoints (Next)
+- [ ] Create `backend/voice_agent.py`
+- [ ] `/api/voice/transcribe` — accepts audio blob → Amazon Transcribe → returns text
+- [ ] `/api/voice/respond` — intent + findings context → Claude (Bedrock) → guardrails → returns structured response
+- [ ] `/api/voice/synthesize` — text → Amazon Polly Neural → returns MP3
+- [ ] Add `voice-agent` service to `docker-compose.yml`
+- [ ] Add `Dockerfile.voice`
+- [ ] Test each endpoint with curl/Postman
+
+**Deliverable:** All 3 endpoints working in Docker
+
+---
+
+### Phase 4 — Upgrade Argus to AWS APIs (Next)
+- [ ] Swap browser `SpeechSynthesisUtterance` → Polly Neural voice in `VoiceIRAgent.tsx`
+- [ ] Swap `webkitSpeechRecognition` → Amazon Transcribe for higher accuracy
+- [ ] Wire Claude (Bedrock) responses into `buildResponse()` for dynamic LLM answers
+- [ ] End-to-end test: "Hey Argus, brief me" → Transcribe → Claude → Polly audio
+
+**Deliverable:** Full AWS-powered pipeline replacing browser APIs
+
+---
+
+### Phase 5 — Testing & Polish (Final)
+- [ ] Test all 11 intents with AWS APIs
+- [ ] Test edge cases — no findings, bad audio, API timeouts
+- [ ] Verify AI-3 guardrails fire on Claude responses
+- [ ] Swap `BEDROCK_MODEL_ID` to Claude 3.5 Sonnet for production quality
+- [ ] Cross-browser test (Chrome required for Web Speech API fallback)
+
+**Deliverable:** Argus production-ready
+
+---
+
+### Summary Timeline
+
+| Phase | Status | Focus | Owner |
+|---|---|---|---|
+| Phase 1 — UI/UX | ✅ Complete | VoiceIRAgent.tsx, Web Speech API, browser TTS | Frontend |
+| Phase 2 — AWS Setup | 🔲 Next | Bedrock access, IAM permissions | DevOps/Security |
+| Phase 3 — Backend | 🔲 Next | voice_agent.py, 3 endpoints, Docker | Backend |
+| Phase 4 — AWS Upgrade | 🔲 Next | Swap browser APIs → Transcribe + Polly + Claude | Frontend + Backend |
+| Phase 5 — Testing | 🔲 Next | Guardrails, edge cases, production model | AI team + QA |
+
+---
+
 ## Team Ownership
 
 | Area | Owner |
 |---|---|
 | Voice backend endpoints | Backend team |
 | Claude (Bedrock) integration + guardrails | AI team |
-| Frontend wake word UI + useArgus hook | Frontend team |
+| Frontend voice UI + wake toggle (`VoiceIRAgent.tsx`) | Frontend team |
 | AWS Transcribe/Polly/Bedrock IAM permissions | DevOps/Security team |

--- a/docs/AI-Team_Documentation/Voice-Incident-Response-Agent.md
+++ b/docs/AI-Team_Documentation/Voice-Incident-Response-Agent.md
@@ -1,0 +1,277 @@
+# Voice Incident Response Agent — Planning Document
+
+## Overview
+
+A voice-driven incident response agent that allows security engineers to interact with the IAM Dashboard hands-free during active incidents. The agent listens for voice commands, pulls live scan findings from the backend, passes them to an LLM (Gemini) for summarization and remediation guidance, and speaks back a structured response.
+
+This extends the existing AI remediation engine (AI-3) with a real-time voice interface.
+
+---
+
+## Use Case
+
+**Scenario:** A critical IAM finding fires at 2am. The on-call engineer opens the dashboard, hits the mic button, and says:
+
+> "Give me a summary of all critical findings"
+
+The agent responds verbally with a Gemini-generated incident summary and recommended next steps — no clicking required.
+
+---
+
+## Architecture Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        FRONTEND (React)                         │
+│                                                                 │
+│   [🎤 Mic Button] ──► MediaRecorder API (audio capture)        │
+│                              │                                  │
+│                              ▼                                  │
+│              Audio stream sent to backend                       │
+└──────────────────────────────┬──────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                     BACKEND (Python/Flask)                      │
+│                                                                 │
+│   /api/voice/transcribe                                         │
+│        │                                                        │
+│        ▼                                                        │
+│   Amazon Transcribe ──► text intent                             │
+│        │                                                        │
+│        ▼                                                        │
+│   Intent Router                                                 │
+│   ├── "critical findings"  ──► pull from ScanResultsContext     │
+│   ├── "summarize incident" ──► pull findings + metadata         │
+│   └── "recommend fix for [resource]" ──► pull specific finding  │
+│        │                                                        │
+│        ▼                                                        │
+│   Build AI Input Schema (existing AI-2 schema)                  │
+│        │                                                        │
+│        ▼                                                        │
+│   Gemini API ──► structured incident summary + remediation      │
+│        │                                                        │
+│        ▼                                                        │
+│   Guardrails check (existing AI-3 pipeline)                     │
+│        │                                                        │
+│        ▼                                                        │
+│   Amazon Polly ──► audio response (MP3)                         │
+│        │                                                        │
+│        ▼                                                        │
+│   Return audio + text transcript to frontend                    │
+└──────────────────────────────┬──────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                        FRONTEND (React)                         │
+│                                                                 │
+│   Play audio response via <audio> element                       │
+│   Display text transcript in incident panel                     │
+│   Show findings table filtered to what was spoken about         │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## AWS Services Required
+
+| Service | Role |
+|---|---|
+| Amazon Transcribe | Speech-to-text (voice input) |
+| Amazon Polly | Text-to-speech (voice output) |
+| Amazon Bedrock (Claude) | LLM for incident summarization |
+| Existing backend | Findings data source — already running |
+
+---
+
+## Full Cost Breakdown
+
+### Amazon Transcribe (Speech-to-Text)
+
+| Tier | Price |
+|---|---|
+| Standard streaming/batch | $0.024 / minute |
+| Free tier (first 12 months) | 60 minutes / month free |
+
+Each voice query is ~5-10 seconds of audio.
+
+- 100 queries/month ≈ **$0.04**
+- 1000 queries/month ≈ **$0.40**
+
+---
+
+### Amazon Polly (Text-to-Speech)
+
+| Voice Type | Price | Free Tier (12 months) |
+|---|---|---|
+| Standard voices | $4.00 / 1M characters | 5M characters/month |
+| Neural voices (more natural) | $16.00 / 1M characters | 1M characters/month |
+
+Each voice response is ~500-800 characters.
+
+- 100 responses/month ≈ **$0.003** (Standard) / **$0.013** (Neural)
+- 1000 responses/month ≈ **$0.03** (Standard) / **$0.13** (Neural)
+
+**Recommendation:** Use Neural voices — the cost difference is negligible and the quality is significantly better for a security tool.
+
+---
+
+### Amazon Bedrock — Claude
+
+| Model | Input | Output | Use |
+|---|---|---|---|
+| Claude 3 Haiku | $0.25 / 1M tokens | $1.25 / 1M tokens | Local dev / testing |
+| Claude 3.5 Sonnet | $3.00 / 1M tokens | $15.00 / 1M tokens | Production |
+
+Each voice query sends ~1500 tokens total (findings context + prompt + response).
+
+- 100 queries/month ≈ **$0.04** (Haiku) / **$0.40** (Sonnet)
+- 1000 queries/month ≈ **$0.40** (Haiku) / **$4.00** (Sonnet)
+
+**Strategy:** Use Haiku for local Docker testing, swap to Sonnet for production via a single env var change.
+
+---
+
+### Total Estimated Monthly Cost
+
+| Volume | Transcribe | Polly (Neural) | Claude Haiku | Claude Sonnet | Total (Haiku) | Total (Sonnet) |
+|---|---|---|---|---|---|---|
+| 100 queries | $0.04 | $0.013 | $0.04 | $0.40 | **~$0.09** | **~$0.45** |
+| 1000 queries | $0.40 | $0.13 | $0.40 | $4.00 | **~$0.93** | **~$4.53** |
+
+For a dev/demo environment this is essentially free. Free tiers on Transcribe and Polly cover the first 12 months of light usage entirely.
+
+> Note: Amazon Lex is optional. For MVP, simple keyword/intent matching in Python is sufficient. Lex adds cost and complexity only needed for multi-turn conversations.
+
+---
+
+## Local Docker Infrastructure
+
+### New service: `voice-agent`
+
+Add to `docker-compose.yml`:
+
+```yaml
+voice-agent:
+  build:
+    context: .
+    dockerfile: Dockerfile.voice
+  ports:
+    - "5001:5001"
+  environment:
+    - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+    - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
+    - BEDROCK_MODEL_ID=${BEDROCK_MODEL_ID}
+  depends_on:
+    - backend
+  volumes:
+    - ./backend:/app
+```
+
+### New env vars needed in `.env`
+
+```
+# Use Haiku for local dev, Sonnet for production
+BEDROCK_MODEL_ID=anthropic.claude-3-haiku-20240307-v1:0
+# BEDROCK_MODEL_ID=anthropic.claude-3-5-sonnet-20241022-v2:0
+
+# AWS keys already exist in .env for existing services
+```
+
+### New file: `Dockerfile.voice`
+
+```dockerfile
+FROM python:3.11-slim
+WORKDIR /app
+COPY backend/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt \
+    boto3 flask flask-cors
+COPY backend/ .
+EXPOSE 5001
+CMD ["python", "voice_agent.py"]
+```
+
+---
+
+## New Backend Endpoints
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/api/voice/transcribe` | POST | Accepts audio blob, returns transcript |
+| `/api/voice/respond` | POST | Accepts transcript + findings context, returns audio + text |
+| `/api/voice/synthesize` | POST | Accepts text, returns Polly audio |
+
+---
+
+## New Frontend Components
+
+| Component | Description |
+|---|---|
+| `VoiceIncidentPanel.tsx` | Main UI — mic button, transcript display, audio playback |
+| `useVoiceAgent.ts` | Hook — handles MediaRecorder, sends audio, plays response |
+
+The mic button lives in the Dashboard header or as a floating action button on the findings table.
+
+---
+
+## Intent Examples
+
+| Voice Input | Intent | Action |
+|---|---|---|
+| "Give me a summary of critical findings" | `SUMMARIZE_CRITICAL` | Pull Critical findings → Gemini summary |
+| "What are the high severity IAM issues" | `FILTER_FINDINGS` | Filter by severity=High, type=IAM |
+| "Recommend a fix for [resource name]" | `REMEDIATE_FINDING` | Find matching finding → AI-3 pipeline |
+| "How many findings from the last scan" | `SCAN_STATS` | Return scan summary stats |
+
+---
+
+## Guardrails
+
+The voice agent reuses the existing **AI-3 guardrails pipeline** (see `Guardrails & Safety Rules.md`):
+
+- All LLM responses go through schema validation
+- `requires_review: true` always — agent never auto-remediates
+- Voice responses are read-only summaries and recommendations
+- No AWS API calls are triggered by voice commands in MVP
+
+---
+
+## MVP Scope
+
+- [ ] `/api/voice/transcribe` endpoint using Amazon Transcribe
+- [ ] `/api/voice/respond` endpoint — intent routing + Gemini call + Polly synthesis
+- [ ] `VoiceIncidentPanel.tsx` — mic button + transcript + audio playback
+- [ ] `useVoiceAgent.ts` hook
+- [ ] Docker service wired up with env vars
+- [ ] 4 core intents: summarize critical, filter by severity, scan stats, recommend fix
+
+## Out of Scope (MVP)
+
+- Multi-turn conversation (Lex)
+- Auto-remediation via voice
+- Voice authentication
+- Mobile push alerts
+
+---
+
+## What You Need to Get Started
+
+1. **AWS credentials** — already in `.env`, need the following permissions added to your IAM role:
+   - `transcribe:StartStreamTranscription`
+   - `polly:SynthesizeSpeech`
+   - `bedrock:InvokeModel`
+2. **Enable Claude on Bedrock** — go to AWS Console → Bedrock → Model Access → request access to Claude 3 Haiku (free, instant approval)
+3. **Frontend mic permission** — browser `getUserMedia` API, works over localhost
+4. **No new API keys needed** — everything runs through your existing AWS credentials
+
+---
+
+## Team Ownership
+
+| Area | Owner |
+|---|---|
+| Voice backend endpoints | Backend team |
+| Gemini integration + guardrails | AI team |
+| Frontend mic UI + hook | Frontend team |
+| AWS Transcribe/Polly IAM permissions | DevOps/Security team |

--- a/docs/AI-Team_Documentation/Voice-Incident-Response-Agent.md
+++ b/docs/AI-Team_Documentation/Voice-Incident-Response-Agent.md
@@ -44,57 +44,45 @@ processCommand → intent match → buildResponse → Polly (preferred) / browse
 
 ## Architecture Flow
 
+> **Shipped path** — STT is entirely in-browser (Web Speech API). Amazon Transcribe is **not** active in the current implementation; it remains a future optional upgrade (see Phase 4).
+
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │                        FRONTEND (React)                         │
 │                                                                 │
-│   Web Speech API — push-to-talk (`continuous: false`)             │
+│   Web Speech API — push-to-talk (`continuous: false`)           │
 │        │                                                        │
 │        ▼                                                        │
-│   Web Speech API captures one utterance per mic press           │
+│   Final transcript produced in-browser (no backend STT call)   │
 │        │                                                        │
 │        ▼                                                        │
-│   Audio blob sent to backend via /api/voice/transcribe          │
+│   processCommand → useVoiceIntent                               │
+│   ├── Tier 1: regex matchIntent() — synchronous, zero network   │
+│   └── Tier 2: POST /api/v1/voice/intent (Bedrock fallback)      │
+│        │           only when regex returns "unknown"            │
+│        ▼                                                        │
+│   buildResponse() → response card rendered in panel            │
+│        │                                                        │
+│        ▼                                                        │
+│   pollySpeak() → POST /api/v1/tts/synthesize                    │
+│        │           falls back to SpeechSynthesisUtterance       │
+│        ▼                                                        │
+│   For briefing/critical/threat: fetchLLMBriefing()             │
+│        └── POST /api/v1/llm/triage → LLMTriageCard in panel    │
 └──────────────────────────────┬──────────────────────────────────┘
                                │
                                ▼
 ┌─────────────────────────────────────────────────────────────────┐
 │                     BACKEND (Python/Flask)                      │
 │                                                                 │
-│   /api/voice/transcribe                                         │
-│        │                                                        │
-│        ▼                                                        │
-│   Amazon Transcribe ──► confirmed text transcript               │
-│        │                                                        │
-│        ▼                                                        │
-│   Intent Router                                                 │
-│   ├── "critical findings"  ──► pull from ScanResultsContext     │
-│   ├── "summarize incident" ──► pull findings + metadata         │
-│   └── "recommend fix for [resource]" ──► pull specific finding  │
-│        │                                                        │
-│        ▼                                                        │
-│   Build AI Input Schema (existing AI-2 schema)                  │
-│        │                                                        │
-│        ▼                                                        │
-│   Amazon Bedrock (Claude) ──► structured incident summary       │
-│        │                                                        │
-│        ▼                                                        │
-│   Guardrails check (existing AI-3 pipeline)                     │
-│        │                                                        │
-│        ▼                                                        │
-│   Amazon Polly ──► audio response (MP3)                         │
-│        │                                                        │
-│        ▼                                                        │
-│   Return audio + text transcript to frontend                    │
-└──────────────────────────────┬──────────────────────────────────┘
-                               │
-                               ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                        FRONTEND (React)                         │
+│   POST /api/v1/voice/intent                                     │
+│        └── Amazon Bedrock (Claude) — intent classification      │
 │                                                                 │
-│   Play audio response via <audio> element                       │
-│   Display text transcript in incident panel                     │
-│   Show findings table filtered to what was spoken about         │
+│   POST /api/v1/tts/synthesize                                   │
+│        └── Amazon Polly Neural ──► audio/mpeg                   │
+│                                                                 │
+│   POST /api/v1/llm/triage                                       │
+│        └── Amazon Bedrock (Claude) ──► triage summary           │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
@@ -102,13 +90,13 @@ processCommand → intent match → buildResponse → Polly (preferred) / browse
 
 ## AWS Services Required
 
-| Service | Role |
-|---|---|
-| Web Speech API (browser) | STT for push-to-talk utterances — free, no AWS |
-| Amazon Transcribe | Confirms transcript server-side for accuracy |
-| Amazon Polly | Text-to-speech — Argus speaks back |
-| Amazon Bedrock (Claude) | LLM for incident summarization and remediation |
-| Existing backend | Findings data source — already running |
+| Service | Role | Status |
+|---|---|---|
+| Web Speech API (browser) | STT for push-to-talk utterances — free, no AWS | **Active** |
+| Amazon Polly Neural | Text-to-speech — `POST /api/v1/tts/synthesize`; falls back to browser TTS | **Active** |
+| Amazon Bedrock (Claude) | Intent classification fallback (`/api/v1/voice/intent`) and LLM triage (`/api/v1/llm/triage`) | **Active** |
+| Existing backend | Findings data source — already running | **Active** |
+| Amazon Transcribe | Optional server-side STT upgrade (not shipped) | Future / Phase 4 optional |
 
 ---
 
@@ -228,13 +216,15 @@ CMD ["python", "voice_agent.py"]
 
 ---
 
-## New Backend Endpoints
+## Backend Endpoints (shipped)
 
 | Endpoint | Method | Description |
 |---|---|---|
-| `/api/voice/transcribe` | POST | Accepts audio blob, returns confirmed transcript |
-| `/api/voice/respond` | POST | Accepts transcript + findings context, returns audio + text |
-| `/api/voice/synthesize` | POST | Accepts text, returns Polly audio |
+| `/api/v1/tts/synthesize` | POST | Accepts `{text, voice, engine}`, returns `audio/mpeg` (Polly Neural) or `{error, fallback:true}` 503 |
+| `/api/v1/voice/intent` | POST | Bedrock intent classification fallback — called only when client regex returns `"unknown"` |
+| `/api/v1/llm/triage` | POST | LLM triage summary for a finding (used by `fetchLLMBriefing` on briefing/critical/threat intents) |
+
+> **Not shipped:** `/api/voice/transcribe` (Transcribe-based STT), `/api/voice/respond`, and `/api/voice/synthesize` are planning artifacts from an earlier design. The active TTS route is `/api/v1/tts/synthesize`.
 
 ---
 

--- a/docs/AI-Team_Documentation/Voice-Incident-Response-Agent.md
+++ b/docs/AI-Team_Documentation/Voice-Incident-Response-Agent.md
@@ -335,49 +335,54 @@ The voice agent reuses the existing **AI-3 guardrails pipeline** (see `Guardrail
 
 ---
 
-### Phase 2 — AWS Setup (Next)
-- [ ] AWS Console → Bedrock → Model Access → enable Claude 3 Haiku (free, ~2 min)
-- [ ] Add IAM permissions to your role:
-  - `bedrock:InvokeModel`
-  - `transcribe:StartStreamTranscription`
-  - `polly:SynthesizeSpeech`
-- [ ] Check free tier status at `console.aws.amazon.com/billing/home#/freetier`
-- [ ] Add `BEDROCK_MODEL_ID` to `.env` and `env.example`
-- [ ] Verify: `aws bedrock list-foundation-models --region us-east-1`
+### ✅ Phase 2 — AWS Setup (COMPLETE)
+- [x] Bedrock API key generated from AWS Console → Bedrock → API keys
+- [x] `BEDROCK_API_KEY` added to `.env`
+- [x] `BEDROCK_MODEL_ID=anthropic.claude-haiku-4-5` added to `.env` (Claude 4.5 Haiku — near-frontier performance at Haiku pricing, available on Bedrock since Oct 2025)
+- [x] `AWS_DEFAULT_REGION=us-east-1` confirmed in `.env`
+- [x] `AmazonBedrockFullAccess`, `AmazonTranscribeFullAccess`, `AmazonPollyFullAccess` attached to IAM user
+- [x] Credential strategy decided: long-term Bedrock API key in `.env` for local Docker dev, IAM role for production Lambda
 
-**Deliverable:** AWS permissions confirmed, Bedrock model accessible
+**Status:** AWS credentials configured, Bedrock model accessible
 
 ---
 
-### Phase 3 — Backend Endpoints (Next)
-- [ ] Create `backend/voice_agent.py`
-- [ ] `/api/voice/transcribe` — accepts audio blob → Amazon Transcribe → returns text
-- [ ] `/api/voice/respond` — intent + findings context → Claude (Bedrock) → guardrails → returns structured response
-- [ ] `/api/voice/synthesize` — text → Amazon Polly Neural → returns MP3
-- [ ] Add `voice-agent` service to `docker-compose.yml`
-- [ ] Add `Dockerfile.voice`
-- [ ] Test each endpoint with curl/Postman
+### ✅ Phase 3 — Backend Wired to Claude (COMPLETE)
+- [x] `BEDROCK_API_KEY` and `BEDROCK_MODEL_ID` passed into `app` container via `docker-compose.yml`
+- [x] `_get_bedrock_client()` added to `backend/api/ir.py` — uses Bedrock API key auth via `boto3`
+- [x] `_invoke_claude(prompt)` helper added — returns `None` on failure (triggers mock fallback)
+- [x] `/api/v1/llm/triage` — now calls Claude with finding context, returns real triage summary
+- [x] `/api/v1/llm/root-cause` — now calls Claude for root cause narrative
+- [x] `/api/v1/llm/runbook` — now calls Claude for markdown IR runbook with IDENTIFY/CONTAIN/ERADICATE/RECOVER phases
+- [x] Live/mock toggle — `model: "anthropic.claude-haiku-4-5"` in response = live, `model: "mock"` = fallback
+- [x] `VITE_IR_API_BASE=http://localhost:3001/api/v1` added to `.env`
+- [x] `VITE_FLASK_PROXY_TARGET=http://app:5000` added to `.env` — fixes Vite proxy forwarding to Flask in Docker
+- [x] `VITE_LLM_MAX_CONCURRENT=2` added to `.env` — prevents Bedrock flooding across concurrent finding rows
+- [x] Verified Flask health at `localhost:5001/api/v1/health` ✅
+- [x] Verified `/api/v1/llm/triage` returns mock data when no Bedrock key present ✅
 
-**Deliverable:** All 3 endpoints working in Docker
+**Status:** All 3 LLM endpoints wired to Claude, live/mock fallback working
 
 ---
 
-### Phase 4 — Upgrade Argus to AWS APIs (Next)
-- [ ] Swap browser `SpeechSynthesisUtterance` → Polly Neural voice in `VoiceIRAgent.tsx`
-- [ ] Swap `webkitSpeechRecognition` → Amazon Transcribe for higher accuracy
-- [ ] Wire Claude (Bedrock) responses into `buildResponse()` for dynamic LLM answers
-- [ ] End-to-end test: "Hey Argus, brief me" → Transcribe → Claude → Polly audio
+### Phase 4 — Upgrade Argus Voice to AWS APIs (Next)
+- [ ] Wire `VoiceIRAgent.tsx` intents (`briefing`, `critical`, `high`, `latest`) to call `/api/v1/llm/triage` and speak back Claude's response
+- [ ] Swap browser `SpeechSynthesisUtterance` → Amazon Polly Neural voice
+- [ ] Optionally swap `webkitSpeechRecognition` → Amazon Transcribe for higher accuracy
+- [ ] End-to-end test: "Hey Argus, brief me" → Claude triage → Polly audio
 
-**Deliverable:** Full AWS-powered pipeline replacing browser APIs
+**Deliverable:** Argus voice responses powered by Claude instead of hardcoded `buildResponse()`
 
 ---
 
 ### Phase 5 — Testing & Polish (Final)
-- [ ] Test all 11 intents with AWS APIs
-- [ ] Test edge cases — no findings, bad audio, API timeouts
+- [ ] Test "Generate AI overview" in `FindingDetailPanel` with real findings
+- [ ] Test all 11 Argus voice intents end-to-end
+- [ ] Test edge cases — no findings, bad audio, Bedrock timeout
 - [ ] Verify AI-3 guardrails fire on Claude responses
-- [ ] Swap `BEDROCK_MODEL_ID` to Claude 3.5 Sonnet for production quality
-- [ ] Cross-browser test (Chrome required for Web Speech API fallback)
+- [ ] Swap `BEDROCK_MODEL_ID` to Claude 3.5 Sonnet for production quality comparison
+- [ ] Cross-browser test (Chrome required for Web Speech API)
+- [ ] Rebuild frontend with `docker-compose build --no-cache frontend` after all env changes
 
 **Deliverable:** Argus production-ready
 
@@ -388,10 +393,10 @@ The voice agent reuses the existing **AI-3 guardrails pipeline** (see `Guardrail
 | Phase | Status | Focus | Owner |
 |---|---|---|---|
 | Phase 1 — UI/UX | ✅ Complete | VoiceIRAgent.tsx, Web Speech API, browser TTS | Frontend |
-| Phase 2 — AWS Setup | 🔲 Next | Bedrock access, IAM permissions | DevOps/Security |
-| Phase 3 — Backend | 🔲 Next | voice_agent.py, 3 endpoints, Docker | Backend |
-| Phase 4 — AWS Upgrade | 🔲 Next | Swap browser APIs → Transcribe + Polly + Claude | Frontend + Backend |
-| Phase 5 — Testing | 🔲 Next | Guardrails, edge cases, production model | AI team + QA |
+| Phase 2 — AWS Setup | ✅ Complete | Bedrock API key, IAM permissions, env vars | DevOps/Security |
+| Phase 3 — Backend | ✅ Complete | Claude wired to /llm/triage, /llm/root-cause, /llm/runbook | Backend |
+| Phase 4 — AWS Voice Upgrade | 🔲 Next | Wire Argus voice → Claude responses + Polly TTS | Frontend + Backend |
+| Phase 5 — Testing | 🔲 Next | End-to-end, guardrails, edge cases, production model | AI team + QA |
 
 ---
 

--- a/docs/AI-Team_Documentation/Voice-Incident-Response-Agent.md
+++ b/docs/AI-Team_Documentation/Voice-Incident-Response-Agent.md
@@ -2,19 +2,44 @@
 
 ## Overview
 
-A voice-driven incident response agent that allows security engineers to interact with the IAM Dashboard hands-free during active incidents. The agent listens for voice commands, pulls live scan findings from the backend, passes them to an LLM (Gemini) for summarization and remediation guidance, and speaks back a structured response.
+A voice-driven incident response agent that allows security engineers to interact with the IAM Dashboard hands-free during active incidents. The agent uses the browser's built-in **Web Speech API** to listen for the wake word **"Hey Argus"**, then pulls live scan findings from the backend, passes them to **Claude via Amazon Bedrock** for summarization and remediation guidance, and speaks back a structured response via **Amazon Polly**.
 
-This extends the existing AI remediation engine (AI-3) with a real-time voice interface.
+This extends the existing AI remediation engine (AI-3) with a real-time voice interface. No external wake word service needed — everything runs in the browser natively.
 
 ---
 
 ## Use Case
 
-**Scenario:** A critical IAM finding fires at 2am. The on-call engineer opens the dashboard, hits the mic button, and says:
+**Scenario:** A critical IAM finding fires at 2am. The on-call engineer opens the dashboard and says:
 
-> "Give me a summary of all critical findings"
+> "Hey Argus, give me a summary of all critical findings"
 
-The agent responds verbally with a Gemini-generated incident summary and recommended next steps — no clicking required.
+Argus responds verbally with a Claude-generated incident summary and recommended next steps — no clicking required.
+
+---
+
+## Wake Word — "Hey Argus"
+
+The browser continuously listens using the **Web Speech API** (built into Chrome/Edge, free, no AWS cost). It only activates the full pipeline when it detects the wake word **"Hey Argus"**.
+
+```
+Browser always listening (Web Speech API — free, runs locally)
+        │
+        ▼
+Detects "hey argus" wake word
+        │
+        ▼
+Full Argus pipeline activates
+        │
+        ▼
+User speaks command → captured and sent to backend
+```
+
+**Why Web Speech API:**
+- Built into Chrome and Edge — no install, no cost
+- Runs entirely in the browser, no audio sent to AWS until wake word is detected
+- Sufficient accuracy for a controlled dashboard environment
+- Can be upgraded to Porcupine (Picovoice) later if false triggers become an issue
 
 ---
 
@@ -24,10 +49,13 @@ The agent responds verbally with a Gemini-generated incident summary and recomme
 ┌─────────────────────────────────────────────────────────────────┐
 │                        FRONTEND (React)                         │
 │                                                                 │
-│   [🎤 Mic Button] ──► MediaRecorder API (audio capture)        │
-│                              │                                  │
-│                              ▼                                  │
-│              Audio stream sent to backend                       │
+│   Web Speech API — always listening for "Hey Argus"            │
+│        │                                                        │
+│        ▼  (wake word detected)                                  │
+│   Web Speech API captures full voice command                    │
+│        │                                                        │
+│        ▼                                                        │
+│   Audio blob sent to backend via /api/voice/transcribe          │
 └──────────────────────────────┬──────────────────────────────────┘
                                │
                                ▼
@@ -37,7 +65,7 @@ The agent responds verbally with a Gemini-generated incident summary and recomme
 │   /api/voice/transcribe                                         │
 │        │                                                        │
 │        ▼                                                        │
-│   Amazon Transcribe ──► text intent                             │
+│   Amazon Transcribe ──► confirmed text transcript               │
 │        │                                                        │
 │        ▼                                                        │
 │   Intent Router                                                 │
@@ -49,7 +77,7 @@ The agent responds verbally with a Gemini-generated incident summary and recomme
 │   Build AI Input Schema (existing AI-2 schema)                  │
 │        │                                                        │
 │        ▼                                                        │
-│   Gemini API ──► structured incident summary + remediation      │
+│   Amazon Bedrock (Claude) ──► structured incident summary       │
 │        │                                                        │
 │        ▼                                                        │
 │   Guardrails check (existing AI-3 pipeline)                     │
@@ -77,14 +105,21 @@ The agent responds verbally with a Gemini-generated incident summary and recomme
 
 | Service | Role |
 |---|---|
-| Amazon Transcribe | Speech-to-text (voice input) |
-| Amazon Polly | Text-to-speech (voice output) |
-| Amazon Bedrock (Claude) | LLM for incident summarization |
+| Web Speech API (browser) | Wake word detection + voice capture — free, no AWS |
+| Amazon Transcribe | Confirms transcript server-side for accuracy |
+| Amazon Polly | Text-to-speech — Argus speaks back |
+| Amazon Bedrock (Claude) | LLM for incident summarization and remediation |
 | Existing backend | Findings data source — already running |
 
 ---
 
 ## Full Cost Breakdown
+
+### Web Speech API (Wake Word)
+
+**Free.** Runs entirely in the browser. No AWS usage, no API calls until wake word is detected.
+
+---
 
 ### Amazon Transcribe (Speech-to-Text)
 
@@ -93,7 +128,7 @@ The agent responds verbally with a Gemini-generated incident summary and recomme
 | Standard streaming/batch | $0.024 / minute |
 | Free tier (first 12 months) | 60 minutes / month free |
 
-Each voice query is ~5-10 seconds of audio.
+Each voice command after wake word is ~5-10 seconds of audio.
 
 - 100 queries/month ≈ **$0.04**
 - 1000 queries/month ≈ **$0.40**
@@ -107,7 +142,7 @@ Each voice query is ~5-10 seconds of audio.
 | Standard voices | $4.00 / 1M characters | 5M characters/month |
 | Neural voices (more natural) | $16.00 / 1M characters | 1M characters/month |
 
-Each voice response is ~500-800 characters.
+Each Argus response is ~500-800 characters.
 
 - 100 responses/month ≈ **$0.003** (Standard) / **$0.013** (Neural)
 - 1000 responses/month ≈ **$0.03** (Standard) / **$0.13** (Neural)
@@ -141,7 +176,7 @@ Each voice query sends ~1500 tokens total (findings context + prompt + response)
 
 For a dev/demo environment this is essentially free. Free tiers on Transcribe and Polly cover the first 12 months of light usage entirely.
 
-> Note: Amazon Lex is optional. For MVP, simple keyword/intent matching in Python is sufficient. Lex adds cost and complexity only needed for multi-turn conversations.
+> Note: Amazon Lex is not needed. Web Speech API handles wake word + capture. Simple Python intent matching handles routing. Lex would only be needed for complex multi-turn conversations.
 
 ---
 
@@ -198,7 +233,7 @@ CMD ["python", "voice_agent.py"]
 
 | Endpoint | Method | Description |
 |---|---|---|
-| `/api/voice/transcribe` | POST | Accepts audio blob, returns transcript |
+| `/api/voice/transcribe` | POST | Accepts audio blob, returns confirmed transcript |
 | `/api/voice/respond` | POST | Accepts transcript + findings context, returns audio + text |
 | `/api/voice/synthesize` | POST | Accepts text, returns Polly audio |
 
@@ -208,10 +243,27 @@ CMD ["python", "voice_agent.py"]
 
 | Component | Description |
 |---|---|
-| `VoiceIncidentPanel.tsx` | Main UI — mic button, transcript display, audio playback |
-| `useVoiceAgent.ts` | Hook — handles MediaRecorder, sends audio, plays response |
+| `ArgusVoicePanel.tsx` | Main UI — wake word status indicator, transcript display, audio playback |
+| `useArgus.ts` | Hook — Web Speech API wake word listener, audio capture, pipeline trigger |
 
-The mic button lives in the Dashboard header or as a floating action button on the findings table.
+### Wake Word Implementation (useArgus.ts)
+
+```ts
+// Simplified wake word detection using Web Speech API
+const recognition = new webkitSpeechRecognition();
+recognition.continuous = true;
+recognition.interimResults = true;
+
+recognition.onresult = (event) => {
+  const transcript = event.results[event.results.length - 1][0].transcript.toLowerCase();
+  if (transcript.includes("hey argus")) {
+    // Wake word detected — capture next command
+    activateArgus();
+  }
+};
+```
+
+The UI shows a subtle indicator when Argus is listening vs active.
 
 ---
 
@@ -219,10 +271,10 @@ The mic button lives in the Dashboard header or as a floating action button on t
 
 | Voice Input | Intent | Action |
 |---|---|---|
-| "Give me a summary of critical findings" | `SUMMARIZE_CRITICAL` | Pull Critical findings → Gemini summary |
-| "What are the high severity IAM issues" | `FILTER_FINDINGS` | Filter by severity=High, type=IAM |
-| "Recommend a fix for [resource name]" | `REMEDIATE_FINDING` | Find matching finding → AI-3 pipeline |
-| "How many findings from the last scan" | `SCAN_STATS` | Return scan summary stats |
+| "Hey Argus, give me a summary of critical findings" | `SUMMARIZE_CRITICAL` | Pull Critical findings → Claude summary |
+| "Hey Argus, what are the high severity IAM issues" | `FILTER_FINDINGS` | Filter by severity=High, type=IAM |
+| "Hey Argus, recommend a fix for [resource name]" | `REMEDIATE_FINDING` | Find matching finding → AI-3 pipeline |
+| "Hey Argus, how many findings from the last scan" | `SCAN_STATS` | Return scan summary stats |
 
 ---
 
@@ -230,8 +282,8 @@ The mic button lives in the Dashboard header or as a floating action button on t
 
 The voice agent reuses the existing **AI-3 guardrails pipeline** (see `Guardrails & Safety Rules.md`):
 
-- All LLM responses go through schema validation
-- `requires_review: true` always — agent never auto-remediates
+- All Claude responses go through schema validation
+- `requires_review: true` always — Argus never auto-remediates
 - Voice responses are read-only summaries and recommendations
 - No AWS API calls are triggered by voice commands in MVP
 
@@ -239,19 +291,21 @@ The voice agent reuses the existing **AI-3 guardrails pipeline** (see `Guardrail
 
 ## MVP Scope
 
+- [ ] Wake word detection — "Hey Argus" via Web Speech API
 - [ ] `/api/voice/transcribe` endpoint using Amazon Transcribe
-- [ ] `/api/voice/respond` endpoint — intent routing + Gemini call + Polly synthesis
-- [ ] `VoiceIncidentPanel.tsx` — mic button + transcript + audio playback
-- [ ] `useVoiceAgent.ts` hook
+- [ ] `/api/voice/respond` endpoint — intent routing + Claude (Bedrock) + Polly synthesis
+- [ ] `ArgusVoicePanel.tsx` — listening indicator + transcript + audio playback
+- [ ] `useArgus.ts` hook — Web Speech API wake word + capture
 - [ ] Docker service wired up with env vars
 - [ ] 4 core intents: summarize critical, filter by severity, scan stats, recommend fix
 
 ## Out of Scope (MVP)
 
-- Multi-turn conversation (Lex)
+- Multi-turn conversation
 - Auto-remediation via voice
-- Voice authentication
+- Voice authentication / speaker recognition
 - Mobile push alerts
+- Custom wake word model (Porcupine) — upgrade path if needed
 
 ---
 
@@ -261,8 +315,8 @@ The voice agent reuses the existing **AI-3 guardrails pipeline** (see `Guardrail
    - `transcribe:StartStreamTranscription`
    - `polly:SynthesizeSpeech`
    - `bedrock:InvokeModel`
-2. **Enable Claude on Bedrock** — go to AWS Console → Bedrock → Model Access → request access to Claude 3 Haiku (free, instant approval)
-3. **Frontend mic permission** — browser `getUserMedia` API, works over localhost
+2. **Enable Claude on Bedrock** — AWS Console → Bedrock → Model Access → request Claude 3 Haiku (free, instant approval)
+3. **Browser** — Chrome or Edge required for Web Speech API (`webkitSpeechRecognition`)
 4. **No new API keys needed** — everything runs through your existing AWS credentials
 
 ---
@@ -272,6 +326,6 @@ The voice agent reuses the existing **AI-3 guardrails pipeline** (see `Guardrail
 | Area | Owner |
 |---|---|
 | Voice backend endpoints | Backend team |
-| Gemini integration + guardrails | AI team |
-| Frontend mic UI + hook | Frontend team |
-| AWS Transcribe/Polly IAM permissions | DevOps/Security team |
+| Claude (Bedrock) integration + guardrails | AI team |
+| Frontend wake word UI + useArgus hook | Frontend team |
+| AWS Transcribe/Polly/Bedrock IAM permissions | DevOps/Security team |

--- a/docs/AI-Team_Documentation/Voice-Incident-Response-Agent.md
+++ b/docs/AI-Team_Documentation/Voice-Incident-Response-Agent.md
@@ -24,7 +24,7 @@ Argus responds verbally (Polly when configured, else browser TTS) and can show a
 
 **Not shipped:** There is **no** “Hey Argus” toggle, **no** `continuous: true` passive listening, and **no** wake-phrase stripping in `VoiceIRAgent.tsx` (those were removed; see file header comment in source).
 
-```
+```text
 Panel open → user presses mic (or types / taps quick command)
         │
         ▼
@@ -46,7 +46,7 @@ processCommand → intent match → buildResponse → Polly (preferred) / browse
 
 > **Shipped path** — STT is entirely in-browser (Web Speech API). Amazon Transcribe is **not** active in the current implementation; it remains a future optional upgrade (see Phase 4).
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │                        FRONTEND (React)                         │
 │                                                                 │

--- a/docs/AI-Team_Documentation/Voice-Incident-Response-Agent.md
+++ b/docs/AI-Team_Documentation/Voice-Incident-Response-Agent.md
@@ -2,36 +2,36 @@
 
 ## Overview
 
-A voice-driven incident response agent that allows security engineers to interact with the IAM Dashboard hands-free during active incidents. The shipped UI (`VoiceIRAgent.tsx`) uses the browser **Web Speech API** for speech-to-text: **push-to-talk** by default (mic button or quick commands), and an optional **“Hey Argus”** mode that uses `continuous: true` and only runs the command pipeline after the wake phrase appears in the transcript. Live findings come from the dashboard context; **Claude via Amazon Bedrock** and **Amazon Polly** are planned upgrades in later phases.
+A voice-driven incident response agent that allows security engineers to interact with the IAM Dashboard hands-free during active incidents. The shipped UI (`VoiceIRAgent.tsx`) uses the browser **Web Speech API** for speech-to-text with **`continuous: false`** — **push-to-talk** via the **mic button** (click to start listening, click again to stop while listening), plus **quick-command** buttons and **typed** input. There is **no** “Hey Argus” wake phrase or passive listening mode in the current code. Live findings come from the dashboard context; **Claude via Amazon Bedrock** is used for LLM triage from the dashboard and (for voice) enrichment on select intents; **Amazon Polly** is wired for Argus TTS when not in mock mode (see Phase 4).
 
-This extends the existing AI remediation engine (AI-3) with a real-time voice interface. No external wake word SDK is required for the browser path — optional wake phrase filtering is done on recognition text.
+This extends the existing AI remediation engine (AI-3) with a real-time voice interface. A future optional wake phrase (transcript-based or a SDK such as Porcupine) is **not** shipped today.
 
 ---
 
 ## Use Case
 
-**Scenario:** A critical IAM finding fires at 2am. The on-call engineer opens the dashboard and says:
+**Scenario:** A critical IAM finding fires at 2am. The on-call engineer opens the Argus panel, presses the **mic** (or uses a quick command), and says:
 
-> "Hey Argus, give me a summary of all critical findings"
+> "Give me a summary of critical findings"
 
-Argus responds verbally with a Claude-generated incident summary and recommended next steps — no clicking required.
+Argus responds verbally (Polly when configured, else browser TTS) and can show an LLM triage card for select intents — minimal clicking.
 
 ---
 
-## Wake phrase — "Hey Argus" (optional)
+## Voice capture (shipped)
 
-**Default:** `continuous: false` — one utterance per mic press (push-to-talk). Quick-command buttons bypass the mic and send text intents directly.
+**Shipped behavior:** `continuous: false` — **one utterance per mic activation** (push-to-talk). **Quick-command** buttons send text intents directly; **text input** uses the same `processCommand` / intent router as STT.
 
-**Optional:** With **HEY ARGUS ON** in the live panel, recognition uses `continuous: true` while the panel is open and in voice mode. Final transcript segments are buffered until the text matches **“Hey Argus”** (case-insensitive); the remainder after the last wake match is passed to the same intent router as typed or push-to-talk input. Listening pauses during processing and TTS to reduce picking up playback. This is **not** a dedicated wake-word engine (no on-device keyword model); it is phrase detection on Web Speech API results.
+**Not shipped:** There is **no** “Hey Argus” toggle, **no** `continuous: true` passive listening, and **no** wake-phrase stripping in `VoiceIRAgent.tsx` (those were removed; see file header comment in source).
 
 ```
-Panel open + HEY ARGUS ON → Web Speech API continuous (browser only)
+Panel open → user presses mic (or types / taps quick command)
         │
         ▼
-Final STT contains "hey argus" + command
+Web Speech API final transcript (or text)
         │
         ▼
-Command text → intent match → buildResponse → browser TTS (today) / Polly (later)
+processCommand → intent match → buildResponse → Polly (preferred) / browser TTS
 ```
 
 **Why Web Speech API:**
@@ -48,10 +48,10 @@ Command text → intent match → buildResponse → browser TTS (today) / Polly 
 ┌─────────────────────────────────────────────────────────────────┐
 │                        FRONTEND (React)                         │
 │                                                                 │
-│   Web Speech API — push-to-talk; optional continuous + "Hey Argus" filter │
+│   Web Speech API — push-to-talk (`continuous: false`)             │
 │        │                                                        │
-│        ▼  (wake phrase in STT text, if HEY ARGUS mode on)      │
-│   Web Speech API captures full voice command                    │
+│        ▼                                                        │
+│   Web Speech API captures one utterance per mic press           │
 │        │                                                        │
 │        ▼                                                        │
 │   Audio blob sent to backend via /api/voice/transcribe          │
@@ -104,7 +104,7 @@ Command text → intent match → buildResponse → browser TTS (today) / Polly 
 
 | Service | Role |
 |---|---|
-| Web Speech API (browser) | STT + optional wake phrase on transcript; push-to-talk — free, no AWS |
+| Web Speech API (browser) | STT for push-to-talk utterances — free, no AWS |
 | Amazon Transcribe | Confirms transcript server-side for accuracy |
 | Amazon Polly | Text-to-speech — Argus speaks back |
 | Amazon Bedrock (Claude) | LLM for incident summarization and remediation |
@@ -127,7 +127,7 @@ Command text → intent match → buildResponse → browser TTS (today) / Polly 
 | Standard streaming/batch | $0.024 / minute |
 | Free tier (first 12 months) | 60 minutes / month free |
 
-Each voice command is typically a few seconds of audio (push-to-talk or phrase after “Hey Argus”).
+Each voice command is typically a few seconds of audio (push-to-talk).
 
 - 100 queries/month ≈ **$0.04**
 - 1000 queries/month ≈ **$0.40**
@@ -175,7 +175,7 @@ Each voice query sends ~1500 tokens total (findings context + prompt + response)
 
 For a dev/demo environment this is essentially free. Free tiers on Transcribe and Polly cover the first 12 months of light usage entirely.
 
-> Note: Amazon Lex is not needed for the current MVP. Web Speech API handles capture in-browser; optional “Hey Argus” is transcript filtering, not a Lex-style intent model. Lex would only be needed for complex multi-turn conversations.
+> Note: Amazon Lex is not needed for the current MVP. Web Speech API handles capture in-browser; intent routing uses **`useVoiceIntent`** — regex fast-path first, optional **Bedrock** fallback for `unknown` (see `src/hooks/useVoiceIntent.ts`). Lex would only be needed for complex multi-turn slot-filling flows.
 
 ---
 
@@ -242,32 +242,24 @@ CMD ["python", "voice_agent.py"]
 
 | Component | Description |
 |---|---|
-| `VoiceIRAgent.tsx` | Main UI — ARGUS pill, live panel, optional **HEY ARGUS ON** toggle, push-to-talk mic, quick commands, audit log |
+| `VoiceIRAgent.tsx` | Main UI — ARGUS pill, live panel, push-to-talk mic, quick commands, text input, audit log |
 
-### Wake phrase filtering (`VoiceIRAgent.tsx`)
+### Command pipeline (`VoiceIRAgent.tsx` + `useVoiceIntent`)
 
-```ts
-// Buffered final segments; command = text after last "hey argus" match
-const cmd = extractCommandAfterLastWake(passiveBuffer);
-if (cmd && !processing.current) {
-  passiveBuffer = "";
-  recognition.stop();
-  processCommand(cmd, confidence);
-}
-```
-
-Push-to-talk and quick commands call `processCommand` directly without requiring the wake phrase. The status line distinguishes passive wake listening vs push-to-talk.
+STT finals, quick-command clicks, and text submit all call **`processCommand`**, which awaits **`resolveIntent`** from **`useVoiceIntent`** (regex first, then optional Bedrock for ambiguous utterances). The agent card uses **`buildResponse`**, but TTS may use Bedrock’s **`spoken_reply`** when returned. **`fetchLLMBriefing`** still adds the separate **LLM triage** card for `briefing` / `critical` / `threat`. There is no wake-phrase buffer.
 
 ---
 
 ## Intent Examples
 
-| Voice Input | Intent | Action |
+| Voice / text input (examples) | Routed intent (examples) | Action |
 |---|---|---|
-| "Hey Argus, give me a summary of critical findings" | `SUMMARIZE_CRITICAL` | Pull Critical findings → Claude summary |
-| "Hey Argus, what are the high severity IAM issues" | `FILTER_FINDINGS` | Filter by severity=High, type=IAM |
-| "Hey Argus, recommend a fix for [resource name]" | `REMEDIATE_FINDING` | Find matching finding → AI-3 pipeline |
-| "Hey Argus, how many findings from the last scan" | `SCAN_STATS` | Return scan summary stats |
+| "Give me a briefing" / SITREP quick command | `briefing` | SITREP card + optional LLM triage for top finding |
+| "Show critical findings" / CRITICAL quick command | `critical` | Critical list + optional LLM triage |
+| "What's the threat level?" | `threat` | Threat assessment + optional LLM triage |
+| "Run a scan" / SCAN quick command | `scan` | Scan intent (pattern in `matchIntent`) |
+
+*(Regex patterns live in `matchIntent` inside `src/hooks/useVoiceIntent.ts`; Bedrock may override when regex returns `unknown`.)*
 
 ---
 
@@ -284,10 +276,10 @@ The voice agent reuses the existing **AI-3 guardrails pipeline** (see `Guardrail
 
 ## MVP Scope
 
-- [x] Optional wake phrase path — "Hey Argus" via Web Speech API (`continuous` + transcript filter in `VoiceIRAgent.tsx`)
+- [x] Push-to-talk voice path — Web Speech API (`continuous: false` in `VoiceIRAgent.tsx`); no wake phrase
 - [ ] `/api/voice/transcribe` endpoint using Amazon Transcribe
 - [ ] `/api/voice/respond` endpoint — intent routing + Claude (Bedrock) + Polly synthesis
-- [x] `VoiceIRAgent.tsx` — listening indicators, transcript, optional Hey Argus mode, browser TTS
+- [x] `VoiceIRAgent.tsx` — listening indicators, transcript, Polly + browser TTS fallback
 - [ ] Docker service wired up with env vars
 - [ ] 4 core intents: summarize critical, filter by severity, scan stats, recommend fix
 
@@ -297,19 +289,86 @@ The voice agent reuses the existing **AI-3 guardrails pipeline** (see `Guardrail
 - Auto-remediation via voice
 - Voice authentication / speaker recognition
 - Mobile push alerts
-- Custom wake word model (Porcupine) — upgrade path if needed
+- Continuous listening + transcript wake phrase (“Hey Argus”) — **removed** from shipped UI; custom wake word (e.g. Porcupine) remains a possible **future** upgrade
 
 ---
 
 ## What You Need to Get Started
 
-1. **AWS credentials** — already in `.env`, need the following permissions added to your IAM role:
-   - `transcribe:StartStreamTranscription`
-   - `polly:SynthesizeSpeech`
-   - `bedrock:InvokeModel`
-2. **Enable Claude on Bedrock** — AWS Console → Bedrock → Model Access → request Claude 3 Haiku (free, instant approval)
-3. **Browser** — Chrome or Edge required for Web Speech API (`webkitSpeechRecognition`)
-4. **No new API keys needed** — everything runs through your existing AWS credentials
+1. Copy **`env.example`** → **`.env`** in the project root. Add your real values; **do not commit** `.env`.
+2. In **AWS → Bedrock → Model access**, turn on the same model you set in **`BEDROCK_MODEL_ID`** (e.g. Claude Haiku).
+3. Use **Chrome or Edge** for Argus (voice input uses the browser’s speech API).
+
+Details for local Docker and AWS keys are in the next section.
+
+---
+
+## Local setup (beginner-friendly)
+
+When you run the stack with **Docker Compose**, the **Flask** container reads variables from your **host `.env`**. Two different AWS setups matter:
+
+### 1. Claude (smart replies / triage / voice “unknown” fallback)
+
+Set in **`.env`**:
+
+- **`BEDROCK_API_KEY`** — from the AWS Bedrock console (API keys). If it ends with **`=`**, that’s normal; don’t delete it.
+- **`BEDROCK_MODEL_ID`** — must match a model you enabled in Bedrock.
+- **`AWS_DEFAULT_REGION`** (or **`AWS_REGION`**) — e.g. `us-east-1`, same region as Bedrock.
+
+Used by the Python backend for **`/api/v1/llm/*`** and **`/api/v1/voice/intent`**.
+
+### 2. Polly (AWS text-to-speech for Argus)
+
+Polly uses your normal **IAM access keys**, **not** the Bedrock API key:
+
+- **`AWS_ACCESS_KEY_ID`**
+- **`AWS_SECRET_ACCESS_KEY`**
+
+That user needs permission for **`polly:SynthesizeSpeech`**. If you leave the template values like `your-aws-access-key-id`, Polly won’t work — Argus will still **speak** using the **browser’s** voice instead.
+
+### 3. Frontend (how the browser finds Flask)
+
+Usually leave these as in **`env.example`** for Docker dev:
+
+- **`VITE_IR_API_BASE`** — e.g. `http://localhost:3001/api/v1`
+- **`VITE_FLASK_PROXY_TARGET`** — e.g. `http://app:5000`
+- **`VITE_DATA_MODE`** — use **`live`** to hit the real backend; **`mock`** uses fake data and skips many calls.
+
+### After you edit `.env`
+
+Restart the app container so it reloads env vars, for example:
+
+`docker compose up -d --force-recreate app`
+
+### Quick checks
+
+- **Logs:** `docker logs -f --tail 200 cybersecurity-dashboard` — look for **503** (often Bedrock/auth) or **405** on TTS paths.
+- **Signing in with Cognito** in the UI does **not** replace these keys; Flask still uses **`.env`** for Claude and Polly.
+
+---
+
+## Phases vs environments (Dev, Staging, Production)
+
+The numbered **implementation phases** in this document are **delivery milestones** (what gets built and verified), not AWS account or URL names. A phase does not automatically mean “we are in production.”
+
+| Milestone | Typical environment | What it means |
+|---|---|---|
+| **Phases 1–3** | **Development** (local) | Work happens on developer machines and **Docker Compose** (`localhost`, `.env` / Bedrock API keys as in onboarding). This is **not** production. |
+| **Phase 4** | **Development** first; then **Staging** | Voice + Polly + triage features are implemented and exercised **locally**; you then validate the same build against a **staging** deployment (shared AWS app account, staging API URL, staging IAM) before any prod cutover. |
+| **Phase 5** | **Staging** (primary); **Production** after sign-off | Formal E2E, edge cases, guardrails, and model comparison should run against **staging**-like config and data. **“Production-ready”** here means **cleared to deploy** to **Production** — the phase is mostly **pre-production QA**, not “Phase 5 only runs in prod.” |
+| **Production** (operational) | **Production** | Customer-facing or official SOC deployment: production AWS account (or equivalent), **IAM roles** (avoid long-lived personal API keys), monitoring, change control. Reached **after** Phase 5 sign-off and a normal release process — not defined by the phase number alone. |
+
+**Short answer:** Phase 4 is still fundamentally **dev/feature work** (first proven locally). Phase 5 is **staging-centric validation** that **gates** going to **production**; neither phase *is* production by itself.
+
+### API Gateway — staging, production, or dev?
+
+**Implementing Argus / LLM / TTS behind Amazon API Gateway is not automatically “staging” or “production.”** API Gateway is **infrastructure**: you attach it to integrations (e.g. Lambda) and deploy **stages** — commonly named `dev`, `staging`, and `prod` (or separate API instances per AWS account). The **same pattern** can serve:
+
+- a **development** stage (shared team URL, low guardrails),
+- a **staging** stage (pre-prod validation, realistic IAM and data), and
+- a **production** stage (customer or official SOC traffic).
+
+So: **Gateway = how traffic enters AWS**; **which environment** depends on **which stage/account/URL** you point the frontend at (`VITE_IR_API_BASE` or equivalent), not on the fact that Gateway exists.
 
 ---
 
@@ -324,9 +383,9 @@ The voice agent reuses the existing **AI-3 guardrails pipeline** (see `Guardrail
 - [x] Quick command buttons — SITREP, CRITICAL, THREAT, SLA, HIGH RISK, SCAN
 - [x] Text input fallback for non-mic environments
 - [x] Keyboard shortcut — backtick `` ` `` to toggle panel
-- [x] Web Speech API — push-to-talk + optional continuous listening with "Hey Argus" transcript filter (`webkitSpeechRecognition`)
-- [x] Browser TTS via `SpeechSynthesisUtterance` (Polly upgrade path ready)
-- [x] Intent router — 11 intents: briefing, critical, threat, sla, latest, compliance, scan, high, isolate, navigate, help
+- [x] Web Speech API — push-to-talk only (`continuous: false`, `webkitSpeechRecognition`)
+- [x] TTS: Polly Neural when live (`/api/v1/tts/synthesize`), `SpeechSynthesisUtterance` fallback (mock mode skips Polly)
+- [x] Intent resolution — regex fast-path + optional Bedrock fallback (`useVoiceIntent`); named intents include briefing, critical, threat, sla, latest, show_findings, compliance, scan, help, high, isolate, revoke, disable_key, navigate
 - [x] Live findings data wired via `useActiveScanResults` hook
 - [x] SLA breach detection logic
 - [x] Confidence score display on STT entries
@@ -348,7 +407,7 @@ The voice agent reuses the existing **AI-3 guardrails pipeline** (see `Guardrail
 ---
 
 ### ✅ Phase 3 — Backend Wired to Claude (COMPLETE)
-- [x] `BEDROCK_API_KEY` and `BEDROCK_MODEL_ID` passed into `app` container via `docker-compose.yml`
+- [x] `BEDROCK_API_KEY`, `BEDROCK_MODEL_ID`, and `AWS_DEFAULT_REGION` passed into `app` container via `docker-compose.yml` (values from host `.env`; verify with `docker compose config` → `services.app.environment`)
 - [x] `_get_bedrock_client()` added to `backend/api/ir.py` — uses Bedrock API key auth via `boto3`
 - [x] `_invoke_claude(prompt)` helper added — returns `None` on failure (triggers mock fallback)
 - [x] `/api/v1/llm/triage` — now calls Claude with finding context, returns real triage summary
@@ -365,24 +424,34 @@ The voice agent reuses the existing **AI-3 guardrails pipeline** (see `Guardrail
 
 ---
 
-### Phase 4 — Upgrade Argus Voice to AWS APIs (Next)
-- [ ] Wire `VoiceIRAgent.tsx` intents (`briefing`, `critical`, `high`, `latest`) to call `/api/v1/llm/triage` and speak back Claude's response
-- [ ] Swap browser `SpeechSynthesisUtterance` → Amazon Polly Neural voice
-- [ ] Optionally swap `webkitSpeechRecognition` → Amazon Transcribe for higher accuracy
-- [ ] End-to-end test: "Hey Argus, brief me" → Claude triage → Polly audio
+### Phase 4 — Upgrade Argus Voice to AWS APIs (In progress)
 
-**Deliverable:** Argus voice responses powered by Claude instead of hardcoded `buildResponse()`
+*Environment: **Development** (local / Docker) for implementation; promote the same artifacts to **Staging** for integration testing. Not production until released as such.*
+
+- [x] **Amazon Polly Neural TTS** — `VoiceIRAgent` calls `pollySpeak()` first (`src/services/ttsService.ts` → `POST /api/v1/tts/synthesize`, `engine: neural`); falls back to `SpeechSynthesisUtterance` if Polly fails or `VITE_DATA_MODE=mock`
+- [x] **Triage API from voice** — Intents `briefing`, `critical`, and `threat` trigger `fetchLLMBriefing()` → `/api/v1/llm/triage`; Claude result shown as `LLMTriageCard` in the live panel (`VoiceIRAgent.tsx`)
+- [ ] **Extend triage hook** — Wire `high` and `latest` to the same triage enrichment (or document as out of scope if only SITREP-style intents need LLM)
+- [ ] **Speak Claude’s triage text** — Today the user hears `buildResponse().spokenText` immediately; the LLM summary is **display-only** until `speak()` is invoked with a trimmed `triage_summary` after the async triage response (optional short lead-in, pause-during-TTS if needed)
+- [ ] **Optional:** Replace `webkitSpeechRecognition` with Amazon Transcribe via a backend audio endpoint (not required for Phase 4 closure)
+- [ ] **Optional / team-scale — API Gateway:** Front LLM and/or TTS routes (e.g. `/llm/*`, `/tts/synthesize`, and any future voice-intent endpoint) with **Amazon API Gateway** (+ Lambda or HTTP integration to your app). Use **IAM execution roles** (and/or Cognito/API keys) so Bedrock/Polly credentials live in AWS instead of every developer’s `.env`. Create **per-environment stages** (e.g. dev / staging / prod) or separate accounts — Gateway itself is neither staging nor production until you map it to a stage and URL.
+- [ ] **End-to-end QA** — Script and run: push-to-talk (or text / quick command) → `briefing` / `critical` / `threat` → triage card + Polly (and, once implemented, spoken Claude summary)
+
+**Deliverable (target):** Argus voice path uses AWS Polly; intelligence intents surface Claude triage in-UI; **full** “voice reads Claude” needs the pending `speak(triage_summary)` step above. `buildResponse()` remains the source of the **first** spoken line and all non-triage intents until further product changes. **API Gateway** (if adopted) is tracked here as **AWS integration work**; proving it in **staging** is Phase 5.
 
 ---
 
 ### Phase 5 — Testing & Polish (Final)
+
+*Environment: **Staging** for primary QA (realistic AWS, data, and auth); **Production** is the deployment target after this phase passes — run only controlled smoke checks in prod post-release.*
+
 - [ ] Test "Generate AI overview" in `FindingDetailPanel` with real findings
-- [ ] Test all 11 Argus voice intents end-to-end
+- [ ] Test all regex-defined Argus intents (+ Bedrock `unknown` fallback) end-to-end
 - [ ] Test edge cases — no findings, bad audio, Bedrock timeout
 - [ ] Verify AI-3 guardrails fire on Claude responses
 - [ ] Swap `BEDROCK_MODEL_ID` to Claude 3.5 Sonnet for production quality comparison
 - [ ] Cross-browser test (Chrome required for Web Speech API)
 - [ ] Rebuild frontend with `docker-compose build --no-cache frontend` after all env changes
+- [ ] If **API Gateway** was added in Phase 4: run full Argus + `FindingDetailPanel` LLM E2E against the **staging** stage (auth, throttling, and Bedrock/Polly via Lambda IAM); only then promote the same pattern to the **production** stage as part of release.
 
 **Deliverable:** Argus production-ready
 
@@ -390,13 +459,13 @@ The voice agent reuses the existing **AI-3 guardrails pipeline** (see `Guardrail
 
 ### Summary Timeline
 
-| Phase | Status | Focus | Owner |
-|---|---|---|---|
-| Phase 1 — UI/UX | ✅ Complete | VoiceIRAgent.tsx, Web Speech API, browser TTS | Frontend |
-| Phase 2 — AWS Setup | ✅ Complete | Bedrock API key, IAM permissions, env vars | DevOps/Security |
-| Phase 3 — Backend | ✅ Complete | Claude wired to /llm/triage, /llm/root-cause, /llm/runbook | Backend |
-| Phase 4 — AWS Voice Upgrade | 🔲 Next | Wire Argus voice → Claude responses + Polly TTS | Frontend + Backend |
-| Phase 5 — Testing | 🔲 Next | End-to-end, guardrails, edge cases, production model | AI team + QA |
+| Phase | Status | Typical env | Focus | Owner |
+|---|---|---|---|---|
+| Phase 1 — UI/UX | ✅ Complete | Dev | VoiceIRAgent.tsx, Web Speech API, TTS path | Frontend |
+| Phase 2 — AWS Setup | ✅ Complete | Dev | Bedrock API key, IAM permissions, env vars | DevOps/Security |
+| Phase 3 — Backend | ✅ Complete | Dev | Claude wired to /llm/triage, /llm/root-cause, /llm/runbook | Backend |
+| Phase 4 — AWS Voice Upgrade | 🟡 In progress | Dev → Staging | Polly + triage cards; optional API Gateway; voice+LLM polish | Frontend + Backend |
+| Phase 5 — Testing | 🔲 Next | Staging → Prod sign-off | E2E, guardrails, edge cases, production model comparison | AI team + QA |
 
 ---
 
@@ -406,5 +475,5 @@ The voice agent reuses the existing **AI-3 guardrails pipeline** (see `Guardrail
 |---|---|
 | Voice backend endpoints | Backend team |
 | Claude (Bedrock) integration + guardrails | AI team |
-| Frontend voice UI + wake toggle (`VoiceIRAgent.tsx`) | Frontend team |
+| Frontend voice UI (`VoiceIRAgent.tsx`) | Frontend team |
 | AWS Transcribe/Polly/Bedrock IAM permissions | DevOps/Security team |

--- a/docs/backend/S16-Backend-Authorization-Review.md
+++ b/docs/backend/S16-Backend-Authorization-Review.md
@@ -1,0 +1,72 @@
+# S16 — Backend Authorization Review
+
+**Scope:** Scanner Lambda (`infra/lambda/lambda_function.py`) — HTTP traffic via API Gateway for `POST /scan/{scanner_type}`.  
+**Related:** [RBAC_Flow.md](./RBAC_Flow.md)
+
+---
+
+## 1. Authentication (session cookie, 401)
+
+- The browser sends an HttpOnly session cookie named **`iamdash_session`**. The Lambda reads it from the API Gateway **`cookies`** array and/or the **`Cookie`** header.
+- The cookie value is a **`session_id`**. The Lambda loads the session from **DynamoDB** (`SESSION_TABLE_NAME`). Missing row, expired `expires_at`, or absent cookie → **`UnauthorizedError`** → **HTTP 401** with body `{"error": "Authentication required"}`.
+- If DynamoDB access fails during session read/delete, the Lambda returns **HTTP 500** `{"error": "Unable to process request"}` (fail closed; no anonymous fallback).
+
+**Applies only when the event is treated as an HTTP API Gateway invocation** (`httpMethod` or `requestContext` present in the event). Other event shapes skip this path.
+
+---
+
+## 2. Authorization (Cognito groups, 403, admin vs non-admin)
+
+- After a valid session, the Lambda uses the session’s **`groups`** list (normalized strings). These reflect **Cognito group membership captured at login** (see [RBAC_Flow.md](./RBAC_Flow.md)).
+- **`require_groups`** enforces which **`scanner_type`** the caller may run:
+  - Users in **`admin`** may invoke **any** supported scanner, including **`full`**.
+  - **`full`** is **admin-only**; any authenticated non-admin receives **`ForbiddenError`** → **HTTP 403** with a forbidden message in the JSON body.
+  - For other types, each non-admin group maps to at most one scanner via **`SCANNER_GROUP_MAP`** (e.g. `iam` → `iam`, `ec2` → `ec2`, `securityhub` → `security-hub`, plus `guardduty`, `config`, `inspector`, `macie`). The user must hold a group whose mapped type matches the requested path.
+- Users with multiple groups receive the **union** of permitted scanner types.
+
+---
+
+## 3. Findings (what is working)
+
+| Area | Observation |
+|------|-------------|
+| **Session-bound authn** | HTTP scan requests require a valid server-side session; anonymous callers get **401**. |
+| **Group-based authz** | Non-admin users are restricted to scanner types aligned with their Cognito groups; mismatches yield **403**. |
+| **Privileged operation** | **`full`** scan is explicitly restricted to **`admin`**. |
+| **Session store failures** | Auth store errors surface as **500**, not silent allow. |
+| **Documentation** | RBAC behavior and direct-invoke semantics are described in [RBAC_Flow.md](./RBAC_Flow.md). |
+
+---
+
+## 4. Gaps
+
+| Gap | Detail |
+|-----|--------|
+| **No dedicated viewer role** | There is no first-class **read-only** vs **scan** permission in the Lambda. Groups not in `SCANNER_GROUP_MAP` cannot run scans but there is no separate “viewer” capability defined here. |
+| **No per-account (or per-tenant) scoping** | Authorization does not bind a user to specific AWS accounts. Scans execute under the **Lambda execution role**; the UI’s account selection is not a server-side access-control boundary in this handler. |
+| **Direct Lambda invocation bypass** | Events without HTTP API Gateway shape **do not** run session or group checks. Anyone with **`lambda:InvokeFunction`** on this function can trigger scans without Cognito/session. |
+| **API Gateway may not enforce auth** | Scan routes may use `authorization_type = NONE` at the gateway while the Lambda enforces the session. Unauthenticated requests still reach the Lambda (then **401**). Defense-in-depth depends on gateway/WAF configuration and operational discipline. |
+| **No separate VPC scanner RBAC** | Supported types include `iam`, `ec2`, `s3`, etc. VPC-oriented flows that call **`/scan/ec2`** are governed by **EC2** group membership only. |
+
+---
+
+## 5. Risks
+
+- **Over-privileged invoke principals:** Broad `lambda:InvokeFunction` grants negate Cognito/RBAC for batch jobs, compromised credentials, or misconfigured roles.
+- **Shared execution identity:** All authorized HTTP users effectively delegate AWS access to the **same** Lambda role; compromise of the function or role has wide blast radius.
+- **Session fixation / theft:** Standard cookie and session hygiene (TLS, `Secure`/`HttpOnly`, rotation, short TTL) matter; this document does not audit the auth Lambda or cookie flags.
+- **Confused deputy / UI mismatch:** Users may believe the dashboard “account switcher” limits backend access; without server-side account binding, that belief is unsafe.
+
+---
+
+## 6. Recommendations
+
+1. **Treat direct invoke as a controlled interface:** Restrict invocation to specific roles; use tools/scanners only via HTTP path if Cognito alignment is required; document exceptions.
+2. **Add per-account (or org) authorization** if multi-account is a requirement: e.g. map users to allowed account IDs and assume role / resource policy checks before `execute_scan`.
+3. **Introduce a viewer / read-only model** if product needs it: separate routes and checks (e.g. `GET` latest results) with a Cognito group that **cannot** `POST /scan/*`.
+4. **Optional API Gateway hardening:** Consider JWT or custom authorizer at the edge **in addition to** session validation if defense-in-depth or uniform policy is desired (coordinate with cookie-based session design).
+5. **Operational monitoring:** Alert on high **401/403** rates and on **direct** invocations if distinguishable in logs/metrics.
+
+---
+
+*This review reflects the scanner Lambda as implemented in the repository at the time of writing.*

--- a/docs/backend/S24-Sensitive-Audit-Logging.md
+++ b/docs/backend/S24-Sensitive-Audit-Logging.md
@@ -1,0 +1,90 @@
+# S24 — Audit logging for sensitive actions
+
+**Issue:** S24 / #186 — security review and compliance for sensitive operations.  
+**Log destination:** [Amazon CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html).
+
+---
+
+## 1. CloudWatch log groups and retention
+
+| Source | Log group pattern | Retention (Terraform) | Notes |
+|--------|-------------------|----------------------|--------|
+| Scanner Lambda | `/aws/lambda/<scanner-function-name>` | **365 days** (`infra/lambda/main.tf`) | Emits structured `SENSITIVE_AUDIT` lines (see §2). |
+| HTTP API (main API) | `/aws/apigwv2/<api-name>/<stage>/access` | **365 days** (`infra/api-gateway/main.tf`) | JSON access fields: `requestId`, `ip`, `routeKey`, `httpMethod`, `status`, `userAgent`, `requestTime`. |
+| Auth Lambda | `/aws/lambda/<auth-function-name>` | Set in AWS Console or Terraform for that function | **Source code is not in this repository**; login/logout/session validation should emit the same schema (§2) when implemented there. |
+
+If a log group already existed before Terraform managed it, import or align retention manually so it matches policy.
+
+---
+
+## 2. Structured audit schema (`iamdash_sensitive_action_v1`)
+
+Scanner Lambda writes **one log line per event** with the literal prefix `SENSITIVE_AUDIT` followed by a JSON object (parse the substring after the prefix for analysis).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `audit_schema` | string | Constant: `iamdash_sensitive_action_v1`. |
+| `timestamp_utc` | string | ISO-8601 UTC time of the record. |
+| `action` | string | `scan_triggered`, `scan_access_denied`, or (from other services) `login`, `logout`, `account_connected`, `role_changed`. |
+| `resource` | string | Logical resource, e.g. `scan:iam`, `scan:full`. |
+| `actor_username` | string or null | Cognito username from session, or `lambda_direct_invocation` for non-HTTP invokes, or null when unknown. |
+| `actor_groups` | array of string | Cognito groups from session (scanner path only); omitted when not applicable. |
+| `environment` | string | Lambda `ENVIRONMENT`. |
+| `project` | string | Lambda `PROJECT_NAME`. |
+| `details` | object | Context: `scanner_type`, `region`, `scan_id`, `target_account_id` (from request body when present), `reason` (`unauthenticated` / `insufficient_privilege`), etc. |
+| `http` | object | When the call is HTTP: `request_id`, `source_ip`, `user_agent`, `http_method`, `path` when available from API Gateway. |
+
+### Example (scan allowed)
+
+```json
+{
+  "audit_schema": "iamdash_sensitive_action_v1",
+  "timestamp_utc": "2026-04-13T12:00:00.000000Z",
+  "action": "scan_triggered",
+  "resource": "scan:iam",
+  "actor_username": "jdoe",
+  "actor_groups": ["iam"],
+  "environment": "prod",
+  "project": "IAMDash",
+  "details": {
+    "scanner_type": "iam",
+    "region": "us-east-1",
+    "scan_id": "iam-2026-04-13T12:00:00",
+    "target_account_id": "123456789012"
+  },
+  "http": {
+    "request_id": "abc-123",
+    "source_ip": "198.51.100.10",
+    "user_agent": "Mozilla/5.0 ...",
+    "http_method": "POST",
+    "path": "/scan/iam"
+  }
+}
+```
+
+### CloudWatch Logs Insights (scanner)
+
+- **Log group:** `/aws/lambda/<scanner-function-name>`
+- **Filter:** `@message like /SENSITIVE_AUDIT/`
+- Parse JSON: use `parse @message /SENSITIVE_AUDIT (?<audit>.*)/` then `parse audit @audit` if your query language supports chained parse, or export to S3/OpenSearch for heavy analytics.
+
+---
+
+## 3. Event coverage vs. implementation
+
+| Event | Where it should be logged | Status in repo |
+|-------|---------------------------|----------------|
+| Login | Auth Lambda (after successful Cognito auth) | **Documented only** — implement in auth Lambda codebase with `action: login` and `http` context; do not log passwords. |
+| Logout | Auth Lambda (session removed) | **Documented only** — same schema with `action: logout`. |
+| Scan trigger | Scanner Lambda | **Implemented** — `scan_triggered` after authorization succeeds. |
+| Scan denied (401/403) | Scanner Lambda | **Implemented** — `scan_access_denied` with `reason` in `details`. |
+| Account connection | Account-registration API / Lambda (when deployed) | **Not in repo** — use `action: account_connected` (or `account_disconnected`) and `details` with `account_id` / `account_name` (avoid secrets). |
+| Role / group changes | Cognito admin operations | Prefer **AWS CloudTrail** (`cognito-idp` events such as `AdminAddUserToGroup`) for IAM/Cognito changes; optionally mirror with `action: role_changed` in the component that performs the change. |
+
+---
+
+## 4. Compliance notes
+
+- **Who / what / when / context:** Covered by `actor_username`, `actor_groups`, `resource`, `details`, `timestamp_utc`, and `http` (IP, request id).
+- **Secrets:** Scanner logging continues to redact cookies in generic `Received event` logs (`sanitize_event_for_logging`); audit lines must never include session cookies or passwords.
+- **Retention:** Align all production log groups to organizational policy (365 days matches current API Gateway Terraform).

--- a/docs/data-retention-policy.md
+++ b/docs/data-retention-policy.md
@@ -1,0 +1,67 @@
+# Data retention policy (A17)
+
+This document defines how long different classes of IAM Dashboard data are kept, how enforcement works in each system, and how the recommended settings compare to what ships in the repo today.
+
+## Retention periods (recommended)
+
+| Data class | Recommended retention | Rationale |
+|------------|----------------------|-----------|
+| **Prometheus metrics** | **15 days** | TSDB size and query performance; long enough for incident review and short-term trends without unbounded disk growth. |
+| **Grafana annotations / snapshots** | **30 days** (annotations policy); snapshots limited | Annotations support incident timelines; bounded cleanup avoids unbounded DB growth. External snapshots disabled to reduce leak surface. |
+| **DynamoDB — scan results & IAM findings** | **90 days** | **TTL** on `expires_at` (Unix epoch seconds): AWS removes items after that time without application-driven deletes. Aligns with typical compliance “review quarterly” cycles. |
+| **PostgreSQL — `security_findings` & `performance_metrics`** | **90 days** | Row-level deletes for rows older than 90 days by `created_at` / `timestamp` keeps the app DB bounded; run via the same scheduled retention job as DynamoDB cleanup. |
+
+Operational note: **TTL** deletes are **eventually consistent** (typically within 48 hours of expiry). The application also runs **explicit deletes** for scan/findings tables during the scheduled job so behavior is predictable even before TTL backfill on legacy rows.
+
+## Prometheus (metrics)
+
+- **Role:** Time-series storage for scraped targets (e.g. app metrics, Grafana, Postgres exporter targets as configured).
+- **Configuration:** Retention is controlled by the Prometheus process flag `--storage.tsdb.retention.time` (not `prometheus.yml`). Scrape rules live in `config/prometheus/prometheus.yml`.
+- **Recommended:** `15d` for `--storage.tsdb.retention.time`.
+
+## Grafana (dashboards, annotations, snapshots)
+
+- **Role:** Dashboards and provisioning live under `config/grafana/provisioning/`; Docker mounts `grafana_data` for state.
+- **Recommended environment variables:**
+  - `GF_ALERTING_MAX_ANNOTATIONS_TO_KEEP=1000` — cap stored annotations.
+  - `GF_ANNOTATIONS_CLEANUPJOB_BATCHSIZE=100` — batch size for annotation cleanup.
+  - `GF_SNAPSHOTS_EXTERNAL_ENABLED=false` — disable external snapshot uploads by default.
+
+Exact Grafana behavior can vary by major version; validate in staging after upgrades.
+
+## DynamoDB (findings + scan results)
+
+- **Tables:** Scan results (`scan_id` + `timestamp`) and IAM findings (`finding_id` + `detected_at`, with GSI `resource-index` on `resource_type` + `detected_at`) as defined in Terraform and `backend/services/dynamodb_service.py`.
+- **TTL:** Attribute name **`expires_at`** (Number, Unix seconds). Terraform enables TTL on both tables. New writes set `expires_at` to **now + 90 days** so AWS can expire items automatically.
+- **Application cleanup:** `DynamoDBService.delete_old_records()` performs paginated scans and deletes items older than the configured day threshold using the correct primary key per table (complements TTL for legacy items without `expires_at`).
+
+## PostgreSQL (`security_findings`, `performance_metrics`)
+
+- **Retention column:** `security_findings.created_at`, `performance_metrics.timestamp`.
+- **Cleanup:** `DatabaseService.cleanup_old_records(days=90)` deletes rows strictly older than the cutoff. Invoked from the same retention job as DynamoDB.
+
+## Scheduled job & HTTP trigger
+
+- **Background:** When `RETENTION_SCHEDULER_ENABLED` is `true` (default), a daemon thread runs the full retention pass once per `RETENTION_SCHEDULER_INTERVAL_SEC` (default **86400** = 24h), after an initial **60s** startup delay.
+- **HTTP (optional):** `POST /api/v1/system/retention` with header `X-Retention-Run-Key` equal to `RETENTION_RUN_KEY` runs the same pass on demand. If `RETENTION_RUN_KEY` is unset, the endpoint returns **503** (disabled).
+
+## Current state vs. recommended
+
+| Area | Previous / shipped state | Recommended / implemented |
+|------|---------------------------|---------------------------|
+| Prometheus TSDB retention | `200h` (~8.3d) in `docker-compose.yml` | **15d** via `--storage.tsdb.retention.time=15d` |
+| Grafana annotation / snapshot controls | Only admin password / sign-up flags | Add **annotation caps**, **cleanup batch size**, **disable external snapshots** |
+| DynamoDB scan results | Table in Terraform; **no TTL** | **TTL on `expires_at`**; writes set `expires_at` |
+| DynamoDB IAM findings | Used by app; **not** in Terraform on older branches | **New table in Terraform** with GSI + **TTL**; writes set `expires_at` |
+| `delete_old_records` | Single-page scan; **wrong keys** for findings; **no caller** | **Paginated scan**; correct keys per table; invoked from **scheduler + optional POST** |
+| PostgreSQL aged rows | No automated delete | **`cleanup_old_records(90)`** for findings + metrics |
+
+## References (code & config)
+
+- `docker-compose.yml` — Prometheus flags, Grafana env.
+- `config/prometheus/prometheus.yml` — scrape configuration.
+- `config/grafana/provisioning/` — datasources and dashboard provisioning.
+- `infra/dynamodb/main.tf` — DynamoDB tables and TTL.
+- `backend/services/dynamodb_service.py` — `expires_at` on writes, `delete_old_records`.
+- `backend/services/database_service.py` — `cleanup_old_records`.
+- `backend/api/retention.py` — HTTP trigger; `backend/app.py` — route registration and scheduler startup.

--- a/docs/infra/S23-API-Gateway-rate-limiting.md
+++ b/docs/infra/S23-API-Gateway-rate-limiting.md
@@ -1,0 +1,59 @@
+# S23 — API Gateway rate limiting (task record)
+
+This document matches **GitHub issue S23** (*Rate limiting on API Gateway*): what was asked, what the platform supports, and what this repository configures.
+
+## Task objective
+
+- **Protect** scan and auth HTTP endpoints from abuse.
+- **Throttle** using API Gateway controls: steady **requests per second (RPS)** and **burst** capacity.
+- **Document** chosen limits and how operators can change them when scaling.
+- The original issue also mentioned **usage plans** and **per-day** limits; see *Platform constraints* below.
+
+## Requirements (from the issue)
+
+| Requirement | Notes |
+|-------------|--------|
+| Throttling on API Gateway | Applied at the HTTP API **stage**, with **per-route overrides** where needed. |
+| Scan endpoints | All `POST /scan/*` routes; **`POST /scan/full`** is throttled more strictly than single-service scans. |
+| Auth endpoints | `POST /auth/login`, `POST /auth/logout`, `GET /auth/session`. |
+| Requests per second | Configured via `throttling_*_rate_limit` variables (steady-state RPS). |
+| Burst | Configured via `throttling_*_burst_limit` variables (token-bucket burst). |
+| Per day | **Not enforced natively** on HTTP APIs; options are documented below. |
+| Usage plans | **REST APIs (v1)** feature. This project uses an **HTTP API (v2)**; equivalent abuse protection is **stage + route throttling** unless we migrate or add another layer. |
+
+## Platform constraints (HTTP API vs usage plans)
+
+- **HTTP API (API Gateway v2)** supports **throttling** (RPS + burst) on the stage default and on individual routes. It does **not** support **usage plans**, **API keys**, or built-in **daily quotas**.
+- To add **hard per-day quotas** later, typical approaches are: **REST API + usage plans** (often with a server-side caller, not a browser-held API key), **application-level** counters (e.g. DynamoDB + Lambda), or **WAF** / edge rules for abuse patterns—not a single toggle on HTTP API.
+
+## Configured limits (defaults)
+
+Source of truth: Terraform in `infra/api-gateway/` (`main.tf`, `variables.tf`). Summary:
+
+| Route group | Steady RPS | Burst |
+|-------------|------------|-------|
+| Individual scans (`POST /scan/*` except `/full`) | 25 | 50 |
+| Full scan (`POST /scan/full`) | 5 | 10 |
+| Auth (`/auth/login`, `/auth/logout`, `/auth/session`) | 35 | 70 |
+
+The deprecated standalone auth HTTP API (`infra/API_Gateway_Auth/`) uses stage throttling aligned with the auth numbers above when that stack is still deployed.
+
+## How to change limits (scaling)
+
+1. Edit **`infra/api-gateway/variables.tf`** (or pass module inputs from **`infra/main.tf`** if you add root-level variables).
+2. From the **`infra/`** directory: `terraform plan` then `terraform apply` (with your usual backend / credentials).
+3. Clients exceeding limits receive **429 Too Many Requests** from API Gateway.
+
+Detailed operator notes and verification (access logs, 429s) live in **`infra/api-gateway/README.md`** (section *Rate limiting*).
+
+## Verification
+
+- CloudWatch access logs for the stage: log group pattern `/aws/apigwv2/<api-name>/<stage>/access`.
+- Filter for HTTP **429** responses after controlled load tests.
+
+## Related files
+
+- `infra/api-gateway/main.tf` — stage `default_route_settings` and `route_settings` overrides.
+- `infra/api-gateway/variables.tf` — all throttling variables and defaults.
+- `infra/api-gateway/README.md` — endpoint list and rate-limiting runbook.
+- `infra/API_Gateway_Auth/main.tf` — optional legacy auth API stage limits.

--- a/docs/planning/GITHUB_ISSUES_BACKLOG.md
+++ b/docs/planning/GITHUB_ISSUES_BACKLOG.md
@@ -290,7 +290,7 @@ This is **expected behavior**, not failure.
 | S20 | (SEMESTER) Gitleaks baseline & allowlist | M3 |
 | S21 | (SEMESTER) IAM least-privilege audit (Lambda, GitHub Actions) | M5 |
 | S22 | (SEMESTER) Security headers on API responses | M4 |
-| S23 | (SEMESTER) Rate limiting on API Gateway | M5 |
+| S23 | (SEMESTER) Rate limiting on API Gateway — [implementation & task record](../infra/S23-API-Gateway-rate-limiting.md) | M5 |
 | S24 | (SEMESTER) Audit logging for sensitive actions | M5 |
 | S25 | (SEMESTER) CORS configuration review | M3 |
 | S26 | (SEMESTER) Remediation content security review (pairs with AI) | M4 |

--- a/docs/team-scope/security.md
+++ b/docs/team-scope/security.md
@@ -67,7 +67,7 @@ Week 6 March 24 – March 30
 - Test throttling behavior.
 - Document scaling considerations.
 
-Dev will configure API Gateway usage plans.
+Dev will configure API Gateway throttling (HTTP API: per-route RPS/burst in Terraform; per-day caps need REST usage plans or app/WAF if required).
 Jade will test throttling edge cases.
 Sebas will monitor logs during load testing.
 Tibo will document rate limiting configuration.

--- a/env.example
+++ b/env.example
@@ -11,8 +11,14 @@ REDIS_URL=redis://redis:6379/0
 
 # AWS Configuration
 AWS_REGION=us-east-1
+# Used by boto3 in backend (Bedrock, Polly); defaults to AWS_REGION in docker-compose if unset
+AWS_DEFAULT_REGION=us-east-1
 AWS_ACCESS_KEY_ID=your-aws-access-key-id
 AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
+
+# Amazon Bedrock (LLM + voice intent fallback) — required in Docker for live Claude; omit for mock-only
+# BEDROCK_API_KEY=your-bedrock-api-key
+# BEDROCK_MODEL_ID=anthropic.claude-haiku-4-5
 
 # SMTP Configuration (local test defaults)
 SMTP_HOST=mailhog

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <head>
       <meta charset="UTF-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <title>CloudSec — AWS Security Dashboard</title>
+      <title>IAM Argus</title>
       <link rel="preconnect" href="https://fonts.googleapis.com" />
       <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
       <link href="https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,300;9..40,400;9..40,500;9..40,600;9..40,700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />

--- a/infra/API_Gateway_Auth/main.tf
+++ b/infra/API_Gateway_Auth/main.tf
@@ -37,6 +37,11 @@ resource "aws_apigatewayv2_stage" "auth" {
   name        = var.stage_name
   auto_deploy = true
 
+  default_route_settings {
+    throttling_burst_limit = var.throttling_burst_limit
+    throttling_rate_limit  = var.throttling_rate_limit
+  }
+
   tags = {
     Name      = "${var.api_name}-${var.stage_name}"
     Project   = var.project_name

--- a/infra/API_Gateway_Auth/variables.tf
+++ b/infra/API_Gateway_Auth/variables.tf
@@ -49,3 +49,15 @@ variable "lambda_function_arn" {
   description = "ARN for the BFF-Auth lambda function"
   type        = string
 }
+
+variable "throttling_burst_limit" {
+  description = "Stage burst limit for this standalone auth HTTP API (RPS bucket)."
+  type        = number
+  default     = 70
+}
+
+variable "throttling_rate_limit" {
+  description = "Steady-state requests per second for this auth API stage."
+  type        = number
+  default     = 35
+}

--- a/infra/api-gateway/README.md
+++ b/infra/api-gateway/README.md
@@ -48,7 +48,7 @@ terraform apply
 - **Protocol**: HTTP API (v2)
 - **Stage**: `v1`
 - **CORS**: Enabled with configurable origins
-- **Throttling**: 100 burst, 50 rate limit per second
+- **Throttling**: Per-route limits on the stage (see below)
 - **Routes**: Added route definitions for 12 routes. 9 scanner, 3 authentication
 - **Lambda Integration**: Integrated the scanner routes with the scanner lambda and auth routes with the auth lambda
 - **Request/Response Mapping**: Configure request/response transformations
@@ -111,4 +111,33 @@ API Gateway will:
 3. Transform responses back to HTTP
 4. Handle CORS for browser requests
 5. Provide throttling and rate limiting
+
+## ⏱️ Rate limiting (throttling)
+
+This API is an **HTTP API (API Gateway v2)**. Throttling uses **steady RPS** plus **burst** (token bucket) on the stage. HTTP APIs do **not** support REST-style **usage plans**, **API keys**, or a built-in **per-day quota**; those require a REST API or another layer (for example application quotas or WAF).
+
+### Chosen limits (defaults)
+
+| Route group | Routes | Steady RPS | Burst | Terraform variables |
+|-------------|--------|------------|-------|---------------------|
+| Individual scans | `POST /scan/security-hub`, `guardduty`, `config`, `inspector`, `macie`, `iam`, `ec2`, `s3` | 25 | 50 | `throttling_rate_limit`, `throttling_burst_limit` |
+| Full scan | `POST /scan/full` | 5 | 10 | `throttling_scan_full_rate_limit`, `throttling_scan_full_burst_limit` |
+| Auth | `POST /auth/login`, `POST /auth/logout`, `GET /auth/session` | 35 | 70 | `throttling_auth_rate_limit`, `throttling_auth_burst_limit` |
+
+Individual scan routes inherit **default_route_settings**. `POST /scan/full` and the auth routes use **route_settings** overrides on the same stage.
+
+### Per-day caps
+
+There is **no native per-day limit** on HTTP API throttling. To add a daily cap later, options include: migrate sensitive routes to a **REST API** with usage plans and quotas, enforce quotas in **Lambda** (for example DynamoDB counters), or use **WAF** / edge rules for abuse patterns. Until then, use CloudWatch on `429` responses and Lambda invocations for monitoring.
+
+### How to change limits for scaling
+
+1. Edit defaults in `variables.tf` or pass overrides when calling the module from `infra/main.tf`.
+2. Run `terraform plan` and `terraform apply` from the `infra` root (or this module directory if applied standalone).
+3. After deploy, clients exceeding limits receive **429 Too Many Requests** from API Gateway.
+
+### Verifying throttling
+
+- Use stage **access logs** (CloudWatch log group `/aws/apigwv2/<api-name>/<stage>/access`) and filter for `status` 429.
+- Load-test gradually; burst allows short spikes above steady RPS.
 

--- a/infra/api-gateway/main.tf
+++ b/infra/api-gateway/main.tf
@@ -73,6 +73,28 @@ resource "aws_apigatewayv2_stage" "default" {
     throttling_rate_limit  = var.throttling_rate_limit
   }
 
+  # Overrides default_route_settings for expensive or user-facing routes.
+  route_settings {
+    route_key              = "POST /scan/full"
+    throttling_burst_limit = var.throttling_scan_full_burst_limit
+    throttling_rate_limit  = var.throttling_scan_full_rate_limit
+  }
+  route_settings {
+    route_key              = "POST /auth/login"
+    throttling_burst_limit = var.throttling_auth_burst_limit
+    throttling_rate_limit  = var.throttling_auth_rate_limit
+  }
+  route_settings {
+    route_key              = "POST /auth/logout"
+    throttling_burst_limit = var.throttling_auth_burst_limit
+    throttling_rate_limit  = var.throttling_auth_rate_limit
+  }
+  route_settings {
+    route_key              = "GET /auth/session"
+    throttling_burst_limit = var.throttling_auth_burst_limit
+    throttling_rate_limit  = var.throttling_auth_rate_limit
+  }
+
   access_log_settings {
     destination_arn = aws_cloudwatch_log_group.apigw_access.arn
     format = jsonencode({

--- a/infra/api-gateway/variables.tf
+++ b/infra/api-gateway/variables.tf
@@ -61,16 +61,41 @@ variable "cors_allowed_headers" {
   default     = ["Content-Type", "Authorization", "X-Requested-With"]
 }
 
+# Stage default_route_settings apply to individual scan routes (POST /scan/* except /scan/full).
 variable "throttling_burst_limit" {
-  description = "API Gateway throttling burst limit"
+  description = "Burst limit (concurrent bucket) for individual scan routes; steady rate is throttling_rate_limit RPS."
   type        = number
-  default     = 100
+  default     = 50
 }
 
 variable "throttling_rate_limit" {
-  description = "API Gateway throttling rate limit"
+  description = "Steady-state requests per second for individual scan routes (POST /scan/* except /scan/full)."
   type        = number
-  default     = 50
+  default     = 25
+}
+
+variable "throttling_scan_full_burst_limit" {
+  description = "Burst limit for POST /scan/full (runs all scanners; kept low to reduce abuse and cost)."
+  type        = number
+  default     = 10
+}
+
+variable "throttling_scan_full_rate_limit" {
+  description = "Steady-state RPS for POST /scan/full."
+  type        = number
+  default     = 5
+}
+
+variable "throttling_auth_burst_limit" {
+  description = "Burst limit for auth routes (login/logout/session)."
+  type        = number
+  default     = 70
+}
+
+variable "throttling_auth_rate_limit" {
+  description = "Steady-state RPS for auth routes."
+  type        = number
+  default     = 35
 }
 
 variable "lambda_function_arn" {

--- a/infra/dynamodb/main.tf
+++ b/infra/dynamodb/main.tf
@@ -62,11 +62,70 @@ resource "aws_dynamodb_table" "scan_results" {
   # Enable deletion protection in production
   deletion_protection_enabled = var.environment == "prod"
 
+  ttl {
+    attribute_name = "expires_at"
+    enabled        = true
+  }
+
   tags = {
     Name        = var.dynamodb_table_name
     Project     = var.project_name
     Env         = var.environment
     ManagedBy   = "terraform"
     Description = "Stores security scan results from AWS native scanners and custom OPA policies"
+  }
+}
+
+# DynamoDB table for IAM findings (TTL aligns with data retention policy)
+resource "aws_dynamodb_table" "iam_findings" {
+  name         = var.iam_findings_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "finding_id"
+  range_key    = "detected_at"
+
+  attribute {
+    name = "finding_id"
+    type = "S"
+  }
+
+  attribute {
+    name = "detected_at"
+    type = "S"
+  }
+
+  attribute {
+    name = "resource_type"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "resource-index"
+    hash_key        = "resource_type"
+    range_key       = "detected_at"
+    projection_type = "ALL"
+  }
+
+  point_in_time_recovery {
+    enabled = var.enable_point_in_time_recovery
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = var.dynamodb_kms_key_arn
+  }
+
+  deletion_protection_enabled = var.environment == "prod"
+
+  ttl {
+    attribute_name = "expires_at"
+    enabled        = true
+  }
+
+  tags = {
+    Name        = var.iam_findings_table_name
+    Project     = var.project_name
+    Env         = var.environment
+    ManagedBy   = "terraform"
+    Description = "Stores IAM security findings; TTL on expires_at for automatic expiration"
   }
 }

--- a/infra/dynamodb/main.tf
+++ b/infra/dynamodb/main.tf
@@ -76,6 +76,10 @@ resource "aws_dynamodb_table" "scan_results" {
   }
 }
 
+# Terraform import/state migration notes:
+# - If this table already exists, import it into state before applying:
+#     terraform -chdir=infra/dynamodb import aws_dynamodb_table.iam_findings <EXISTING_TABLE_NAME>
+# - After import, run plan/apply to ensure TTL, tags, and encryption match this config.
 # DynamoDB table for IAM findings (TTL aligns with data retention policy)
 resource "aws_dynamodb_table" "iam_findings" {
   name         = var.iam_findings_table_name

--- a/infra/dynamodb/outputs.tf
+++ b/infra/dynamodb/outputs.tf
@@ -13,3 +13,13 @@ output "dynamodb_table_id" {
   value       = aws_dynamodb_table.scan_results.id
 }
 
+output "iam_findings_table_name" {
+  description = "Name of the IAM findings DynamoDB table"
+  value       = aws_dynamodb_table.iam_findings.name
+}
+
+output "iam_findings_table_arn" {
+  description = "ARN of the IAM findings DynamoDB table"
+  value       = aws_dynamodb_table.iam_findings.arn
+}
+

--- a/infra/dynamodb/variables.tf
+++ b/infra/dynamodb/variables.tf
@@ -22,6 +22,12 @@ variable "dynamodb_table_name" {
   default     = "iam-dashboard-scan-results"
 }
 
+variable "iam_findings_table_name" {
+  description = "Name of the DynamoDB table for IAM security findings"
+  type        = string
+  default     = "iam-dashboard-iam-findings"
+}
+
 variable "enable_scanner_type_index" {
   description = "Enable Global Secondary Index for scanner_type-based queries"
   type        = bool

--- a/infra/lambda/lambda_function.py
+++ b/infra/lambda/lambda_function.py
@@ -151,6 +151,72 @@ class SessionStoreError(Exception):
     """Raised when session storage cannot be read safely."""
 
 
+def _http_request_audit_context(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Correlation and client context from API Gateway (HTTP API v2 or REST) for audit logs."""
+    ctx: Dict[str, Any] = {}
+    rc = event.get('requestContext') or {}
+    if not isinstance(rc, dict):
+        return ctx
+    ctx['request_id'] = rc.get('requestId')
+    http = rc.get('http') or {}
+    if isinstance(http, dict):
+        if http.get('sourceIp'):
+            ctx['source_ip'] = http.get('sourceIp')
+        if http.get('userAgent'):
+            ctx['user_agent'] = http.get('userAgent')
+        if http.get('method'):
+            ctx['http_method'] = http.get('method')
+        if http.get('path'):
+            ctx['path'] = http.get('path')
+    ident = rc.get('identity') or {}
+    if isinstance(ident, dict):
+        if 'source_ip' not in ctx and ident.get('sourceIp'):
+            ctx['source_ip'] = ident.get('sourceIp')
+        if 'user_agent' not in ctx and ident.get('userAgent'):
+            ctx['user_agent'] = ident.get('userAgent')
+    return {k: v for k, v in ctx.items() if v is not None}
+
+
+def emit_sensitive_audit_record(
+    action: str,
+    *,
+    actor_username: Optional[str] = None,
+    actor_groups: Optional[list] = None,
+    resource: str = '',
+    details: Optional[Dict[str, Any]] = None,
+    http_context: Optional[Dict[str, Any]] = None,
+) -> None:
+    """
+    Emit one JSON audit record to CloudWatch Logs (Lambda platform log stream).
+    Prefix with SENSITIVE_AUDIT for CloudWatch Logs Insights: filter @message like /SENSITIVE_AUDIT/
+    """
+    record: Dict[str, Any] = {
+        'audit_schema': 'iamdash_sensitive_action_v1',
+        'timestamp_utc': datetime.utcnow().isoformat() + 'Z',
+        'action': action,
+        'resource': resource,
+        'actor_username': actor_username,
+        'environment': ENVIRONMENT,
+        'project': PROJECT_NAME,
+        'details': details or {},
+    }
+    if actor_groups is not None:
+        record['actor_groups'] = actor_groups
+    if http_context:
+        record['http'] = http_context
+    try:
+        logger.info('SENSITIVE_AUDIT %s', json.dumps(record, default=json_serial))
+    except (TypeError, ValueError) as exc:
+        logger.warning('SENSITIVE_AUDIT serialization failed: %s', exc)
+
+
+def _target_account_from_scan_params(params: Dict[str, Any]) -> Optional[str]:
+    raw = params.get('account_id') if isinstance(params.get('account_id'), str) else params.get('accountId')
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return None
+
+
 def _cors_allowed_origins_set() -> set:
     raw = os.environ.get('CORS_ALLOWED_ORIGINS', '')
     return {o.strip() for o in raw.split(',') if o.strip()}
@@ -403,12 +469,72 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 'error': f'Invalid scanner type. Must be one of: {", ".join(valid_scanners)}'
             })
 
+        session: Optional[Dict[str, Any]] = None
         if is_http_request:
-            session = require_authenticated_session(event)
-            require_groups(session, scanner_type)
-        
+            http_audit_ctx = _http_request_audit_context(event)
+            session = get_request_session(event)
+            target_account = _target_account_from_scan_params(scan_params)
+            if not session:
+                emit_sensitive_audit_record(
+                    'scan_access_denied',
+                    resource=f'scan:{scanner_type}',
+                    details={
+                        'reason': 'unauthenticated',
+                        'scanner_type': scanner_type,
+                        'region': region,
+                        'target_account_id': target_account,
+                    },
+                    http_context=http_audit_ctx,
+                )
+                raise UnauthorizedError('Authentication required.')
+            try:
+                require_groups(session, scanner_type)
+            except ForbiddenError:
+                emit_sensitive_audit_record(
+                    'scan_access_denied',
+                    actor_username=session.get('username') if isinstance(session.get('username'), str) else None,
+                    actor_groups=normalize_groups(session.get('groups')),
+                    resource=f'scan:{scanner_type}',
+                    details={
+                        'reason': 'insufficient_privilege',
+                        'scanner_type': scanner_type,
+                        'region': region,
+                        'target_account_id': target_account,
+                    },
+                    http_context=http_audit_ctx,
+                )
+                raise
+
         # Execute scan
         scan_id = f"{scanner_type}-{datetime.utcnow().isoformat()}"
+        target_account = _target_account_from_scan_params(scan_params)
+        if is_http_request and session is not None:
+            emit_sensitive_audit_record(
+                'scan_triggered',
+                actor_username=session.get('username') if isinstance(session.get('username'), str) else None,
+                actor_groups=normalize_groups(session.get('groups')),
+                resource=f'scan:{scanner_type}',
+                details={
+                    'scanner_type': scanner_type,
+                    'region': region,
+                    'scan_id': scan_id,
+                    'target_account_id': target_account,
+                },
+                http_context=_http_request_audit_context(event),
+            )
+        elif not is_http_request:
+            emit_sensitive_audit_record(
+                'scan_triggered',
+                actor_username='lambda_direct_invocation',
+                resource=f'scan:{scanner_type}',
+                details={
+                    'scanner_type': scanner_type,
+                    'region': region,
+                    'scan_id': scan_id,
+                    'target_account_id': target_account,
+                    'invocation': 'direct',
+                },
+            )
         logger.info(f"Starting scan: {scan_id} for type: {scanner_type}")
         
         try:

--- a/infra/lambda/main.tf
+++ b/infra/lambda/main.tf
@@ -99,3 +99,17 @@ resource "aws_lambda_function" "scanner" {
 
   depends_on = [aws_iam_role_policy.lambda_policy]
 }
+
+# Scanner Lambda logs (structured SENSITIVE_AUDIT lines + platform messages)
+resource "aws_cloudwatch_log_group" "scanner_lambda" {
+  name              = "/aws/lambda/${var.lambda_function_name}"
+  retention_in_days = 365
+
+  tags = {
+    Name      = "${var.lambda_function_name}-logs"
+    Project   = var.project_name
+    Env       = var.environment
+    ManagedBy = "terraform"
+    Purpose   = "audit-scanner"
+  }
+}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1969,6 +1969,7 @@ export function Dashboard({ onNavigate, onFullScanComplete }: DashboardProps) {
           </button>
         ))}
       </div>
+
     </div>
   );
 }

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,6 +7,7 @@ import {
   Search, Bell, Settings, User, LogOut,
   ChevronDown, MapPin,
 } from "lucide-react";
+import { VoiceIRAgent } from "./ir/VoiceIRAgent";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
@@ -411,6 +412,9 @@ export function Header({ onNavigate, activeTab = "dashboard" }: HeaderProps) {
           </span>
           LIVE
         </div>
+
+        {/* ARIA Voice IR Agent */}
+        <VoiceIRAgent onNavigate={onNavigate} />
 
         {/* Notifications */}
         <Popover>

--- a/src/components/ir/IRActionEngine.tsx
+++ b/src/components/ir/IRActionEngine.tsx
@@ -41,6 +41,7 @@ import type {
   IRActionResult,
   ApprovalRequest,
   IREngineState,
+  PlaybookStep,
 } from "../../types/ir";
 import { ACTION_META, HIGH_IMPACT_ACTIONS } from "../../types/ir";
 import {
@@ -425,49 +426,79 @@ function LLMResult({ result, type }: { result: IRActionResult; type: IRActionTyp
     );
   }
 
-  if (type === "llm_runbook" && result.runbook_markdown) {
+  if (type === "llm_runbook" && result.runbook_steps) {
+    const steps = result.runbook_steps as PlaybookStep[];
+    const PHASE_COLOR: Record<string, string> = {
+      IDENTIFY: "#60a5fa",
+      CONTAIN: "#ffb000",
+      REMEDIATE: "#ff6b35",
+      VERIFY: "#00ff88",
+    };
     return (
-      <div style={{ marginTop: 10, position: "relative" }}>
-        <button
-          onClick={() => copyText(result.runbook_markdown!)}
-          style={{
-            position: "absolute",
-            top: 6,
-            right: 6,
-            background: "rgba(255,255,255,0.06)",
-            border: "1px solid rgba(255,255,255,0.1)",
-            borderRadius: 4,
-            padding: "3px 8px",
-            color: copied ? "#00ff88" : "rgba(100,116,139,0.55)",
-            cursor: "pointer",
-            display: "flex",
-            alignItems: "center",
-            gap: 4,
-            fontSize: 10,
-            ...mono,
-          }}
-        >
-          {copied ? <Check size={10} /> : <Copy size={10} />}
-          {copied ? "Copied" : "Copy"}
-        </button>
-        <pre
-          style={{
-            ...mono,
-            fontSize: 10,
-            color: "rgba(148,163,184,0.85)",
-            background: "rgba(0,0,0,0.2)",
-            padding: "10px 12px",
-            borderRadius: 6,
-            overflow: "auto",
-            maxHeight: 220,
-            margin: 0,
-            lineHeight: 1.7,
-            whiteSpace: "pre-wrap",
-            wordBreak: "break-word",
-          }}
-        >
-          {result.runbook_markdown}
-        </pre>
+      <div style={{ marginTop: 10, display: "flex", flexDirection: "column", gap: 8 }}>
+        {steps.map((step) => (
+          <div
+            key={step.step}
+            style={{
+              background: "rgba(0,0,0,0.2)",
+              border: `1px solid ${PHASE_COLOR[step.phase] ?? "#818cf8"}22`,
+              borderLeft: `3px solid ${PHASE_COLOR[step.phase] ?? "#818cf8"}`,
+              borderRadius: 6,
+              padding: "8px 10px",
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 4 }}>
+              <span
+                style={{
+                  ...mono,
+                  fontSize: 8,
+                  fontWeight: 700,
+                  color: PHASE_COLOR[step.phase] ?? "#818cf8",
+                  textTransform: "uppercase",
+                  letterSpacing: "0.08em",
+                }}
+              >
+                {step.phase}
+              </span>
+              <span style={{ ...mono, fontSize: 10, fontWeight: 600, color: "#e2e8f0" }}>
+                {step.title}
+              </span>
+              <span style={{ marginLeft: "auto", ...mono, fontSize: 9, color: "rgba(100,116,139,0.5)" }}>
+                {step.estimated_time}m
+              </span>
+            </div>
+            <p style={{ margin: "0 0 6px", fontSize: 10, color: "rgba(148,163,184,0.8)", lineHeight: 1.5 }}>
+              {step.description}
+            </p>
+            {step.commands.length > 0 && (
+              <div
+                style={{
+                  background: "rgba(0,0,0,0.3)",
+                  borderRadius: 4,
+                  padding: "6px 8px",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: 2,
+                }}
+              >
+                {step.commands.map((cmd, ci) => (
+                  <code
+                    key={ci}
+                    style={{
+                      ...mono,
+                      fontSize: 9,
+                      color: cmd.startsWith("#") ? "rgba(100,116,139,0.5)" : "rgba(148,163,184,0.85)",
+                      whiteSpace: "pre-wrap",
+                      wordBreak: "break-all",
+                    }}
+                  >
+                    {cmd}
+                  </code>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
       </div>
     );
   }

--- a/src/components/ir/VoiceIRAgent.tsx
+++ b/src/components/ir/VoiceIRAgent.tsx
@@ -20,6 +20,8 @@ import { Mic, MicOff, Volume2, Zap, X, Download, Trash2, ShieldAlert } from "luc
 import { useActiveScanResults } from "../../hooks/useActiveScanResults";
 import { pollySpeak } from "../../services/ttsService";
 import { fetchLLMActionResult, triggerIRAction } from "../../services/irEngine";
+import { useVoiceIntent } from "../../hooks/useVoiceIntent";
+import type { ConversationTurn, FindingContext } from "../../hooks/useVoiceIntent";
 import type { IRActionType, IRActionResult } from "../../types/ir";
 import { ACTION_META } from "../../types/ir";
 
@@ -111,26 +113,6 @@ function sevColor(s: string) { return SEV_COLOR[(s ?? "").toUpperCase()] ?? "#64
 
 function newSessionId(): string {
   return `argus-${Date.now().toString(36).slice(-4)}-${Math.random().toString(36).slice(2, 5)}`;
-}
-
-// ── Intent matching ───────────────────────────────────────────────────────────
-function matchIntent(input: string): string {
-  const t = input.toLowerCase().trim();
-  if (/\b(brief|briefing|situation|status|sitrep|what('s| is) (going on|happening|the situation))\b/.test(t)) return "briefing";
-  if (/\b(critical|crit findings?|show critical|critical alerts?)\b/.test(t)) return "critical";
-  if (/\b(threat level|threat assessment|current threat)\b/.test(t)) return "threat";
-  if (/\b(sla|breach|breached|overdue)\b/.test(t)) return "sla";
-  if (/\b(latest|new findings?|recent|last scan)\b/.test(t)) return "latest";
-  if (/\b(show findings?|list findings?|findings? list|all findings?)\b/.test(t)) return "show_findings";
-  if (/\b(compliance|score|posture|frameworks?)\b/.test(t)) return "compliance";
-  if (/\b(scan|run scan|start scan)\b/.test(t)) return "scan";
-  if (/\b(help|commands?|what can you)\b/.test(t)) return "help";
-  if (/\b(high (risk|findings?|severity)|high risk)\b/.test(t)) return "high";
-  if (/\b(isolate|contain|lock down|quarantine)\b/.test(t)) return "isolate";
-  if (/\b(revoke|delete key|remove key|kill key)\b/.test(t)) return "revoke";
-  if (/\b(disable key|deactivate key|suspend key)\b/.test(t)) return "disable_key";
-  if (/\b(go to|navigate|open|take me)\b/.test(t)) return "navigate";
-  return "unknown";
 }
 
 // ── Response builder ──────────────────────────────────────────────────────────
@@ -733,6 +715,8 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
   const [pendingConfirm, setPendingConfirm] = useState<IRConfirmData | null>(null);
   const [sessionId,    setSessionId]    = useState(() => newSessionId());
 
+  const { resolveIntent, isThinking } = useVoiceIntent();
+
   const recognitionRef     = useRef<any>(null);
   const synthRef           = useRef<SpeechSynthesis | null>(null);
   const processing         = useRef(false);
@@ -1000,7 +984,7 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
   }, []);
 
   // ── Process command ─────────────────────────────────────────────────────────
-  const processCommand = useCallback((input: string, confidence?: number) => {
+  const processCommand = useCallback(async (input: string, confidence?: number) => {
     if (processing.current || !input.trim()) return;
 
     // Intercept confirmation responses first
@@ -1016,44 +1000,80 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
     setStatus("processing");
     setPartial("");
 
-    const intent = matchIntent(input);
-
+    // Immediate feedback: user bubble and STT audit appear before async work
     pushAudit({ type: "stt", content: input.trim(), confidence, sessionId: lastSessionRef.current });
-
-    // Navigation side-effect
-    if (intent === "navigate") {
-      const navMap: Record<string, string> = {
-        iam: "iam-security", guardduty: "guardduty", alerts: "alerts",
-        "security hub": "security-hub", compliance: "grc", reports: "reports",
-        ec2: "ec2-security", s3: "s3-security", vpc: "vpc-security",
-        soc: "soc", infra: "infra-security", macie: "macie",
-      };
-      const lower = input.toLowerCase();
-      for (const [k, v] of Object.entries(navMap)) {
-        if (lower.includes(k)) { onNavigate?.(v); break; }
-      }
-    }
-
-    pushAudit({ type: "intent", content: intent.toUpperCase().replace(/_/g, " "), sessionId: lastSessionRef.current });
     setMessages(p => [...p, { id: `u-${Date.now()}`, role: "user" as const, text: input.trim(), ts: Date.now() }]);
 
-    setTimeout(() => {
-      const response = buildResponse(intent, stats, findings, input);
-      setMessages(p => [...p, { id: `r-${Date.now()}`, role: "agent" as const, response, ts: Date.now() }]);
-      pushAudit({ type: "tts", content: response.spokenText, sessionId: lastSessionRef.current });
-      processing.current = false;
-      void speak(response.spokenText);
+    // Build context window for Bedrock (last 3 turns with readable text)
+    const contextTurns: ConversationTurn[] = messages
+      .filter(m => (m.role === "user" || m.role === "agent") && (m.text || m.response?.spokenText))
+      .slice(-3)
+      .map(m => ({
+        role: m.role as "user" | "agent",
+        text: m.text ?? m.response?.spokenText ?? "",
+      }));
 
-      // ── LLM enrichment for intelligence-gathering intents ────────────────
+    const topFinding =
+      findings.find(f => (f.severity ?? "").toUpperCase() === "CRITICAL") ??
+      findings.find(f => (f.severity ?? "").toUpperCase() === "HIGH") ??
+      findings[0] ?? null;
+
+    const findingCtx: FindingContext | null = topFinding ? {
+      id:           String(topFinding.id ?? topFinding.finding_id ?? "unknown"),
+      severity:     topFinding.severity,
+      finding_type: topFinding.finding_type ?? topFinding.title,
+      resource_name: topFinding.resource_name ?? topFinding.resource_arn,
+      service:      topFinding.service,
+    } : null;
+
+    try {
+      // Two-tier intent resolution: regex fast-path → Bedrock fallback
+      const resolved = await resolveIntent(input, contextTurns, findingCtx);
+      const intent = resolved.intent;
+
+      // Navigation side-effect (unchanged)
+      if (intent === "navigate") {
+        const navMap: Record<string, string> = {
+          iam: "iam-security", guardduty: "guardduty", alerts: "alerts",
+          "security hub": "security-hub", compliance: "grc", reports: "reports",
+          ec2: "ec2-security", s3: "s3-security", vpc: "vpc-security",
+          soc: "soc", infra: "infra-security", macie: "macie",
+        };
+        const lower = input.toLowerCase();
+        for (const [k, v] of Object.entries(navMap)) {
+          if (lower.includes(k)) { onNavigate?.(v); break; }
+        }
+      }
+
+      // Audit the resolved intent (note Bedrock source for traceability)
+      const intentLabel = resolved.source === "bedrock"
+        ? `${intent.toUpperCase().replace(/_/g, " ")} [BEDROCK ${Math.round((resolved.confidence ?? 0) * 100)}%]`
+        : intent.toUpperCase().replace(/_/g, " ");
+      pushAudit({ type: "intent", content: intentLabel, sessionId: lastSessionRef.current });
+
+      // Build response card; Bedrock spoken_reply overrides spokenText for TTS
+      const response = buildResponse(intent, stats, findings, input);
+      const spokenText = resolved.spokenReply ?? response.spokenText;
+
+      setMessages(p => [...p, {
+        id: `r-${Date.now()}`, role: "agent" as const,
+        response: { ...response, spokenText },
+        ts: Date.now(),
+      }]);
+      pushAudit({ type: "tts", content: spokenText, sessionId: lastSessionRef.current });
+      processing.current = false;
+      void speak(spokenText);
+
+      // ── LLM enrichment for intelligence-gathering intents (unchanged) ────
       if (["briefing", "critical", "threat"].includes(intent) && findings.length > 0) {
-        const topFinding =
+        const enrichFinding =
           findings.find(f => (f.severity ?? "").toUpperCase() === "CRITICAL") ??
           findings.find(f => (f.severity ?? "").toUpperCase() === "HIGH") ??
           findings[0];
-        if (topFinding) void fetchLLMBriefing(topFinding);
+        if (enrichFinding) void fetchLLMBriefing(enrichFinding);
       }
 
-      // ── Inline finding cards for list intent ─────────────────────────────
+      // ── Inline finding cards for list intent (unchanged) ─────────────────
       if (intent === "show_findings" && findings.length > 0) {
         const snippets: FindingSnippet[] = findings.slice(0, 6).map((f, i) => ({
           id:       String(f.id ?? f.finding_id ?? i),
@@ -1070,7 +1090,7 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
         }]);
       }
 
-      // ── IR action confirmation flow ───────────────────────────────────────
+      // ── IR confirmation (unchanged — always gated regardless of source) ──
       if (["isolate", "revoke", "disable_key"].includes(intent) && findings.length > 0) {
         const irFinding =
           findings.find(f => (f.severity ?? "").toUpperCase() === "CRITICAL") ??
@@ -1080,8 +1100,11 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
           setTimeout(() => showIRConfirm(intent, irFinding), 400);
         }
       }
-    }, 240 + Math.random() * 280);
-  }, [stats, findings, speak, onNavigate, pushAudit, handleConfirmResponse, fetchLLMBriefing, showIRConfirm]);
+    } catch {
+      processing.current = false;
+      setStatus("standby");
+    }
+  }, [stats, findings, messages, speak, onNavigate, pushAudit, handleConfirmResponse, fetchLLMBriefing, showIRConfirm, resolveIntent]);
 
   // ── Push-to-talk ────────────────────────────────────────────────────────────
   const startListening = useCallback(() => {
@@ -1098,7 +1121,7 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
       setPartial(last[0].transcript);
       if (last.isFinal) {
         r.stop();
-        processCommand(last[0].transcript, last[0].confidence ?? undefined);
+        void processCommand(last[0].transcript, last[0].confidence ?? undefined);
       }
     };
     r.onerror = (e: any) => {
@@ -1292,7 +1315,7 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
                 {quickCmds.map(({ label, cmd, color }) => (
                   <button
                     key={cmd}
-                    onClick={() => processCommand(cmd)}
+                    onClick={() => { void processCommand(cmd); }}
                     disabled={voiceBusy}
                     style={{ fontSize: 8, fontWeight: 700, letterSpacing: "0.1em", color, background: `${color}09`, border: `1px solid ${color}20`, borderRadius: 4, padding: "3px 8px", cursor: "pointer", fontFamily: "'JetBrains Mono', monospace", opacity: voiceBusy ? 0.3 : 1, transition: "all 0.1s" }}
                     onMouseEnter={e => { e.currentTarget.style.background = `${color}18`; e.currentTarget.style.borderColor = `${color}38`; }}
@@ -1370,7 +1393,7 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
                 {status === "processing" && (
                   <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "6px 10px", background: "rgba(167,139,250,0.05)", border: "1px solid rgba(167,139,250,0.12)", borderTop: "2px solid rgba(167,139,250,0.5)", borderRadius: 6 }}>
                     <span style={{ fontSize: 7.5, color: "#a78bfa", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.12em" }}>
-                      {pendingConfirm ? "AWAITING RESPONSE" : "ANALYZING"}
+                      {pendingConfirm ? "AWAITING RESPONSE" : isThinking ? "ARGUS THINKING…" : "ANALYZING"}
                     </span>
                     {[0, 0.14, 0.28].map((d, i) => (
                       <div key={i} style={{ width: 3, height: 3, borderRadius: "50%", background: "#a78bfa", animation: `argus-pulse 0.8s ease-in-out ${d}s infinite` }} />
@@ -1388,7 +1411,7 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
                       value={textInput}
                       onChange={e => { setTextInput(e.target.value); if (e.target.value) setInputMode("text"); }}
                       onFocus={() => setInputMode("text")}
-                      onKeyDown={e => { if (e.key === "Enter" && textInput.trim()) { processCommand(textInput); setTextInput(""); } }}
+                      onKeyDown={e => { if (e.key === "Enter" && textInput.trim()) { void processCommand(textInput); setTextInput(""); } }}
                       placeholder={
                         pendingConfirm
                           ? `Confirm or cancel ${pendingConfirm.label}…`
@@ -1409,7 +1432,7 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
                   </div>
                   {/* Send button */}
                   <button
-                    onClick={() => { if (textInput.trim()) { processCommand(textInput); setTextInput(""); } }}
+                    onClick={() => { if (textInput.trim()) { void processCommand(textInput); setTextInput(""); } }}
                     disabled={!textInput.trim() || status === "processing"}
                     style={{
                       height: 30, paddingInline: 12, borderRadius: 6, cursor: textInput.trim() ? "pointer" : "default",

--- a/src/components/ir/VoiceIRAgent.tsx
+++ b/src/components/ir/VoiceIRAgent.tsx
@@ -1,0 +1,1041 @@
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import { Mic, MicOff, Volume2, Zap, X, Download, Trash2 } from "lucide-react";
+import { useActiveScanResults } from "../../hooks/useActiveScanResults";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+type AgentStatus   = "standby" | "listening" | "processing" | "speaking" | "error";
+type ResponsePriority = "critical" | "high" | "warning" | "normal" | "success";
+type PanelTab      = "live" | "audit";
+
+interface ResponseField { label: string; value: string; color?: string }
+interface ResponseItem  { text: string; sub?: string; action?: string; color?: string }
+interface AgentResponse {
+  classification: string;
+  priority: ResponsePriority;
+  fields?: ResponseField[];
+  items?: ResponseItem[];
+  spokenText: string;
+}
+
+interface Message {
+  id: string;
+  role: "user" | "agent" | "system";
+  ts: number;
+  text?: string;
+  response?: AgentResponse;
+}
+
+// Audit log entry — every voice event recorded here
+interface AuditEntry {
+  id: string;
+  ts: number;
+  type: "stt" | "tts" | "intent" | "sys";
+  content: string;
+  confidence?: number;   // 0–1, from Web Speech API
+  sessionId: string;
+}
+
+export interface VoiceIRAgentProps { onNavigate?: (tab: string) => void }
+
+interface DerivedStats {
+  total: number; critical: number; high: number; medium: number;
+  slaBreached: number; threatLabel: string; threatColor: string;
+}
+
+// ── Priority palette ──────────────────────────────────────────────────────────
+const PRIO: Record<ResponsePriority, { color: string; bg: string; border: string; label: string }> = {
+  critical: { color: "#ff0040", bg: "rgba(255,0,64,0.08)",   border: "rgba(255,0,64,0.22)",   label: "CRITICAL" },
+  high:     { color: "#ff6b35", bg: "rgba(255,107,53,0.07)", border: "rgba(255,107,53,0.2)",  label: "HIGH"     },
+  warning:  { color: "#ffb000", bg: "rgba(255,176,0,0.06)",  border: "rgba(255,176,0,0.18)",  label: "WARNING"  },
+  normal:   { color: "#00d4ff", bg: "rgba(0,212,255,0.06)",  border: "rgba(0,212,255,0.15)",  label: "INFO"     },
+  success:  { color: "#00ff88", bg: "rgba(0,255,136,0.06)",  border: "rgba(0,255,136,0.18)",  label: "CLEAR"    },
+};
+
+// ── Session ID ────────────────────────────────────────────────────────────────
+function newSessionId(): string {
+  return `argus-${Date.now().toString(36).slice(-4)}-${Math.random().toString(36).slice(2, 5)}`;
+}
+
+// ── Intent matching ───────────────────────────────────────────────────────────
+function matchIntent(input: string): string {
+  const t = input.toLowerCase().trim();
+  if (/\b(brief|briefing|situation|status|sitrep|what('s| is) (going on|happening|the situation))\b/.test(t)) return "briefing";
+  if (/\b(critical|crit findings?|show critical|critical alerts?)\b/.test(t)) return "critical";
+  if (/\b(threat level|threat assessment|current threat)\b/.test(t)) return "threat";
+  if (/\b(sla|breach|breached|overdue)\b/.test(t)) return "sla";
+  if (/\b(latest|new findings?|recent|last scan)\b/.test(t)) return "latest";
+  if (/\b(compliance|score|posture|frameworks?)\b/.test(t)) return "compliance";
+  if (/\b(scan|run scan|start scan)\b/.test(t)) return "scan";
+  if (/\b(help|commands?|what can you)\b/.test(t)) return "help";
+  if (/\b(high (risk|findings?|severity)|high risk)\b/.test(t)) return "high";
+  if (/\b(isolate|contain|lock down|quarantine)\b/.test(t)) return "isolate";
+  if (/\b(go to|navigate|open|take me)\b/.test(t)) return "navigate";
+  return "unknown";
+}
+
+// ── Response builder ──────────────────────────────────────────────────────────
+function buildResponse(intent: string, stats: DerivedStats, findings: any[], _raw: string): AgentResponse {
+  const tz = new Date().toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false });
+
+  switch (intent) {
+    case "briefing": {
+      const p: ResponsePriority = stats.critical > 0 ? "critical" : stats.high > 2 ? "high" : stats.total > 0 ? "warning" : "success";
+      return {
+        classification: "SITREP", priority: p,
+        fields: [
+          { label: "THREAT",   value: stats.threatLabel,                                  color: stats.threatColor },
+          { label: "OPEN",     value: String(stats.total),                                color: stats.total > 0 ? "#ff6b35" : "#00ff88" },
+          { label: "CRITICAL", value: String(stats.critical),                             color: stats.critical > 0 ? "#ff0040" : "#00ff88" },
+          { label: "HIGH",     value: String(stats.high),                                 color: stats.high > 0 ? "#ff6b35" : "#00ff88" },
+          { label: "SLA",      value: stats.slaBreached > 0 ? `${stats.slaBreached} BREACH` : "OK", color: stats.slaBreached > 0 ? "#ff0040" : "#00ff88" },
+          { label: "TIME",     value: `${tz}Z`,                                           color: "rgba(100,116,139,0.6)" },
+        ],
+        items: stats.critical > 0
+          ? findings.filter(f => (f.severity ?? "").toUpperCase() === "CRITICAL").slice(0, 3).map(f => ({
+              text: f.finding_type ?? f.title ?? "Unnamed finding",
+              sub: f.resource_arn?.split(":").slice(-1)[0] ?? f.resource_name ?? "Unknown resource",
+              action: "TRIAGE IMMEDIATELY", color: "#ff0040",
+            }))
+          : undefined,
+        spokenText: stats.critical > 0
+          ? `Situation report at ${tz}. Threat level is ${stats.threatLabel}. ${stats.total} open findings. ${stats.critical} critical require immediate action. ${stats.slaBreached > 0 ? `${stats.slaBreached} SLA breach active.` : ""} Initiate containment now.`
+          : `Situation report at ${tz}. Threat level ${stats.threatLabel}. ${stats.total} open findings. ${stats.high > 0 ? `${stats.high} high severity in triage.` : "No critical threats."} Standard monitoring cadence.`,
+      };
+    }
+    case "critical": {
+      const crits = findings.filter(f => (f.severity ?? "").toUpperCase() === "CRITICAL");
+      if (stats.critical === 0) return {
+        classification: "CRITICAL FINDINGS", priority: "success",
+        fields: [{ label: "STATUS", value: "NONE ACTIVE", color: "#00ff88" }, { label: "TIME", value: `${tz}Z`, color: "rgba(100,116,139,0.6)" }],
+        spokenText: `No critical findings in queue at ${tz}. Critical tier is clean.`,
+      };
+      return {
+        classification: "CRITICAL FINDINGS", priority: "critical",
+        fields: [
+          { label: "COUNT",  value: String(stats.critical), color: "#ff0040" },
+          { label: "SLA",    value: "4H WINDOW",            color: "#ffb000" },
+          { label: "ACTION", value: "IMMEDIATE",            color: "#ff0040" },
+        ],
+        items: crits.slice(0, 4).map((f, i) => ({
+          text: f.finding_type ?? f.title ?? `Critical Finding ${i + 1}`,
+          sub: f.resource_arn?.split(":").slice(-1)[0] ?? f.resource_name ?? f.region ?? "us-east-1",
+          action: f.service === "iam" ? "REVOKE + AUDIT" : f.service === "ec2" ? "ISOLATE INSTANCE" : f.service === "s3" ? "BLOCK PUBLIC ACCESS" : "TRIAGE NOW",
+          color: "#ff0040",
+        })),
+        spokenText: `${stats.critical} critical findings active at ${tz}. ${crits.slice(0, 2).map((f, i) => `Finding ${i + 1}: ${f.finding_type ?? "Unnamed"}`).join(". ")}. Immediate response required.`,
+      };
+    }
+    case "threat": {
+      const p: ResponsePriority = stats.threatLabel === "CRITICAL" ? "critical" : stats.threatLabel === "HIGH" ? "high" : stats.threatLabel === "GUARDED" ? "warning" : "success";
+      return {
+        classification: "THREAT ASSESSMENT", priority: p,
+        fields: [
+          { label: "LEVEL",    value: stats.threatLabel,      color: stats.threatColor },
+          { label: "CRITICAL", value: String(stats.critical), color: stats.critical > 0 ? "#ff0040" : "#00ff88" },
+          { label: "HIGH",     value: String(stats.high),     color: stats.high > 0 ? "#ff6b35" : "#00ff88" },
+          { label: "TOTAL",    value: String(stats.total),    color: "rgba(148,163,184,0.8)" },
+          { label: "TIME",     value: `${tz}Z`,               color: "rgba(100,116,139,0.6)" },
+        ],
+        items: stats.critical > 0 ? [{ text: "Elevated response cadence required", action: "DECLARE INCIDENT", color: "#ff0040" }] : undefined,
+        spokenText: `Threat level ${stats.threatLabel} at ${tz}. ${stats.total} open findings — ${stats.critical} critical, ${stats.high} high. ${stats.critical > 0 ? "Elevated response and incident declaration recommended." : "Standard protocols sufficient."}`,
+      };
+    }
+    case "sla":
+      if (stats.slaBreached === 0) return {
+        classification: "SLA STATUS", priority: "success",
+        fields: [
+          { label: "STATUS",  value: "COMPLIANT",  color: "#00ff88" },
+          { label: "CRIT",    value: "4H WINDOW",  color: "rgba(148,163,184,0.6)" },
+          { label: "HIGH",    value: "24H WINDOW", color: "rgba(148,163,184,0.6)" },
+          { label: "MEDIUM",  value: "7D WINDOW",  color: "rgba(148,163,184,0.6)" },
+        ],
+        spokenText: `All incidents within SLA at ${tz}. Critical window 4 hours. High 24 hours. Fully compliant.`,
+      };
+      return {
+        classification: "SLA BREACH", priority: "critical",
+        fields: [
+          { label: "BREACHED", value: String(stats.slaBreached), color: "#ff0040" },
+          { label: "ACTION",   value: "ESCALATE NOW",            color: "#ff0040" },
+          { label: "TIME",     value: `${tz}Z`,                  color: "rgba(100,116,139,0.6)" },
+        ],
+        items: [
+          { text: "Escalate to SOC leadership immediately",       action: "PAGE INCIDENT COMMANDER", color: "#ff0040" },
+          { text: "Document all response actions with timestamps", action: "UPDATE TICKET",           color: "#ffb000" },
+        ],
+        spokenText: `SLA breach at ${tz}. ${stats.slaBreached} incident${stats.slaBreached > 1 ? "s" : ""} exceeded response window. Escalate to SOC leadership immediately.`,
+      };
+    case "latest": {
+      const recent = findings.slice(0, 4);
+      if (!recent.length) return {
+        classification: "RECENT FINDINGS", priority: "success",
+        fields: [{ label: "STATUS", value: "QUEUE EMPTY", color: "#00ff88" }],
+        spokenText: `No findings in queue. Run a full scan to refresh.`,
+      };
+      return {
+        classification: "RECENT FINDINGS",
+        priority: recent[0] && (recent[0].severity ?? "").toUpperCase() === "CRITICAL" ? "critical" : "normal",
+        fields: [{ label: "COUNT", value: String(recent.length), color: "#00d4ff" }, { label: "TIME", value: `${tz}Z`, color: "rgba(100,116,139,0.6)" }],
+        items: recent.map(f => {
+          const sev = (f.severity ?? "MEDIUM").toUpperCase();
+          const c = sev === "CRITICAL" ? "#ff0040" : sev === "HIGH" ? "#ff6b35" : sev === "MEDIUM" ? "#ffb000" : "#00ff88";
+          return { text: f.finding_type ?? f.title ?? "Unnamed", sub: `${sev} · ${f.region ?? "us-east-1"}`, color: c };
+        }),
+        spokenText: `${recent.length} recent findings. ${recent.slice(0, 2).map(f => `${(f.severity ?? "medium").toLowerCase()}: ${f.finding_type ?? "unnamed"}`).join(". ")}. Triage in priority order.`,
+      };
+    }
+    case "compliance":
+      return {
+        classification: "COMPLIANCE STATUS", priority: stats.critical > 0 ? "warning" : "success",
+        fields: [
+          { label: "SOC 2",   value: "TYPE II", color: "#00ff88" },
+          { label: "CIS",     value: "v8",      color: "#00ff88" },
+          { label: "NIST",    value: "CSF 2.0", color: "#00ff88" },
+          { label: "PCI DSS", value: "4.0",     color: "#00ff88" },
+        ],
+        items: stats.critical > 0 ? [{ text: "Critical findings degrading compliance posture", action: "REMEDIATE BEFORE AUDIT", color: "#ffb000" }] : undefined,
+        spokenText: `Compliance under active assessment across SOC 2, CIS, NIST, and PCI DSS. ${stats.critical > 0 ? "Critical findings are degrading posture." : "Posture tracking within target bands."}`,
+      };
+    case "high": {
+      const highs = findings.filter(f => (f.severity ?? "").toUpperCase() === "HIGH");
+      if (stats.high === 0) return {
+        classification: "HIGH FINDINGS", priority: "success",
+        fields: [{ label: "STATUS", value: "NONE ACTIVE", color: "#00ff88" }],
+        spokenText: `No high-severity findings at ${tz}. High-risk tier clean.`,
+      };
+      return {
+        classification: "HIGH FINDINGS", priority: "high",
+        fields: [
+          { label: "COUNT", value: String(stats.high), color: "#ff6b35" },
+          { label: "SLA",   value: "24H WINDOW",       color: "#ffb000" },
+        ],
+        items: highs.slice(0, 3).map(f => ({
+          text: f.finding_type ?? f.title ?? "Unnamed",
+          sub: f.resource_arn?.split(":").slice(-1)[0] ?? f.region ?? "us-east-1",
+          color: "#ff6b35",
+        })),
+        spokenText: `${stats.high} high-severity findings at ${tz}. 24-hour SLA. ${stats.high > 3 ? "Volume elevated — assign dedicated responders." : "Load manageable."}`,
+      };
+    }
+    case "isolate":
+      return {
+        classification: "CONTAINMENT REQUEST", priority: "warning",
+        fields: [{ label: "STATUS", value: "APPROVAL REQUIRED", color: "#ffb000" }],
+        items: [
+          { text: "Navigate to IR Mode on Security Overview", action: "SELECT TARGET FINDING", color: "#00d4ff" },
+          { text: "Execute via IR Action Engine",             action: "REQUIRES SR. ENGINEER",  color: "#ffb000" },
+        ],
+        spokenText: `Containment requires senior engineer approval. Navigate to IR Mode, select the target finding, and execute via the Action Engine.`,
+      };
+    case "scan":
+      return {
+        classification: "SCAN INITIATED", priority: "normal",
+        fields: [
+          { label: "SCOPE",  value: "FULL",        color: "#00d4ff" },
+          { label: "TARGET", value: "ALL REGIONS", color: "#00d4ff" },
+          { label: "ETA",    value: "45–90 SEC",   color: "#00d4ff" },
+        ],
+        items: [
+          { text: "IAM · EC2 · S3 · VPC",             color: "rgba(148,163,184,0.6)" },
+          { text: "GuardDuty · Security Hub · Config", color: "rgba(148,163,184,0.6)" },
+        ],
+        spokenText: `Full security scan initiated at ${tz}. Scanning all services across active regions. Estimated completion 45 to 90 seconds.`,
+      };
+    case "navigate":
+      return {
+        classification: "NAVIGATION", priority: "normal",
+        fields: [],
+        items: [
+          { text: "IAM · Access Analyzer",    sub: "iam, access analyzer"    },
+          { text: "GuardDuty · Security Hub", sub: "guardduty, security hub" },
+          { text: "Alerts · Compliance",      sub: "alerts, compliance"      },
+          { text: "SOC · Infra · Reports",    sub: "soc, infra, reports"     },
+        ],
+        spokenText: `Navigation available. Say the page name such as IAM, GuardDuty, alerts, or compliance.`,
+      };
+    case "help":
+      return {
+        classification: "COMMAND REFERENCE", priority: "normal",
+        fields: [],
+        items: [
+          { text: "Brief me",            sub: "full situational report",    color: "rgba(148,163,184,0.8)" },
+          { text: "Critical findings",   sub: "active critical alerts",     color: "#ff0040" },
+          { text: "Threat level",        sub: "current threat assessment",  color: "#ff6b35" },
+          { text: "SLA status",          sub: "breach and compliance info", color: "#ffb000" },
+          { text: "High risk",           sub: "high severity findings",     color: "#ff6b35" },
+          { text: "Compliance",          sub: "framework posture",          color: "#00ff88" },
+          { text: "Run scan",            sub: "full environment scan",      color: "#00d4ff" },
+          { text: "Isolate",             sub: "containment request",        color: "#ffb000" },
+          { text: "Navigate to [page]",  sub: "jump to any section",        color: "#00d4ff" },
+        ],
+        spokenText: `Available commands: brief me, critical findings, threat level, SLA status, high risk, compliance, run scan, isolate, and navigate to any page. Standing by.`,
+      };
+    default:
+      return {
+        classification: "UNRECOGNIZED", priority: "normal",
+        fields: [],
+        items: [{ text: "Command not recognized", sub: `Say "help" for command list`, color: "rgba(100,116,139,0.5)" }],
+        spokenText: `Command not recognized. Say "help" for available commands. Standing by.`,
+      };
+  }
+}
+
+// ── Waveform ──────────────────────────────────────────────────────────────────
+function Waveform({ active, color, count = 28 }: { active: boolean; color: string; count?: number }) {
+  const [h, setH] = useState<number[]>(() => Array(count).fill(2));
+  const t = useRef<ReturnType<typeof setInterval> | null>(null);
+  useEffect(() => {
+    if (active) {
+      t.current = setInterval(() => setH(Array(count).fill(0).map((_, i) => {
+        const center = Math.abs(i - count / 2) / (count / 2);
+        const max = Math.round(22 - center * 6);
+        return Math.floor(Math.random() * max) + 3;
+      })), 75);
+    } else {
+      if (t.current) clearInterval(t.current);
+      setH(Array(count).fill(2));
+    }
+    return () => { if (t.current) clearInterval(t.current); };
+  }, [active, count]);
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 1.5, height: 28 }}>
+      {h.map((v, i) => (
+        <div key={i} style={{
+          width: 2.5, height: v, borderRadius: 1.5,
+          background: active ? color : "rgba(100,116,139,0.12)",
+          opacity: active ? 0.35 + (v / 24) * 0.65 : 1,
+          transition: active ? "height 0.075s ease" : "height 0.5s ease",
+        }} />
+      ))}
+    </div>
+  );
+}
+
+function MiniWave({ active, color }: { active: boolean; color: string }) {
+  const [h, setH] = useState([2, 4, 5, 4, 2]);
+  const t = useRef<ReturnType<typeof setInterval> | null>(null);
+  useEffect(() => {
+    if (active) {
+      t.current = setInterval(() => setH([
+        Math.floor(Math.random() * 8) + 2, Math.floor(Math.random() * 12) + 4,
+        Math.floor(Math.random() * 14) + 5, Math.floor(Math.random() * 12) + 4,
+        Math.floor(Math.random() * 8) + 2,
+      ]), 80);
+    } else {
+      if (t.current) clearInterval(t.current);
+      setH([2, 4, 5, 4, 2]);
+    }
+    return () => { if (t.current) clearInterval(t.current); };
+  }, [active]);
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 1, height: 14 }}>
+      {h.map((v, i) => (
+        <div key={i} style={{ width: 2, height: v, borderRadius: 1, background: active ? color : "rgba(100,116,139,0.25)", transition: "height 0.075s ease" }} />
+      ))}
+    </div>
+  );
+}
+
+const STATUS_CFG: Record<AgentStatus, { label: string; color: string }> = {
+  standby:    { label: "STANDBY",    color: "#475569" },
+  listening:  { label: "LISTENING",  color: "#00d4ff" },
+  processing: { label: "PROCESSING", color: "#a78bfa" },
+  speaking:   { label: "SPEAKING",   color: "#00ff88" },
+  error:      { label: "ERROR",      color: "#ff0040" },
+};
+
+// ── Response card ─────────────────────────────────────────────────────────────
+function ResponseCard({ response, ts, onSpeak }: { response: AgentResponse; ts: number; onSpeak?: () => void }) {
+  const p = PRIO[response.priority];
+  const [speaking, setSpeaking] = useState(false);
+  const timeStr = new Date(ts).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false });
+
+  function handleSpeak() {
+    if (!onSpeak) return;
+    setSpeaking(true);
+    onSpeak();
+    // reset icon after ~3s as a visual cue (actual TTS duration varies)
+    setTimeout(() => setSpeaking(false), 3000);
+  }
+
+  return (
+    <div style={{
+      background: "rgba(8,14,30,0.7)",
+      border: `1px solid ${p.border}`,
+      borderTop: `2px solid ${p.color}`,
+      borderRadius: 6,
+      overflow: "hidden",
+    }}>
+      {/* Card header */}
+      <div style={{
+        display: "flex", alignItems: "center", justifyContent: "space-between",
+        padding: "5px 10px",
+        background: p.bg, borderBottom: `1px solid ${p.border}`,
+      }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span style={{ fontSize: 7.5, fontWeight: 800, letterSpacing: "0.14em", color: p.color, fontFamily: "'JetBrains Mono', monospace" }}>{response.classification}</span>
+          <span style={{ fontSize: 6.5, fontWeight: 700, color: p.color, background: `${p.color}18`, border: `1px solid ${p.color}30`, borderRadius: 3, padding: "0 5px", lineHeight: "13px", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.1em" }}>{p.label}</span>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span style={{ fontSize: 7.5, color: "rgba(100,116,139,0.4)", fontFamily: "'JetBrains Mono', monospace" }}>ARGUS · {timeStr}Z</span>
+          {onSpeak && (
+            <button
+              onClick={handleSpeak}
+              title="Replay audio"
+              style={{
+                width: 18, height: 18, borderRadius: 3, border: "none", cursor: "pointer",
+                display: "flex", alignItems: "center", justifyContent: "center",
+                background: speaking ? `${p.color}18` : "transparent",
+                color: speaking ? p.color : "rgba(100,116,139,0.3)",
+                transition: "all 0.15s",
+              }}
+              onMouseEnter={e => { if (!speaking) { e.currentTarget.style.color = p.color; e.currentTarget.style.background = `${p.color}12`; } }}
+              onMouseLeave={e => { if (!speaking) { e.currentTarget.style.color = "rgba(100,116,139,0.3)"; e.currentTarget.style.background = "transparent"; } }}
+            >
+              <Volume2 size={9} style={{ animation: speaking ? "argus-pulse 0.85s ease-in-out infinite" : "none" }} />
+            </button>
+          )}
+        </div>
+      </div>
+      {/* Fields */}
+      {response.fields && response.fields.length > 0 && (
+        <div style={{
+          display: "grid",
+          gridTemplateColumns: `repeat(${Math.min(response.fields.length, 3)}, 1fr)`,
+          borderBottom: response.items?.length ? `1px solid rgba(255,255,255,0.05)` : "none",
+        }}>
+          {response.fields.map((f, i) => (
+            <div key={i} style={{
+              padding: "6px 10px",
+              borderRight: (i + 1) % Math.min(response.fields!.length, 3) !== 0 ? "1px solid rgba(255,255,255,0.05)" : "none",
+            }}>
+              <div style={{ fontSize: 7.5, color: "rgba(100,116,139,0.4)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.1em", marginBottom: 2 }}>{f.label}</div>
+              <div style={{ fontSize: 11, fontWeight: 700, color: f.color ?? "#e2e8f0", fontFamily: "'JetBrains Mono', monospace", lineHeight: 1.2 }}>{f.value}</div>
+            </div>
+          ))}
+        </div>
+      )}
+      {/* Items */}
+      {response.items && response.items.length > 0 && (
+        <div style={{ padding: "2px 0" }}>
+          {response.items.map((item, i) => (
+            <div key={i} style={{
+              display: "flex", alignItems: "flex-start", gap: 8, padding: "6px 10px",
+              borderBottom: i < response.items!.length - 1 ? "1px solid rgba(255,255,255,0.04)" : "none",
+            }}>
+              <span style={{ fontSize: 7.5, fontWeight: 700, color: item.color ?? "rgba(100,116,139,0.4)", fontFamily: "'JetBrains Mono', monospace", width: 10, flexShrink: 0, marginTop: 1.5 }}>{i + 1}.</span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 11, color: "#cbd5e1", lineHeight: 1.3, marginBottom: (item.sub || item.action) ? 3 : 0 }}>{item.text}</div>
+                {item.sub && <div style={{ fontSize: 9.5, color: "rgba(100,116,139,0.5)", fontFamily: "'JetBrains Mono', monospace", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{item.sub}</div>}
+                {item.action && (
+                  <div style={{ display: "inline-flex", alignItems: "center", gap: 3, fontSize: 7.5, fontWeight: 700, letterSpacing: "0.1em", color: item.color ?? "#00d4ff", background: `${item.color ?? "#00d4ff"}10`, border: `1px solid ${item.color ?? "#00d4ff"}22`, borderRadius: 3, padding: "1px 6px", marginTop: 3, fontFamily: "'JetBrains Mono', monospace" }}>
+                    → {item.action}
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Audit entry row ───────────────────────────────────────────────────────────
+const AUDIT_CFG = {
+  stt:    { label: "STT ↓", color: "#00d4ff",  bg: "rgba(0,212,255,0.05)",   border: "rgba(0,212,255,0.12)"  },
+  tts:    { label: "TTS ↑", color: "#00ff88",  bg: "rgba(0,255,136,0.04)",   border: "rgba(0,255,136,0.1)"   },
+  intent: { label: "INT",   color: "#a78bfa",  bg: "rgba(167,139,250,0.05)", border: "rgba(167,139,250,0.12)" },
+  sys:    { label: "SYS",   color: "#475569",  bg: "rgba(71,85,105,0.04)",   border: "rgba(71,85,105,0.1)"   },
+};
+
+function AuditRow({ entry, showSession }: { entry: AuditEntry; showSession: boolean }) {
+  const cfg = AUDIT_CFG[entry.type];
+  const timeStr = new Date(entry.ts).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false });
+  return (
+    <div>
+      {showSession && (
+        <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 0 4px" }}>
+          <div style={{ flex: 1, height: 1, background: "rgba(255,255,255,0.05)" }} />
+          <span style={{ fontSize: 7.5, color: "rgba(100,116,139,0.3)", fontFamily: "'JetBrains Mono', monospace", whiteSpace: "nowrap" }}>SESSION {entry.sessionId}</span>
+          <div style={{ flex: 1, height: 1, background: "rgba(255,255,255,0.05)" }} />
+        </div>
+      )}
+      <div style={{
+        display: "grid",
+        gridTemplateColumns: "52px 36px 1fr",
+        gap: 8,
+        padding: "5px 0",
+        alignItems: "flex-start",
+        borderBottom: "1px solid rgba(255,255,255,0.03)",
+      }}>
+        {/* Timestamp */}
+        <span style={{ fontSize: 8.5, color: "rgba(100,116,139,0.38)", fontFamily: "'JetBrains Mono', monospace", paddingTop: 1 }}>
+          {timeStr}
+        </span>
+
+        {/* Type badge */}
+        <span style={{
+          fontSize: 7, fontWeight: 700, letterSpacing: "0.1em",
+          color: cfg.color, background: cfg.bg, border: `1px solid ${cfg.border}`,
+          borderRadius: 3, padding: "1px 0", textAlign: "center" as const,
+          fontFamily: "'JetBrains Mono', monospace",
+          alignSelf: "flex-start",
+        }}>{cfg.label}</span>
+
+        {/* Content */}
+        <div style={{ minWidth: 0 }}>
+          <div style={{
+            fontSize: 10.5, color: entry.type === "stt" ? "#e2e8f0" : entry.type === "tts" ? "rgba(148,163,184,0.85)" : entry.type === "intent" ? "#a78bfa" : "rgba(100,116,139,0.5)",
+            lineHeight: 1.4, wordBreak: "break-word" as const,
+            fontFamily: entry.type === "intent" ? "'JetBrains Mono', monospace" : "inherit",
+            letterSpacing: entry.type === "intent" ? "0.06em" : "normal",
+          }}>
+            {entry.type === "stt" ? `"${entry.content}"` : entry.content}
+          </div>
+          {entry.confidence !== undefined && entry.type === "stt" && (
+            <div style={{ display: "flex", alignItems: "center", gap: 4, marginTop: 2 }}>
+              <span style={{ fontSize: 7.5, color: "rgba(100,116,139,0.35)", fontFamily: "'JetBrains Mono', monospace" }}>CONF</span>
+              <div style={{ width: 36, height: 2, background: "rgba(255,255,255,0.06)", borderRadius: 1, overflow: "hidden" }}>
+                <div style={{ height: "100%", width: `${entry.confidence * 100}%`, background: entry.confidence > 0.9 ? "#00ff88" : entry.confidence > 0.7 ? "#ffb000" : "#ff6b35", borderRadius: 1 }} />
+              </div>
+              <span style={{ fontSize: 7.5, fontWeight: 700, color: entry.confidence > 0.9 ? "#00ff88" : "#ffb000", fontFamily: "'JetBrains Mono', monospace" }}>{Math.round(entry.confidence * 100)}%</span>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
+  const [isOpen,    setIsOpen]    = useState(false);
+  const [tab,       setTab]       = useState<PanelTab>("live");
+  const [status,    setStatus]    = useState<AgentStatus>("standby");
+  const [messages,  setMessages]  = useState<Message[]>([
+    { id: "boot", role: "system", text: "ARGUS online — voice IR agent ready.", ts: Date.now() },
+  ]);
+  const [auditLog,  setAuditLog]  = useState<AuditEntry[]>([]);
+  const [partial,   setPartial]   = useState("");
+  const [textInput,  setTextInput]  = useState("");
+  const [inputMode,  setInputMode]  = useState<"voice" | "text">("voice");
+  const [hasMic,     setHasMic]     = useState(true);
+  const [sessionId, setSessionId] = useState(() => newSessionId());
+
+  const recognitionRef = useRef<any>(null);
+  const synthRef       = useRef<SpeechSynthesis | null>(null);
+  const processing     = useRef(false);
+  const liveScrollRef  = useRef<HTMLDivElement>(null);
+  const auditScrollRef = useRef<HTMLDivElement>(null);
+  const lastSessionRef = useRef<string>(sessionId);
+
+  // ── Live data ───────────────────────────────────────────────────────────────
+  const { getAllScanResults, scanResultsVersion } = useActiveScanResults();
+  const { findings, stats } = useMemo<{ findings: any[]; stats: DerivedStats }>(() => {
+    const results = getAllScanResults();
+    const all: any[] = results.flatMap((s: any) => s.findings ?? []);
+    const critical = all.filter(f => (f.severity ?? "").toUpperCase() === "CRITICAL").length;
+    const high     = all.filter(f => (f.severity ?? "").toUpperCase() === "HIGH").length;
+    const medium   = all.filter(f => (f.severity ?? "").toUpperCase() === "MEDIUM").length;
+    const slaBreached = all.filter((f: any) => {
+      const SLA: Record<string, number> = { CRITICAL: 4, HIGH: 24, MEDIUM: 168, LOW: 720 };
+      const sev = (f.severity ?? "MEDIUM").toUpperCase();
+      const ageH = f.created_at ? (Date.now() - new Date(f.created_at).getTime()) / 36e5 : 0;
+      return ageH > (SLA[sev] ?? 24);
+    }).length;
+    const threatLabel = critical > 0 ? "CRITICAL" : high > 2 ? "HIGH" : all.length > 0 ? "GUARDED" : "LOW";
+    const threatColor = critical > 0 ? "#ff0040" : high > 2 ? "#ff6b35" : all.length > 0 ? "#ffb000" : "#00ff88";
+    return { findings: all, stats: { total: all.length, critical, high, medium, slaBreached, threatLabel, threatColor } };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scanResultsVersion]);
+
+  const hasThreat = stats.critical > 0 || stats.slaBreached > 0;
+  const sc        = STATUS_CFG[status];
+  const isActive  = status === "listening" || status === "speaking";
+
+  // ── Init ────────────────────────────────────────────────────────────────────
+  useEffect(() => {
+    const SR = (window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition;
+    if (!SR) { setHasMic(false); setInputMode("text"); }
+    synthRef.current = window.speechSynthesis ?? null;
+    return () => { recognitionRef.current?.abort(); synthRef.current?.cancel(); };
+  }, []);
+
+  // New session + sys log on open
+  useEffect(() => {
+    if (isOpen) {
+      const sid = newSessionId();
+      setSessionId(sid);
+      lastSessionRef.current = sid;
+      pushAudit({ type: "sys", content: `Session started · threat ${stats.threatLabel} · ${stats.total} open findings`, sessionId: sid });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  // Keyboard shortcut: backtick
+  useEffect(() => {
+    const h = (e: KeyboardEvent) => {
+      if (e.key === "`" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+        const tag = (e.target as HTMLElement).tagName;
+        if (tag === "INPUT" || tag === "TEXTAREA") return;
+        e.preventDefault();
+        setIsOpen(o => !o);
+      }
+    };
+    window.addEventListener("keydown", h);
+    return () => window.removeEventListener("keydown", h);
+  }, []);
+
+  useEffect(() => { liveScrollRef.current?.scrollIntoView({ behavior: "smooth" }); }, [messages]);
+  useEffect(() => { auditScrollRef.current?.scrollIntoView({ behavior: "smooth" }); }, [auditLog]);
+
+  // ── Audit helpers ───────────────────────────────────────────────────────────
+  const pushAudit = useCallback((entry: Omit<AuditEntry, "id" | "ts">) => {
+    setAuditLog(prev => [...prev, { ...entry, id: `a-${Date.now()}-${Math.random().toString(36).slice(2, 5)}`, ts: Date.now() }]);
+  }, []);
+
+  // ── TTS ─────────────────────────────────────────────────────────────────────
+  const speak = useCallback((text: string) => {
+    if (!synthRef.current) return;
+    synthRef.current.cancel();
+    const utt = new SpeechSynthesisUtterance(text);
+    utt.rate = 1.0; utt.pitch = 0.82; utt.volume = 0.9;
+    const voices = synthRef.current.getVoices();
+    const voice = voices.find(v => /google uk english male/i.test(v.name))
+      ?? voices.find(v => /daniel/i.test(v.name))
+      ?? voices.find(v => v.lang === "en-GB") ?? voices[0];
+    if (voice) utt.voice = voice;
+    utt.onstart = () => setStatus("speaking");
+    utt.onend   = () => setStatus("standby");
+    utt.onerror = () => setStatus("standby");
+    synthRef.current.speak(utt);
+  }, []);
+
+  // ── Process command ─────────────────────────────────────────────────────────
+  const processCommand = useCallback((input: string, confidence?: number) => {
+    if (processing.current || !input.trim()) return;
+    processing.current = true;
+    setStatus("processing");
+    setPartial("");
+
+    const intent = matchIntent(input);
+
+    // Log STT
+    pushAudit({ type: "stt", content: input.trim(), confidence, sessionId: lastSessionRef.current });
+
+    // Navigate intent
+    if (intent === "navigate") {
+      const navMap: Record<string, string> = {
+        iam: "iam-security", guardduty: "guardduty", alerts: "alerts",
+        "security hub": "security-hub", compliance: "grc", reports: "reports",
+        ec2: "ec2-security", s3: "s3-security", vpc: "vpc-security",
+        soc: "soc", infra: "infra-security", macie: "macie",
+      };
+      const lower = input.toLowerCase();
+      for (const [k, v] of Object.entries(navMap)) {
+        if (lower.includes(k)) { onNavigate?.(v); break; }
+      }
+    }
+
+    // Log intent
+    pushAudit({ type: "intent", content: intent.toUpperCase().replace(/_/g, " "), sessionId: lastSessionRef.current });
+
+    setMessages(p => [...p, { id: `u-${Date.now()}`, role: "user", text: input.trim(), ts: Date.now() }]);
+
+    setTimeout(() => {
+      const response = buildResponse(intent, stats, findings, input);
+      setMessages(p => [...p, { id: `r-${Date.now()}`, role: "agent", response, ts: Date.now() }]);
+      // Log TTS
+      pushAudit({ type: "tts", content: response.spokenText, sessionId: lastSessionRef.current });
+      processing.current = false;
+      speak(response.spokenText);
+    }, 240 + Math.random() * 280);
+  }, [stats, findings, speak, onNavigate, pushAudit]);
+
+  // ── Speech recognition ──────────────────────────────────────────────────────
+  const startListening = useCallback(() => {
+    const SR = (window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition;
+    if (!SR) return;
+    recognitionRef.current?.abort();
+    const r = new SR();
+    r.lang = "en-US"; r.interimResults = true; r.continuous = false;
+    r.onstart  = () => setStatus("listening");
+    r.onresult = (e: any) => {
+      const last = e.results[e.results.length - 1];
+      setPartial(last[0].transcript);
+      if (last.isFinal) {
+        r.stop();
+        processCommand(last[0].transcript, last[0].confidence ?? undefined);
+      }
+    };
+    r.onerror  = (e: any) => { setStatus(e.error === "no-speech" ? "standby" : "error"); setTimeout(() => setStatus("standby"), 1000); };
+    r.onend    = () => { if (status === "listening") setStatus("standby"); };
+    recognitionRef.current = r;
+    r.start();
+  }, [processCommand, status]);
+
+  const handleMicToggle = useCallback(() => {
+    if (status === "listening")     { recognitionRef.current?.stop(); setStatus("standby"); }
+    else if (status === "speaking") { synthRef.current?.cancel(); setStatus("standby"); }
+    else                            startListening();
+  }, [status, startListening]);
+
+  // ── Audit export ────────────────────────────────────────────────────────────
+  const exportAudit = useCallback(() => {
+    const lines = auditLog.map(e => {
+      const t = new Date(e.ts).toISOString();
+      const conf = e.confidence !== undefined ? ` [conf:${Math.round(e.confidence * 100)}%]` : "";
+      return `${t} [${e.type.toUpperCase()}] [${e.sessionId}]${conf} ${e.content}`;
+    });
+    const blob = new Blob([lines.join("\n")], { type: "text/plain" });
+    const url  = URL.createObjectURL(blob);
+    const a    = document.createElement("a");
+    a.href = url;
+    a.download = `argus-audit-${new Date().toISOString().slice(0, 10)}.log`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, [auditLog]);
+
+  // ── Quick commands ──────────────────────────────────────────────────────────
+  const quickCmds = [
+    { label: "SITREP",    cmd: "brief me",                 color: "#00d4ff" },
+    { label: "CRITICAL",  cmd: "show critical findings",   color: "#ff0040" },
+    { label: "THREAT",    cmd: "what is the threat level", color: stats.critical > 0 ? "#ff0040" : "#ffb000" },
+    { label: "SLA",       cmd: "sla status",               color: stats.slaBreached > 0 ? "#ff0040" : "#00ff88" },
+    { label: "HIGH RISK", cmd: "high risk findings",       color: "#ff6b35" },
+    { label: "SCAN",      cmd: "run scan",                 color: "#00ff88" },
+  ] as const;
+
+  // Group audit entries by session for dividers
+  const auditWithDividers = useMemo(() => {
+    let lastSid = "";
+    return auditLog.map(e => {
+      const showSession = e.sessionId !== lastSid;
+      lastSid = e.sessionId;
+      return { entry: e, showSession };
+    });
+  }, [auditLog]);
+
+  return (
+    <>
+      <style>{`
+        @keyframes argus-pulse  { 0%,100%{opacity:1;} 50%{opacity:0.22;} }
+        @keyframes argus-threat { 0%,85%,100%{opacity:1;} 87%{opacity:0.08;} }
+        @keyframes argus-border { 0%,100%{box-shadow:0 0 0 1px rgba(0,212,255,0.12);} 50%{box-shadow:0 0 0 2px rgba(0,212,255,0.4);} }
+        .argus-threat  { animation: argus-threat 2s ease-in-out infinite; }
+        .argus-border  { animation: argus-border 2s ease-in-out infinite; }
+      `}</style>
+
+      {/* ── Header pill ── */}
+      <button
+        onClick={() => setIsOpen(o => !o)}
+        title="ARGUS Voice IR Agent (` to toggle)"
+        style={{
+          position: "relative", display: "flex", alignItems: "center", gap: 6,
+          height: 32, padding: "0 10px 0 8px", borderRadius: 6, cursor: "pointer",
+          overflow: "hidden", transition: "background 0.15s, border-color 0.15s",
+          background: isOpen ? "rgba(0,212,255,0.09)" : hasThreat ? "rgba(255,0,64,0.06)" : "rgba(255,255,255,0.03)",
+          border: `1px solid ${isOpen ? "rgba(0,212,255,0.3)" : hasThreat ? "rgba(255,0,64,0.22)" : "rgba(255,255,255,0.08)"}`,
+        }}
+        onMouseEnter={e => {
+          if (!isOpen) {
+            e.currentTarget.style.background = "rgba(0,212,255,0.07)";
+            e.currentTarget.style.borderColor = "rgba(0,212,255,0.22)";
+          }
+        }}
+        onMouseLeave={e => {
+          if (!isOpen) {
+            e.currentTarget.style.background = hasThreat ? "rgba(255,0,64,0.06)" : "rgba(255,255,255,0.03)";
+            e.currentTarget.style.borderColor = hasThreat ? "rgba(255,0,64,0.22)" : "rgba(255,255,255,0.08)";
+          }
+        }}
+      >
+        <div style={{ position: "absolute", left: 0, top: 0, bottom: 0, width: 2, borderRadius: "6px 0 0 6px", background: isActive ? sc.color : hasThreat ? "#ff0040" : "rgba(0,212,255,0.35)", transition: "background 0.3s" }} />
+
+        <span style={{ marginLeft: 4, display: "flex", alignItems: "center", color: isActive ? sc.color : hasThreat ? "#ff6b35" : "rgba(0,212,255,0.5)", transition: "color 0.2s" }}>
+          {isActive ? <MiniWave active color={sc.color} /> : status === "processing" ? <Zap size={11} style={{ animation: "spin 0.65s linear infinite" }} /> : <Mic size={11} />}
+        </span>
+
+        <span style={{ fontSize: 9.5, fontWeight: 700, letterSpacing: "0.15em", fontFamily: "'JetBrains Mono', monospace", color: isActive ? sc.color : "rgba(148,163,184,0.7)", transition: "color 0.2s" }}>ARGUS</span>
+
+        <span style={{ width: 4, height: 4, borderRadius: "50%", flexShrink: 0, background: sc.color, boxShadow: isActive ? `0 0 0 1px ${sc.color}40` : "none", animation: isActive ? "argus-pulse 0.85s ease-in-out infinite" : "none", transition: "background 0.2s" }} />
+
+        {hasThreat && (
+          <span className="argus-threat" style={{ fontSize: 7, fontWeight: 800, letterSpacing: "0.06em", color: "#ff0040", background: "rgba(255,0,64,0.1)", border: "1px solid rgba(255,0,64,0.25)", borderRadius: 999, padding: "0 4px", lineHeight: "14px", fontFamily: "'JetBrains Mono', monospace" }}>
+            {stats.critical}C
+          </span>
+        )}
+      </button>
+
+      {/* ── Panel ── */}
+      {isOpen && (
+        <div
+          className={isActive ? "argus-border" : ""}
+          style={{
+            position: "fixed", top: 64, right: 56, width: 440, zIndex: 9999,
+            display: "flex", flexDirection: "column",
+            background: "rgba(4,9,20,0.98)",
+            backdropFilter: "blur(28px) saturate(180%)",
+            border: `1px solid ${isActive ? "rgba(0,212,255,0.3)" : "rgba(0,212,255,0.12)"}`,
+            borderTop: `2px solid ${isActive ? sc.color : "rgba(0,212,255,0.4)"}`,
+            borderRadius: "0 0 10px 10px",
+            boxShadow: `0 0 0 1px rgba(0,212,255,0.04)`,
+            overflow: "hidden",
+            transition: "border-color 0.3s",
+          }}
+        >
+          {/* ── Top bar: wordmark + status + close ── */}
+          <div style={{ padding: "10px 14px", borderBottom: "1px solid rgba(255,255,255,0.055)", display: "flex", alignItems: "center", gap: 8 }}>
+            <span style={{ width: 6, height: 6, borderRadius: "50%", flexShrink: 0, background: sc.color, boxShadow: isActive ? `0 0 0 1px ${sc.color}40` : "none", animation: isActive ? "argus-pulse 0.85s ease-in-out infinite" : "none", transition: "all 0.3s" }} />
+            <span style={{ fontSize: 10.5, fontWeight: 700, color: "#00d4ff", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.18em" }}>ARGUS</span>
+            <span style={{ fontSize: 8, color: "rgba(100,116,139,0.38)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.06em" }}>VOICE IR AGENT</span>
+            <span style={{ fontSize: 7.5, fontWeight: 700, color: sc.color, background: `${sc.color}10`, border: `1px solid ${sc.color}22`, borderRadius: 3, padding: "1px 6px", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.12em", transition: "all 0.25s" }}>{sc.label}</span>
+            <div style={{ flex: 1 }} />
+            {stats.critical > 0 && <span style={{ fontSize: 8, fontWeight: 700, color: "#ff0040", background: "rgba(255,0,64,0.08)", border: "1px solid rgba(255,0,64,0.2)", borderRadius: 3, padding: "1px 5px", fontFamily: "'JetBrains Mono', monospace" }}>{stats.critical}C</span>}
+            {stats.high > 0    && <span style={{ fontSize: 8, fontWeight: 700, color: "#ff6b35", background: "rgba(255,107,53,0.07)", border: "1px solid rgba(255,107,53,0.18)", borderRadius: 3, padding: "1px 5px", fontFamily: "'JetBrains Mono', monospace" }}>{stats.high}H</span>}
+            <span style={{ fontSize: 8, color: "rgba(100,116,139,0.28)", fontFamily: "'JetBrains Mono', monospace" }}>{stats.total} open</span>
+            <button onClick={() => setIsOpen(false)} style={{ width: 22, height: 22, borderRadius: 4, background: "rgba(255,255,255,0.04)", border: "1px solid rgba(255,255,255,0.07)", color: "rgba(100,116,139,0.45)", cursor: "pointer", display: "flex", alignItems: "center", justifyContent: "center", marginLeft: 4 }}><X size={10} /></button>
+          </div>
+
+          {/* ── Tab bar ── */}
+          <div style={{
+            display: "flex",
+            borderBottom: "1px solid rgba(255,255,255,0.06)",
+            background: "rgba(0,3,10,0.4)",
+          }}>
+            {([
+              { id: "live",  label: "LIVE",      badge: null },
+              { id: "audit", label: "AUDIT LOG", badge: auditLog.length > 0 ? String(auditLog.length) : null },
+            ] as const).map(({ id, label, badge }) => {
+              const active = tab === id;
+              return (
+                <button
+                  key={id}
+                  onClick={() => setTab(id)}
+                  style={{
+                    flex: 1, padding: "8px 14px",
+                    display: "flex", alignItems: "center", justifyContent: "center", gap: 6,
+                    cursor: "pointer", background: "transparent", border: "none",
+                    borderBottom: active ? `2px solid #00d4ff` : "2px solid transparent",
+                    marginBottom: -1,
+                    transition: "all 0.15s",
+                  }}
+                >
+                  <span style={{ fontSize: 9, fontWeight: 700, letterSpacing: "0.12em", color: active ? "#00d4ff" : "rgba(100,116,139,0.4)", fontFamily: "'JetBrains Mono', monospace", transition: "color 0.15s" }}>{label}</span>
+                  {badge && (
+                    <span style={{ fontSize: 7, fontWeight: 700, color: active ? "#00d4ff" : "rgba(100,116,139,0.35)", background: active ? "rgba(0,212,255,0.1)" : "rgba(255,255,255,0.04)", border: `1px solid ${active ? "rgba(0,212,255,0.22)" : "rgba(255,255,255,0.07)"}`, borderRadius: 999, padding: "0 5px", lineHeight: "14px", fontFamily: "'JetBrains Mono', monospace", transition: "all 0.15s" }}>
+                      {badge}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* ══ LIVE TAB ════════════════════════════════════════════════════════ */}
+          {tab === "live" && (
+            <>
+              {/* Waveform */}
+              <div style={{ padding: "8px 14px", borderBottom: "1px solid rgba(255,255,255,0.05)", display: "flex", alignItems: "center", gap: 12, background: "rgba(0,5,14,0.4)", minHeight: 44, opacity: inputMode === "text" && !isActive ? 0.28 : 1, transition: "opacity 0.3s" }}>
+                <Waveform active={isActive} color={sc.color} />
+                {partial && status === "listening" && (
+                  <span style={{ flex: 1, fontSize: 10, color: "rgba(0,212,255,0.5)", fontFamily: "'JetBrains Mono', monospace", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>"{partial}"</span>
+                )}
+                {!isActive && (
+                  <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 6, flexShrink: 0 }}>
+                    <span style={{ fontSize: 7.5, color: "rgba(100,116,139,0.28)", fontFamily: "'JetBrains Mono', monospace" }}>` to toggle</span>
+                    <div style={{ width: 1, height: 12, background: "rgba(255,255,255,0.06)" }} />
+                    <span style={{ fontSize: 7.5, fontWeight: 700, color: stats.threatColor, fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.08em" }}>{stats.threatLabel}</span>
+                  </div>
+                )}
+              </div>
+
+              {/* Quick commands */}
+              <div style={{ padding: "7px 14px", borderBottom: "1px solid rgba(255,255,255,0.05)", display: "flex", flexWrap: "wrap", gap: 4 }}>
+                {quickCmds.map(({ label, cmd, color }) => (
+                  <button
+                    key={cmd}
+                    onClick={() => processCommand(cmd)}
+                    disabled={status === "processing" || status === "listening"}
+                    style={{ fontSize: 8, fontWeight: 700, letterSpacing: "0.1em", color, background: `${color}09`, border: `1px solid ${color}20`, borderRadius: 4, padding: "3px 8px", cursor: "pointer", fontFamily: "'JetBrains Mono', monospace", opacity: (status === "processing" || status === "listening") ? 0.3 : 1, transition: "all 0.1s" }}
+                    onMouseEnter={e => { e.currentTarget.style.background = `${color}18`; e.currentTarget.style.borderColor = `${color}38`; }}
+                    onMouseLeave={e => { e.currentTarget.style.background = `${color}09`; e.currentTarget.style.borderColor = `${color}20`; }}
+                  >{label}</button>
+                ))}
+              </div>
+
+              {/* Transcript */}
+              <div style={{ overflowY: "auto", maxHeight: 320, padding: "10px 14px", display: "flex", flexDirection: "column", gap: 8 }}>
+                {messages.map(msg => {
+                  if (msg.role === "system") return (
+                    <div key={msg.id} style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <div style={{ flex: 1, height: 1, background: "rgba(0,212,255,0.07)" }} />
+                      <span style={{ fontSize: 7.5, color: "rgba(0,212,255,0.25)", fontFamily: "'JetBrains Mono', monospace", whiteSpace: "nowrap" }}>{msg.text}</span>
+                      <div style={{ flex: 1, height: 1, background: "rgba(0,212,255,0.07)" }} />
+                    </div>
+                  );
+                  if (msg.role === "user") return (
+                    <div key={msg.id} style={{ display: "flex", justifyContent: "flex-end" }}>
+                      <div style={{ maxWidth: "72%", background: "rgba(0,212,255,0.06)", border: "1px solid rgba(0,212,255,0.12)", borderRadius: "6px 6px 2px 6px", padding: "5px 10px" }}>
+                        <div style={{ fontSize: 7.5, color: "rgba(0,212,255,0.3)", fontFamily: "'JetBrains Mono', monospace", marginBottom: 2 }}>{new Date(msg.ts).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", hour12: false })}</div>
+                        <div style={{ fontSize: 11.5, color: "#94a3b8" }}>{msg.text}</div>
+                      </div>
+                    </div>
+                  );
+                  if (msg.role === "agent" && msg.response) return (
+                    <div key={msg.id}><ResponseCard response={msg.response} ts={msg.ts} onSpeak={() => speak(msg.response!.spokenText)} /></div>
+                  );
+                  return null;
+                })}
+                {status === "processing" && (
+                  <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "6px 10px", background: "rgba(167,139,250,0.05)", border: "1px solid rgba(167,139,250,0.12)", borderTop: "2px solid rgba(167,139,250,0.5)", borderRadius: 6 }}>
+                    <span style={{ fontSize: 7.5, color: "#a78bfa", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.12em" }}>ANALYZING</span>
+                    {[0, 0.14, 0.28].map((d, i) => (
+                      <div key={i} style={{ width: 3, height: 3, borderRadius: "50%", background: "#a78bfa", animation: `argus-pulse 0.8s ease-in-out ${d}s infinite` }} />
+                    ))}
+                  </div>
+                )}
+                <div ref={liveScrollRef} />
+              </div>
+
+              {/* Unified input footer */}
+              <div style={{ borderTop: "1px solid rgba(255,255,255,0.05)", background: "rgba(0,3,10,0.5)" }}>
+                {/* Input row */}
+                <div style={{ padding: "8px 14px", display: "flex", gap: 5, alignItems: "center" }}>
+                  <div style={{ flex: 1, position: "relative" as const }}>
+                    <input
+                      value={textInput}
+                      onChange={e => { setTextInput(e.target.value); if (e.target.value) setInputMode("text"); }}
+                      onFocus={() => setInputMode("text")}
+                      onKeyDown={e => { if (e.key === "Enter" && textInput.trim()) { processCommand(textInput); setTextInput(""); } }}
+                      placeholder={inputMode === "voice" ? "Or type a command…" : "Type a command or question…"}
+                      disabled={status === "processing"}
+                      style={{
+                        width: "100%", boxSizing: "border-box" as const,
+                        background: inputMode === "text" ? "rgba(0,212,255,0.04)" : "rgba(0,5,14,0.6)",
+                        border: `1px solid ${inputMode === "text" ? "rgba(0,212,255,0.22)" : "rgba(255,255,255,0.07)"}`,
+                        borderRadius: 6, padding: "6px 10px", fontSize: 11,
+                        color: "#e2e8f0", fontFamily: "'JetBrains Mono', monospace", outline: "none",
+                        transition: "border-color 0.2s, background 0.2s",
+                      }}
+                    />
+                  </div>
+                  {/* Send — visible when text is present */}
+                  <button
+                    onClick={() => { if (textInput.trim()) { processCommand(textInput); setTextInput(""); } }}
+                    disabled={!textInput.trim() || status === "processing"}
+                    style={{
+                      height: 30, paddingInline: 12, borderRadius: 6, cursor: textInput.trim() ? "pointer" : "default",
+                      display: "flex", alignItems: "center", justifyContent: "center",
+                      background: textInput.trim() ? "rgba(0,212,255,0.1)" : "rgba(255,255,255,0.03)",
+                      border: `1px solid ${textInput.trim() ? "rgba(0,212,255,0.28)" : "rgba(255,255,255,0.06)"}`,
+                      color: textInput.trim() ? "#00d4ff" : "rgba(100,116,139,0.25)",
+                      fontSize: 10, fontWeight: 700, fontFamily: "'JetBrains Mono', monospace",
+                      transition: "all 0.15s", opacity: status === "processing" ? 0.35 : 1,
+                      flexShrink: 0,
+                    }}
+                  >→</button>
+                  {/* Mic — deprioritized in text mode */}
+                  {hasMic && (
+                    <button
+                      onClick={() => { setInputMode("voice"); handleMicToggle(); }}
+                      style={{
+                        height: 30, paddingInline: 12, borderRadius: 6, cursor: "pointer",
+                        display: "flex", alignItems: "center", gap: 5,
+                        fontSize: 9, fontWeight: 700, letterSpacing: "0.08em",
+                        fontFamily: "'JetBrains Mono', monospace", transition: "all 0.15s",
+                        background: status === "listening" ? "rgba(0,212,255,0.12)" : status === "speaking" ? "rgba(0,255,136,0.08)" : inputMode === "text" ? "rgba(255,255,255,0.03)" : "rgba(255,255,255,0.05)",
+                        border: `1px solid ${status === "listening" ? "rgba(0,212,255,0.4)" : status === "speaking" ? "rgba(0,255,136,0.25)" : inputMode === "text" ? "rgba(255,255,255,0.06)" : "rgba(255,255,255,0.1)"}`,
+                        color: status === "listening" ? "#00d4ff" : status === "speaking" ? "#00ff88" : inputMode === "text" ? "rgba(100,116,139,0.3)" : "rgba(148,163,184,0.5)",
+                        flexShrink: 0,
+                      }}
+                    >
+                      {status === "listening" ? <MicOff size={10} /> : <Mic size={10} />}
+                      {status === "listening" ? "STOP" : status === "speaking" ? "MUTE" : "MIC"}
+                    </button>
+                  )}
+                </div>
+                {/* Status line */}
+                <div style={{ padding: "0 14px 7px", display: "flex", alignItems: "center", gap: 6 }}>
+                  <span style={{ fontSize: 7.5, letterSpacing: "0.1em", fontFamily: "'JetBrains Mono', monospace", color: isActive ? sc.color : inputMode === "text" ? "rgba(0,212,255,0.35)" : "rgba(100,116,139,0.25)", transition: "color 0.25s" }}>
+                    {status === "listening" ? "● VOICE ACTIVE — SPEAK NOW" : status === "processing" ? "● PROCESSING COMMAND" : status === "speaking" ? "● ARGUS SPEAKING" : inputMode === "text" ? "TEXT MODE — ENTER TO SEND" : hasMic ? "VOICE READY — PRESS MIC OR TYPE" : "TEXT MODE ACTIVE"}
+                  </span>
+                  {inputMode === "text" && hasMic && (
+                    <button
+                      onClick={() => setInputMode("voice")}
+                      style={{ fontSize: 7, fontWeight: 700, color: "rgba(100,116,139,0.35)", background: "none", border: "none", cursor: "pointer", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.08em", padding: 0 }}
+                    >switch to voice</button>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+
+          {/* ══ AUDIT TAB ═══════════════════════════════════════════════════════ */}
+          {tab === "audit" && (
+            <>
+              {/* Audit toolbar */}
+              <div style={{ padding: "8px 14px", borderBottom: "1px solid rgba(255,255,255,0.05)", display: "flex", alignItems: "center", gap: 8, background: "rgba(0,5,14,0.4)" }}>
+                <div style={{ flex: 1 }}>
+                  <span style={{ fontSize: 8, color: "rgba(100,116,139,0.35)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.08em" }}>
+                    {auditLog.length} ENTRIES · SESSION {sessionId}
+                  </span>
+                </div>
+                <div style={{ display: "flex", gap: 4 }}>
+                  {/* Legend */}
+                  {([
+                    { label: "STT", color: "#00d4ff" },
+                    { label: "TTS", color: "#00ff88" },
+                    { label: "INT", color: "#a78bfa" },
+                  ] as const).map(({ label, color }) => (
+                    <span key={label} style={{ fontSize: 7, fontWeight: 700, color, background: `${color}0a`, border: `1px solid ${color}20`, borderRadius: 3, padding: "1px 5px", fontFamily: "'JetBrains Mono', monospace" }}>{label}</span>
+                  ))}
+                </div>
+                <div style={{ width: 1, height: 16, background: "rgba(255,255,255,0.06)" }} />
+                <button
+                  onClick={() => setAuditLog([])}
+                  disabled={auditLog.length === 0}
+                  title="Clear log"
+                  style={{ width: 24, height: 24, borderRadius: 4, display: "flex", alignItems: "center", justifyContent: "center", background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.07)", color: "rgba(100,116,139,0.4)", cursor: auditLog.length === 0 ? "not-allowed" : "pointer", opacity: auditLog.length === 0 ? 0.3 : 1 }}
+                >
+                  <Trash2 size={10} />
+                </button>
+                <button
+                  onClick={exportAudit}
+                  disabled={auditLog.length === 0}
+                  title="Export log as .log file"
+                  style={{ width: 24, height: 24, borderRadius: 4, display: "flex", alignItems: "center", justifyContent: "center", background: auditLog.length > 0 ? "rgba(0,212,255,0.07)" : "rgba(255,255,255,0.03)", border: `1px solid ${auditLog.length > 0 ? "rgba(0,212,255,0.18)" : "rgba(255,255,255,0.07)"}`, color: auditLog.length > 0 ? "#00d4ff" : "rgba(100,116,139,0.35)", cursor: auditLog.length === 0 ? "not-allowed" : "pointer", opacity: auditLog.length === 0 ? 0.3 : 1 }}
+                >
+                  <Download size={10} />
+                </button>
+              </div>
+
+              {/* Log entries */}
+              <div style={{ overflowY: "auto", maxHeight: 440, padding: "6px 14px 10px" }}>
+                {auditLog.length === 0 ? (
+                  <div style={{ padding: "40px 0", textAlign: "center" as const }}>
+                    <div style={{ fontSize: 8.5, color: "rgba(100,116,139,0.3)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.1em" }}>NO ENTRIES YET</div>
+                    <div style={{ fontSize: 10, color: "rgba(100,116,139,0.2)", marginTop: 6 }}>Switch to LIVE and issue a voice command to begin logging.</div>
+                  </div>
+                ) : (
+                  auditWithDividers.map(({ entry, showSession }) => (
+                    <AuditRow key={entry.id} entry={entry} showSession={showSession} />
+                  ))
+                )}
+                <div ref={auditScrollRef} />
+              </div>
+
+              {/* Audit footer */}
+              <div style={{ padding: "8px 14px", borderTop: "1px solid rgba(255,255,255,0.05)", display: "flex", alignItems: "center", gap: 8, background: "rgba(0,3,10,0.5)" }}>
+                <span style={{ flex: 1, fontSize: 8, color: "rgba(100,116,139,0.28)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.08em" }}>
+                  VOICE AUDIT LOG · ARGUS v1.0 · FOR QA AND COMPLIANCE USE
+                </span>
+                <span style={{ fontSize: 7.5, color: "rgba(100,116,139,0.25)", fontFamily: "'JetBrains Mono', monospace" }}>↓ .log export</span>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/ir/VoiceIRAgent.tsx
+++ b/src/components/ir/VoiceIRAgent.tsx
@@ -57,6 +57,19 @@ function newSessionId(): string {
 }
 
 // ── Intent matching ───────────────────────────────────────────────────────────
+/** Match "Hey Argus" in STT text; return command after the last wake phrase, or null if none / empty. */
+function extractCommandAfterLastWake(buffer: string): string | null {
+  const re = /hey\s+argus\b/gi;
+  let lastEnd = -1;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(buffer)) !== null) {
+    lastEnd = m.index + m[0].length;
+  }
+  if (lastEnd < 0) return null;
+  const cmd = buffer.slice(lastEnd).trim().replace(/^[,.;:\s]+/, "").trim();
+  return cmd.length >= 1 ? cmd : null;
+}
+
 function matchIntent(input: string): string {
   const t = input.toLowerCase().trim();
   if (/\b(brief|briefing|situation|status|sitrep|what('s| is) (going on|happening|the situation))\b/.test(t)) return "briefing";
@@ -520,11 +533,22 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
   const [textInput,  setTextInput]  = useState("");
   const [inputMode,  setInputMode]  = useState<"voice" | "text">("voice");
   const [hasMic,     setHasMic]     = useState(true);
+  const [wakeListenOn, setWakeListenOn] = useState(false);
+  const [passiveResumeTick, setPassiveResumeTick] = useState(0);
   const [sessionId, setSessionId] = useState(() => newSessionId());
 
   const recognitionRef = useRef<any>(null);
   const synthRef       = useRef<SpeechSynthesis | null>(null);
   const processing     = useRef(false);
+  const wakeListenOnRef = useRef(false);
+  const suspendWakeForPushRef = useRef(false);
+  const passiveBufferRef = useRef("");
+  const isOpenRef = useRef(isOpen);
+  const hasMicRef = useRef(hasMic);
+  const inputModeRef = useRef(inputMode);
+  const startPassiveWakeRef = useRef<() => void>(() => {});
+  const processCommandRef = useRef<(input: string, confidence?: number) => void>(() => {});
+  const [pushToTalkActive, setPushToTalkActive] = useState(false);
   const liveScrollRef  = useRef<HTMLDivElement>(null);
   const auditScrollRef = useRef<HTMLDivElement>(null);
   const lastSessionRef = useRef<string>(sessionId);
@@ -560,6 +584,17 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
     synthRef.current = window.speechSynthesis ?? null;
     return () => { recognitionRef.current?.abort(); synthRef.current?.cancel(); };
   }, []);
+
+  useEffect(() => {
+    wakeListenOnRef.current = wakeListenOn;
+    isOpenRef.current = isOpen;
+    hasMicRef.current = hasMic;
+    inputModeRef.current = inputMode;
+  }, [wakeListenOn, isOpen, hasMic, inputMode]);
+
+  useEffect(() => {
+    if (!wakeListenOn) passiveBufferRef.current = "";
+  }, [wakeListenOn]);
 
   // New session + sys log on open
   useEffect(() => {
@@ -652,14 +687,123 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
     }, 240 + Math.random() * 280);
   }, [stats, findings, speak, onNavigate, pushAudit]);
 
-  // ── Speech recognition ──────────────────────────────────────────────────────
+  useEffect(() => {
+    processCommandRef.current = processCommand;
+  }, [processCommand]);
+
+  // ── Passive "Hey Argus" listening (continuous STT; command only after wake phrase) ──
+  const startPassiveWake = useCallback(() => {
+    const SR = (window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition;
+    if (!SR) return;
+    if (!wakeListenOnRef.current || suspendWakeForPushRef.current) return;
+    if (!isOpenRef.current || !hasMicRef.current || inputModeRef.current !== "voice") return;
+
+    recognitionRef.current?.abort();
+
+    const r = new SR();
+    r.lang = "en-US";
+    r.interimResults = true;
+    r.continuous = true;
+    r.maxAlternatives = 1;
+
+    r.onstart = () => {
+      setPushToTalkActive(false);
+      setStatus("listening");
+    };
+
+    r.onresult = (e: any) => {
+      let pieceFinal = "";
+      let lastConf = 0.85;
+      let interim = "";
+      for (let i = e.resultIndex; i < e.results.length; i++) {
+        const res = e.results[i];
+        const tr = res[0].transcript;
+        if (res.isFinal) {
+          pieceFinal += tr;
+          if (res[0].confidence != null) lastConf = res[0].confidence;
+        } else {
+          interim += tr;
+        }
+      }
+      if (interim) setPartial(interim.trim());
+      if (!pieceFinal) return;
+
+      passiveBufferRef.current = `${passiveBufferRef.current} ${pieceFinal}`.trim();
+      if (passiveBufferRef.current.length > 400) {
+        passiveBufferRef.current = passiveBufferRef.current.slice(-220);
+      }
+
+      const cmd = extractCommandAfterLastWake(passiveBufferRef.current);
+      if (cmd && !processing.current) {
+        passiveBufferRef.current = "";
+        setPartial("");
+        r.stop();
+        processCommandRef.current(cmd, lastConf);
+      }
+    };
+
+    r.onerror = (ev: any) => {
+      if (ev.error === "no-speech" || ev.error === "aborted") return;
+      setStatus("error");
+      setTimeout(() => setStatus("standby"), 1200);
+    };
+
+    r.onend = () => {
+      if (!wakeListenOnRef.current) {
+        setStatus("standby");
+        return;
+      }
+      if (suspendWakeForPushRef.current) return;
+      if (processing.current) return;
+      queueMicrotask(() => {
+        if (!wakeListenOnRef.current || suspendWakeForPushRef.current || processing.current) return;
+        if (!isOpenRef.current || inputModeRef.current !== "voice") return;
+        startPassiveWakeRef.current();
+      });
+    };
+
+    recognitionRef.current = r;
+    try {
+      r.start();
+    } catch {
+      /* SR may throw if start called in an invalid state */
+    }
+  }, []);
+
+  useEffect(() => {
+    startPassiveWakeRef.current = startPassiveWake;
+  }, [startPassiveWake]);
+
+  useEffect(() => {
+    if (!isOpen || !wakeListenOn || !hasMic || inputMode !== "voice") {
+      recognitionRef.current?.abort();
+      return;
+    }
+    if (status === "processing" || status === "speaking") {
+      recognitionRef.current?.abort();
+      return;
+    }
+    if (suspendWakeForPushRef.current) return;
+    startPassiveWake();
+    return () => {
+      recognitionRef.current?.abort();
+    };
+  }, [isOpen, wakeListenOn, hasMic, inputMode, status, passiveResumeTick, startPassiveWake]);
+
+  // ── Speech recognition (push-to-talk — no wake phrase required) ───────────────
   const startListening = useCallback(() => {
     const SR = (window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition;
     if (!SR) return;
+    suspendWakeForPushRef.current = true;
     recognitionRef.current?.abort();
+    passiveBufferRef.current = "";
+    setPartial("");
     const r = new SR();
     r.lang = "en-US"; r.interimResults = true; r.continuous = false;
-    r.onstart  = () => setStatus("listening");
+    r.onstart = () => {
+      setPushToTalkActive(true);
+      setStatus("listening");
+    };
     r.onresult = (e: any) => {
       const last = e.results[e.results.length - 1];
       setPartial(last[0].transcript);
@@ -668,16 +812,49 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
         processCommand(last[0].transcript, last[0].confidence ?? undefined);
       }
     };
-    r.onerror  = (e: any) => { setStatus(e.error === "no-speech" ? "standby" : "error"); setTimeout(() => setStatus("standby"), 1000); };
-    r.onend    = () => { if (status === "listening") setStatus("standby"); };
+    r.onerror = (e: any) => {
+      if (e.error === "aborted") return;
+      if (e.error === "no-speech") setStatus("standby");
+      else {
+        setStatus("error");
+        setTimeout(() => setStatus("standby"), 1000);
+      }
+    };
+    r.onend = () => {
+      suspendWakeForPushRef.current = false;
+      setPushToTalkActive(false);
+      setStatus("standby");
+      if (wakeListenOnRef.current && isOpenRef.current && hasMicRef.current && inputModeRef.current === "voice") {
+        setPassiveResumeTick(t => t + 1);
+      }
+    };
     recognitionRef.current = r;
     r.start();
-  }, [processCommand, status]);
+  }, [processCommand]);
 
   const handleMicToggle = useCallback(() => {
-    if (status === "listening")     { recognitionRef.current?.stop(); setStatus("standby"); }
-    else if (status === "speaking") { synthRef.current?.cancel(); setStatus("standby"); }
-    else                            startListening();
+    if (status === "speaking") {
+      synthRef.current?.cancel();
+      setStatus("standby");
+      return;
+    }
+    if (status === "listening") {
+      if (suspendWakeForPushRef.current) {
+        recognitionRef.current?.stop();
+        suspendWakeForPushRef.current = false;
+        setPushToTalkActive(false);
+        setStatus("standby");
+        if (wakeListenOnRef.current) setPassiveResumeTick(t => t + 1);
+      } else if (wakeListenOnRef.current) {
+        startListening();
+      } else {
+        recognitionRef.current?.stop();
+        setPushToTalkActive(false);
+        setStatus("standby");
+      }
+      return;
+    }
+    startListening();
   }, [status, startListening]);
 
   // ── Audit export ────────────────────────────────────────────────────────────
@@ -850,18 +1027,38 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
                 )}
               </div>
 
-              {/* Quick commands */}
-              <div style={{ padding: "7px 14px", borderBottom: "1px solid rgba(255,255,255,0.05)", display: "flex", flexWrap: "wrap", gap: 4 }}>
-                {quickCmds.map(({ label, cmd, color }) => (
+              {/* Quick commands + optional wake phrase listening */}
+              <div style={{ padding: "7px 14px", borderBottom: "1px solid rgba(255,255,255,0.05)", display: "flex", flexWrap: "wrap", alignItems: "center", gap: 4 }}>
+                {hasMic && inputMode === "voice" && (
+                  <button
+                    type="button"
+                    title="When ON, the mic stays open while this panel is visible; say “Hey Argus” before your command. Turn OFF for push-to-talk only."
+                    onClick={() => setWakeListenOn(w => !w)}
+                    disabled={status === "processing" || (status === "listening" && pushToTalkActive)}
+                    style={{
+                      fontSize: 8, fontWeight: 800, letterSpacing: "0.1em",
+                      color: wakeListenOn ? "#00d4ff" : "rgba(100,116,139,0.45)",
+                      background: wakeListenOn ? "rgba(0,212,255,0.1)" : "rgba(255,255,255,0.03)",
+                      border: `1px solid ${wakeListenOn ? "rgba(0,212,255,0.35)" : "rgba(255,255,255,0.08)"}`,
+                      borderRadius: 4, padding: "3px 8px", cursor: "pointer", fontFamily: "'JetBrains Mono', monospace",
+                      opacity: status === "processing" || (status === "listening" && pushToTalkActive) ? 0.35 : 1,
+                      transition: "all 0.1s", marginRight: 4,
+                    }}
+                  >HEY ARGUS {wakeListenOn ? "ON" : "OFF"}</button>
+                )}
+                {quickCmds.map(({ label, cmd, color }) => {
+                  const voiceBusy = status === "processing" || (status === "listening" && pushToTalkActive);
+                  return (
                   <button
                     key={cmd}
                     onClick={() => processCommand(cmd)}
-                    disabled={status === "processing" || status === "listening"}
-                    style={{ fontSize: 8, fontWeight: 700, letterSpacing: "0.1em", color, background: `${color}09`, border: `1px solid ${color}20`, borderRadius: 4, padding: "3px 8px", cursor: "pointer", fontFamily: "'JetBrains Mono', monospace", opacity: (status === "processing" || status === "listening") ? 0.3 : 1, transition: "all 0.1s" }}
+                    disabled={voiceBusy}
+                    style={{ fontSize: 8, fontWeight: 700, letterSpacing: "0.1em", color, background: `${color}09`, border: `1px solid ${color}20`, borderRadius: 4, padding: "3px 8px", cursor: "pointer", fontFamily: "'JetBrains Mono', monospace", opacity: voiceBusy ? 0.3 : 1, transition: "all 0.1s" }}
                     onMouseEnter={e => { e.currentTarget.style.background = `${color}18`; e.currentTarget.style.borderColor = `${color}38`; }}
                     onMouseLeave={e => { e.currentTarget.style.background = `${color}09`; e.currentTarget.style.borderColor = `${color}20`; }}
                   >{label}</button>
-                ))}
+                  );
+                })}
               </div>
 
               {/* Transcript */}
@@ -958,7 +1155,23 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
                 {/* Status line */}
                 <div style={{ padding: "0 14px 7px", display: "flex", alignItems: "center", gap: 6 }}>
                   <span style={{ fontSize: 7.5, letterSpacing: "0.1em", fontFamily: "'JetBrains Mono', monospace", color: isActive ? sc.color : inputMode === "text" ? "rgba(0,212,255,0.35)" : "rgba(100,116,139,0.25)", transition: "color 0.25s" }}>
-                    {status === "listening" ? "● VOICE ACTIVE — SPEAK NOW" : status === "processing" ? "● PROCESSING COMMAND" : status === "speaking" ? "● ARGUS SPEAKING" : inputMode === "text" ? "TEXT MODE — ENTER TO SEND" : hasMic ? "VOICE READY — PRESS MIC OR TYPE" : "TEXT MODE ACTIVE"}
+                    {status === "listening" && pushToTalkActive
+                      ? "● PUSH-TO-TALK — SPEAK NOW"
+                      : status === "listening" && wakeListenOn
+                        ? "● LISTENING — SAY \"HEY ARGUS\", THEN COMMAND"
+                        : status === "listening"
+                          ? "● VOICE ACTIVE — SPEAK NOW"
+                          : status === "processing"
+                            ? "● PROCESSING COMMAND"
+                            : status === "speaking"
+                              ? "● ARGUS SPEAKING"
+                              : inputMode === "text"
+                                ? "TEXT MODE — ENTER TO SEND"
+                                : hasMic
+                                  ? wakeListenOn
+                                    ? "HEY ARGUS ON — OR PRESS MIC / TYPE"
+                                    : "VOICE READY — PRESS MIC OR TYPE"
+                                  : "TEXT MODE ACTIVE"}
                   </span>
                   {inputMode === "text" && hasMic && (
                     <button

--- a/src/components/ir/VoiceIRAgent.tsx
+++ b/src/components/ir/VoiceIRAgent.tsx
@@ -861,7 +861,8 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
       } else {
         setMessages(p => p.filter(m => m.id !== loadId));
       }
-    } catch {
+    } catch (err) {
+      console.warn("[VoiceIRAgent] LLM triage fetch failed:", err);
       setMessages(p => p.filter(m => m.id !== loadId));
     }
   }, []);
@@ -878,7 +879,8 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
       });
 
       const statusLabel = result.approval_required ? "PENDING APPROVAL" : "EXECUTING";
-      const spoken = `${confirm.label} initiated. Job ${result.job_id.slice(-6).toUpperCase()}. Status: ${statusLabel}.`;
+      const jobSuffix = typeof result.job_id === "string" ? result.job_id.slice(-6).toUpperCase() : "UNKNOWN";
+      const spoken = `${confirm.label} initiated. Job ${jobSuffix}. Status: ${statusLabel}.`;
 
       setMessages(p => [
         ...p.filter(m => m.id !== runId),

--- a/src/components/ir/VoiceIRAgent.tsx
+++ b/src/components/ir/VoiceIRAgent.tsx
@@ -1090,12 +1090,44 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
         }]);
       }
 
-      // ── IR confirmation (unchanged — always gated regardless of source) ──
+      // ── IR confirmation — target resolution ──────────────────────────────
       if (["isolate", "revoke", "disable_key"].includes(intent) && findings.length > 0) {
-        const irFinding =
-          findings.find(f => (f.severity ?? "").toUpperCase() === "CRITICAL") ??
-          findings.find(f => (f.severity ?? "").toUpperCase() === "HIGH") ??
-          findings[0];
+        const targetResource = resolved.args?.resource as string | undefined;
+        let irFinding: any;
+
+        if (targetResource) {
+          // Bedrock extracted a specific resource from the utterance — match it.
+          const t = targetResource.toLowerCase();
+          irFinding = findings.find(f =>
+            (f.resource_name ?? "").toLowerCase().includes(t) ||
+            (f.resource_arn  ?? "").toLowerCase().includes(t)
+          );
+          if (!irFinding) {
+            // Fail closed: named resource not found. Do not auto-pick an unrelated finding.
+            const msg = `No active finding matched resource "${targetResource}". Verify the resource ID or say "list findings" first.`;
+            setMessages(p => [...p, {
+              id: `err-${Date.now()}`, role: "agent" as const, ts: Date.now(),
+              response: {
+                classification: "NO MATCH",
+                priority: "warning" as const,
+                fields: [{ label: "RESOURCE", value: targetResource.toUpperCase(), color: "#ffb000" }],
+                items: [{ text: `No finding matched "${targetResource}"`, sub: `Verify the resource ID or say "list findings"`, color: "#ffb000" }],
+                spokenText: msg,
+              },
+            }]);
+            pushAudit({ type: "tts", content: msg, sessionId: lastSessionRef.current });
+            processing.current = false;
+            void speak(msg);
+            return;
+          }
+        } else {
+          // No specific resource in utterance — fall back to top critical/high finding.
+          irFinding =
+            findings.find(f => (f.severity ?? "").toUpperCase() === "CRITICAL") ??
+            findings.find(f => (f.severity ?? "").toUpperCase() === "HIGH") ??
+            findings[0];
+        }
+
         if (irFinding) {
           setTimeout(() => showIRConfirm(intent, irFinding), 400);
         }
@@ -1129,7 +1161,8 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
       if (e.error === "no-speech") { setStatus("standby"); }
       else { setStatus("error"); setTimeout(() => setStatus("standby"), 1000); }
     };
-    r.onend = () => setStatus("standby");
+    // Only reset to standby if we're not mid-processing (isFinal already called processCommand).
+    r.onend = () => { if (!processing.current) setStatus("standby"); };
     recognitionRef.current = r;
     r.start();
   }, [processCommand]);

--- a/src/components/ir/VoiceIRAgent.tsx
+++ b/src/components/ir/VoiceIRAgent.tsx
@@ -1,6 +1,27 @@
+/**
+ * VoiceIRAgent — Argus v2
+ *
+ * Interaction model: push-to-talk (mic button) or type. No wake phrase required.
+ * The engineer holds the mic button, speaks a command, releases — Argus responds.
+ * Natural conversation flow: speak → response → speak again.
+ *
+ * New in v2:
+ *   - AWS Polly Neural TTS via ttsService (Web Speech fallback)
+ *   - LLM-powered briefings: briefing/critical/threat intents call llm_triage
+ *     for the top critical finding and stream the result as a second card
+ *   - Voice-triggered IR actions: isolate/revoke/disable intents enter a
+ *     voice confirmation state machine (YES → execute, NO → cancel)
+ *   - Context Preservation: finding cards rendered inline in chat
+ *   - "Hey Argus" wake phrase fully removed
+ */
+
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
-import { Mic, MicOff, Volume2, Zap, X, Download, Trash2 } from "lucide-react";
+import { Mic, MicOff, Volume2, Zap, X, Download, Trash2, ShieldAlert } from "lucide-react";
 import { useActiveScanResults } from "../../hooks/useActiveScanResults";
+import { pollySpeak } from "../../services/ttsService";
+import { fetchLLMActionResult, triggerIRAction } from "../../services/irEngine";
+import type { IRActionType, IRActionResult } from "../../types/ir";
+import { ACTION_META } from "../../types/ir";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 type AgentStatus   = "standby" | "listening" | "processing" | "speaking" | "error";
@@ -17,21 +38,52 @@ interface AgentResponse {
   spokenText: string;
 }
 
+interface TriageResult {
+  summary: string;
+  confidence?: number;
+  mitre?: string[];
+  falsePositive?: number;
+}
+
+interface IRConfirmData {
+  actionType: IRActionType;
+  findingId: string;
+  findingTitle: string;
+  resourceName: string;
+  label: string;
+  impactSummary: string;
+}
+
+// Message is a discriminated union via `type`
 interface Message {
   id: string;
   role: "user" | "agent" | "system";
   ts: number;
   text?: string;
   response?: AgentResponse;
+  type?: "normal" | "ir_confirm" | "llm_triage" | "finding_list" | "ir_result";
+  confirmData?: IRConfirmData;
+  triageData?: TriageResult;
+  findingList?: FindingSnippet[];
 }
 
-// Audit log entry — every voice event recorded here
+interface FindingSnippet {
+  id: string;
+  title: string;
+  severity: string;
+  resource: string;
+  region: string;
+  service: string;
+  color: string;
+}
+
+// Audit log entry
 interface AuditEntry {
   id: string;
   ts: number;
   type: "stt" | "tts" | "intent" | "sys";
   content: string;
-  confidence?: number;   // 0–1, from Web Speech API
+  confidence?: number;
   sessionId: string;
 }
 
@@ -51,25 +103,17 @@ const PRIO: Record<ResponsePriority, { color: string; bg: string; border: string
   success:  { color: "#00ff88", bg: "rgba(0,255,136,0.06)",  border: "rgba(0,255,136,0.18)",  label: "CLEAR"    },
 };
 
-// ── Session ID ────────────────────────────────────────────────────────────────
+const SEV_COLOR: Record<string, string> = {
+  CRITICAL: "#ff0040", HIGH: "#ff6b35", MEDIUM: "#ffb000", LOW: "#00ff88", INFORMATIONAL: "#64748b",
+};
+
+function sevColor(s: string) { return SEV_COLOR[(s ?? "").toUpperCase()] ?? "#64748b"; }
+
 function newSessionId(): string {
   return `argus-${Date.now().toString(36).slice(-4)}-${Math.random().toString(36).slice(2, 5)}`;
 }
 
 // ── Intent matching ───────────────────────────────────────────────────────────
-/** Match "Hey Argus" in STT text; return command after the last wake phrase, or null if none / empty. */
-function extractCommandAfterLastWake(buffer: string): string | null {
-  const re = /hey\s+argus\b/gi;
-  let lastEnd = -1;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(buffer)) !== null) {
-    lastEnd = m.index + m[0].length;
-  }
-  if (lastEnd < 0) return null;
-  const cmd = buffer.slice(lastEnd).trim().replace(/^[,.;:\s]+/, "").trim();
-  return cmd.length >= 1 ? cmd : null;
-}
-
 function matchIntent(input: string): string {
   const t = input.toLowerCase().trim();
   if (/\b(brief|briefing|situation|status|sitrep|what('s| is) (going on|happening|the situation))\b/.test(t)) return "briefing";
@@ -77,11 +121,14 @@ function matchIntent(input: string): string {
   if (/\b(threat level|threat assessment|current threat)\b/.test(t)) return "threat";
   if (/\b(sla|breach|breached|overdue)\b/.test(t)) return "sla";
   if (/\b(latest|new findings?|recent|last scan)\b/.test(t)) return "latest";
+  if (/\b(show findings?|list findings?|findings? list|all findings?)\b/.test(t)) return "show_findings";
   if (/\b(compliance|score|posture|frameworks?)\b/.test(t)) return "compliance";
   if (/\b(scan|run scan|start scan)\b/.test(t)) return "scan";
   if (/\b(help|commands?|what can you)\b/.test(t)) return "help";
   if (/\b(high (risk|findings?|severity)|high risk)\b/.test(t)) return "high";
   if (/\b(isolate|contain|lock down|quarantine)\b/.test(t)) return "isolate";
+  if (/\b(revoke|delete key|remove key|kill key)\b/.test(t)) return "revoke";
+  if (/\b(disable key|deactivate key|suspend key)\b/.test(t)) return "disable_key";
   if (/\b(go to|navigate|open|take me)\b/.test(t)) return "navigate";
   return "unknown";
 }
@@ -96,22 +143,22 @@ function buildResponse(intent: string, stats: DerivedStats, findings: any[], _ra
       return {
         classification: "SITREP", priority: p,
         fields: [
-          { label: "THREAT",   value: stats.threatLabel,                                  color: stats.threatColor },
-          { label: "OPEN",     value: String(stats.total),                                color: stats.total > 0 ? "#ff6b35" : "#00ff88" },
-          { label: "CRITICAL", value: String(stats.critical),                             color: stats.critical > 0 ? "#ff0040" : "#00ff88" },
-          { label: "HIGH",     value: String(stats.high),                                 color: stats.high > 0 ? "#ff6b35" : "#00ff88" },
-          { label: "SLA",      value: stats.slaBreached > 0 ? `${stats.slaBreached} BREACH` : "OK", color: stats.slaBreached > 0 ? "#ff0040" : "#00ff88" },
-          { label: "TIME",     value: `${tz}Z`,                                           color: "rgba(100,116,139,0.6)" },
+          { label: "THREAT",   value: stats.threatLabel,                                              color: stats.threatColor },
+          { label: "OPEN",     value: String(stats.total),                                            color: stats.total > 0 ? "#ff6b35" : "#00ff88" },
+          { label: "CRITICAL", value: String(stats.critical),                                         color: stats.critical > 0 ? "#ff0040" : "#00ff88" },
+          { label: "HIGH",     value: String(stats.high),                                             color: stats.high > 0 ? "#ff6b35" : "#00ff88" },
+          { label: "SLA",      value: stats.slaBreached > 0 ? `${stats.slaBreached} BREACH` : "OK",  color: stats.slaBreached > 0 ? "#ff0040" : "#00ff88" },
+          { label: "TIME",     value: `${tz}Z`,                                                       color: "rgba(100,116,139,0.5)" },
         ],
         items: stats.critical > 0
           ? findings.filter(f => (f.severity ?? "").toUpperCase() === "CRITICAL").slice(0, 3).map(f => ({
               text: f.finding_type ?? f.title ?? "Unnamed finding",
-              sub: f.resource_arn?.split(":").slice(-1)[0] ?? f.resource_name ?? "Unknown resource",
+              sub:  f.resource_arn?.split(":").slice(-1)[0] ?? f.resource_name ?? "Unknown resource",
               action: "TRIAGE IMMEDIATELY", color: "#ff0040",
             }))
           : undefined,
         spokenText: stats.critical > 0
-          ? `Situation report at ${tz}. Threat level is ${stats.threatLabel}. ${stats.total} open findings. ${stats.critical} critical require immediate action. ${stats.slaBreached > 0 ? `${stats.slaBreached} SLA breach active.` : ""} Initiate containment now.`
+          ? `Situation report at ${tz}. Threat level ${stats.threatLabel}. ${stats.total} open findings. ${stats.critical} critical require immediate action. ${stats.slaBreached > 0 ? `${stats.slaBreached} SLA breach active.` : ""} Initiating LLM analysis.`
           : `Situation report at ${tz}. Threat level ${stats.threatLabel}. ${stats.total} open findings. ${stats.high > 0 ? `${stats.high} high severity in triage.` : "No critical threats."} Standard monitoring cadence.`,
       };
     }
@@ -119,7 +166,7 @@ function buildResponse(intent: string, stats: DerivedStats, findings: any[], _ra
       const crits = findings.filter(f => (f.severity ?? "").toUpperCase() === "CRITICAL");
       if (stats.critical === 0) return {
         classification: "CRITICAL FINDINGS", priority: "success",
-        fields: [{ label: "STATUS", value: "NONE ACTIVE", color: "#00ff88" }, { label: "TIME", value: `${tz}Z`, color: "rgba(100,116,139,0.6)" }],
+        fields: [{ label: "STATUS", value: "NONE ACTIVE", color: "#00ff88" }, { label: "TIME", value: `${tz}Z`, color: "rgba(100,116,139,0.5)" }],
         spokenText: `No critical findings in queue at ${tz}. Critical tier is clean.`,
       };
       return {
@@ -131,11 +178,11 @@ function buildResponse(intent: string, stats: DerivedStats, findings: any[], _ra
         ],
         items: crits.slice(0, 4).map((f, i) => ({
           text: f.finding_type ?? f.title ?? `Critical Finding ${i + 1}`,
-          sub: f.resource_arn?.split(":").slice(-1)[0] ?? f.resource_name ?? f.region ?? "us-east-1",
+          sub:  f.resource_arn?.split(":").slice(-1)[0] ?? f.resource_name ?? f.region ?? "us-east-1",
           action: f.service === "iam" ? "REVOKE + AUDIT" : f.service === "ec2" ? "ISOLATE INSTANCE" : f.service === "s3" ? "BLOCK PUBLIC ACCESS" : "TRIAGE NOW",
           color: "#ff0040",
         })),
-        spokenText: `${stats.critical} critical findings active at ${tz}. ${crits.slice(0, 2).map((f, i) => `Finding ${i + 1}: ${f.finding_type ?? "Unnamed"}`).join(". ")}. Immediate response required.`,
+        spokenText: `${stats.critical} critical findings active. ${crits.slice(0, 2).map((f, i) => `Finding ${i + 1}: ${f.finding_type ?? "Unnamed"}`).join(". ")}. Fetching LLM triage now.`,
       };
     }
     case "threat": {
@@ -147,20 +194,20 @@ function buildResponse(intent: string, stats: DerivedStats, findings: any[], _ra
           { label: "CRITICAL", value: String(stats.critical), color: stats.critical > 0 ? "#ff0040" : "#00ff88" },
           { label: "HIGH",     value: String(stats.high),     color: stats.high > 0 ? "#ff6b35" : "#00ff88" },
           { label: "TOTAL",    value: String(stats.total),    color: "rgba(148,163,184,0.8)" },
-          { label: "TIME",     value: `${tz}Z`,               color: "rgba(100,116,139,0.6)" },
+          { label: "TIME",     value: `${tz}Z`,               color: "rgba(100,116,139,0.5)" },
         ],
         items: stats.critical > 0 ? [{ text: "Elevated response cadence required", action: "DECLARE INCIDENT", color: "#ff0040" }] : undefined,
-        spokenText: `Threat level ${stats.threatLabel} at ${tz}. ${stats.total} open findings — ${stats.critical} critical, ${stats.high} high. ${stats.critical > 0 ? "Elevated response and incident declaration recommended." : "Standard protocols sufficient."}`,
+        spokenText: `Threat level ${stats.threatLabel}. ${stats.total} open findings — ${stats.critical} critical, ${stats.high} high. ${stats.critical > 0 ? "Elevated response and incident declaration recommended." : "Standard protocols sufficient."}`,
       };
     }
     case "sla":
       if (stats.slaBreached === 0) return {
         classification: "SLA STATUS", priority: "success",
         fields: [
-          { label: "STATUS",  value: "COMPLIANT",  color: "#00ff88" },
-          { label: "CRIT",    value: "4H WINDOW",  color: "rgba(148,163,184,0.6)" },
-          { label: "HIGH",    value: "24H WINDOW", color: "rgba(148,163,184,0.6)" },
-          { label: "MEDIUM",  value: "7D WINDOW",  color: "rgba(148,163,184,0.6)" },
+          { label: "STATUS", value: "COMPLIANT",  color: "#00ff88" },
+          { label: "CRIT",   value: "4H WINDOW",  color: "rgba(148,163,184,0.6)" },
+          { label: "HIGH",   value: "24H WINDOW", color: "rgba(148,163,184,0.6)" },
+          { label: "MEDIUM", value: "7D WINDOW",  color: "rgba(148,163,184,0.6)" },
         ],
         spokenText: `All incidents within SLA at ${tz}. Critical window 4 hours. High 24 hours. Fully compliant.`,
       };
@@ -172,10 +219,10 @@ function buildResponse(intent: string, stats: DerivedStats, findings: any[], _ra
           { label: "TIME",     value: `${tz}Z`,                  color: "rgba(100,116,139,0.6)" },
         ],
         items: [
-          { text: "Escalate to SOC leadership immediately",       action: "PAGE INCIDENT COMMANDER", color: "#ff0040" },
-          { text: "Document all response actions with timestamps", action: "UPDATE TICKET",           color: "#ffb000" },
+          { text: "Escalate to SOC leadership immediately",        action: "PAGE INCIDENT COMMANDER", color: "#ff0040" },
+          { text: "Document all response actions with timestamps",  action: "UPDATE TICKET",           color: "#ffb000" },
         ],
-        spokenText: `SLA breach at ${tz}. ${stats.slaBreached} incident${stats.slaBreached > 1 ? "s" : ""} exceeded response window. Escalate to SOC leadership immediately.`,
+        spokenText: `SLA breach. ${stats.slaBreached} incident${stats.slaBreached > 1 ? "s" : ""} exceeded response window. Escalate to SOC leadership immediately.`,
       };
     case "latest": {
       const recent = findings.slice(0, 4);
@@ -190,10 +237,25 @@ function buildResponse(intent: string, stats: DerivedStats, findings: any[], _ra
         fields: [{ label: "COUNT", value: String(recent.length), color: "#00d4ff" }, { label: "TIME", value: `${tz}Z`, color: "rgba(100,116,139,0.6)" }],
         items: recent.map(f => {
           const sev = (f.severity ?? "MEDIUM").toUpperCase();
-          const c = sev === "CRITICAL" ? "#ff0040" : sev === "HIGH" ? "#ff6b35" : sev === "MEDIUM" ? "#ffb000" : "#00ff88";
-          return { text: f.finding_type ?? f.title ?? "Unnamed", sub: `${sev} · ${f.region ?? "us-east-1"}`, color: c };
+          return { text: f.finding_type ?? f.title ?? "Unnamed", sub: `${sev} · ${f.region ?? "us-east-1"}`, color: sevColor(sev) };
         }),
         spokenText: `${recent.length} recent findings. ${recent.slice(0, 2).map(f => `${(f.severity ?? "medium").toLowerCase()}: ${f.finding_type ?? "unnamed"}`).join(". ")}. Triage in priority order.`,
+      };
+    }
+    case "show_findings": {
+      if (!findings.length) return {
+        classification: "FINDINGS", priority: "success",
+        fields: [{ label: "STATUS", value: "QUEUE EMPTY", color: "#00ff88" }],
+        spokenText: "No open findings. Environment looks clean.",
+      };
+      return {
+        classification: "OPEN FINDINGS", priority: stats.critical > 0 ? "critical" : stats.high > 0 ? "high" : "warning",
+        fields: [
+          { label: "TOTAL",    value: String(stats.total),    color: "#00d4ff" },
+          { label: "CRITICAL", value: String(stats.critical), color: stats.critical > 0 ? "#ff0040" : "#00ff88" },
+          { label: "HIGH",     value: String(stats.high),     color: stats.high > 0 ? "#ff6b35" : "#00ff88" },
+        ],
+        spokenText: `${stats.total} open findings. ${stats.critical} critical, ${stats.high} high. Rendering cards below.`,
       };
     }
     case "compliance":
@@ -213,31 +275,36 @@ function buildResponse(intent: string, stats: DerivedStats, findings: any[], _ra
       if (stats.high === 0) return {
         classification: "HIGH FINDINGS", priority: "success",
         fields: [{ label: "STATUS", value: "NONE ACTIVE", color: "#00ff88" }],
-        spokenText: `No high-severity findings at ${tz}. High-risk tier clean.`,
+        spokenText: `No high-severity findings. High-risk tier clean.`,
       };
       return {
         classification: "HIGH FINDINGS", priority: "high",
-        fields: [
-          { label: "COUNT", value: String(stats.high), color: "#ff6b35" },
-          { label: "SLA",   value: "24H WINDOW",       color: "#ffb000" },
-        ],
+        fields: [{ label: "COUNT", value: String(stats.high), color: "#ff6b35" }, { label: "SLA", value: "24H WINDOW", color: "#ffb000" }],
         items: highs.slice(0, 3).map(f => ({
           text: f.finding_type ?? f.title ?? "Unnamed",
-          sub: f.resource_arn?.split(":").slice(-1)[0] ?? f.region ?? "us-east-1",
+          sub:  f.resource_arn?.split(":").slice(-1)[0] ?? f.region ?? "us-east-1",
           color: "#ff6b35",
         })),
-        spokenText: `${stats.high} high-severity findings at ${tz}. 24-hour SLA. ${stats.high > 3 ? "Volume elevated — assign dedicated responders." : "Load manageable."}`,
+        spokenText: `${stats.high} high-severity findings. 24-hour SLA. ${stats.high > 3 ? "Volume elevated — assign dedicated responders." : "Load manageable."}`,
       };
     }
     case "isolate":
       return {
         classification: "CONTAINMENT REQUEST", priority: "warning",
-        fields: [{ label: "STATUS", value: "APPROVAL REQUIRED", color: "#ffb000" }],
-        items: [
-          { text: "Navigate to IR Mode on Security Overview", action: "SELECT TARGET FINDING", color: "#00d4ff" },
-          { text: "Execute via IR Action Engine",             action: "REQUIRES SR. ENGINEER",  color: "#ffb000" },
-        ],
-        spokenText: `Containment requires senior engineer approval. Navigate to IR Mode, select the target finding, and execute via the Action Engine.`,
+        fields: [{ label: "STATUS", value: "AWAITING CONFIRMATION", color: "#ffb000" }],
+        spokenText: `EC2 isolation requested. Reviewing top critical finding.`,
+      };
+    case "revoke":
+      return {
+        classification: "KEY REVOCATION REQUEST", priority: "warning",
+        fields: [{ label: "STATUS", value: "AWAITING CONFIRMATION", color: "#ffb000" }],
+        spokenText: `IAM key revocation requested. Reviewing top critical finding.`,
+      };
+    case "disable_key":
+      return {
+        classification: "KEY DISABLE REQUEST", priority: "warning",
+        fields: [{ label: "STATUS", value: "AWAITING CONFIRMATION", color: "#ffb000" }],
+        spokenText: `IAM key disable requested. Reviewing top critical finding.`,
       };
     case "scan":
       return {
@@ -251,7 +318,7 @@ function buildResponse(intent: string, stats: DerivedStats, findings: any[], _ra
           { text: "IAM · EC2 · S3 · VPC",             color: "rgba(148,163,184,0.6)" },
           { text: "GuardDuty · Security Hub · Config", color: "rgba(148,163,184,0.6)" },
         ],
-        spokenText: `Full security scan initiated at ${tz}. Scanning all services across active regions. Estimated completion 45 to 90 seconds.`,
+        spokenText: `Full security scan initiated. Scanning all services across active regions.`,
       };
     case "navigate":
       return {
@@ -263,7 +330,7 @@ function buildResponse(intent: string, stats: DerivedStats, findings: any[], _ra
           { text: "Alerts · Compliance",      sub: "alerts, compliance"      },
           { text: "SOC · Infra · Reports",    sub: "soc, infra, reports"     },
         ],
-        spokenText: `Navigation available. Say the page name such as IAM, GuardDuty, alerts, or compliance.`,
+        spokenText: `Navigation available. Say the page name: IAM, GuardDuty, alerts, or compliance.`,
       };
     case "help":
       return {
@@ -274,20 +341,21 @@ function buildResponse(intent: string, stats: DerivedStats, findings: any[], _ra
           { text: "Critical findings",   sub: "active critical alerts",     color: "#ff0040" },
           { text: "Threat level",        sub: "current threat assessment",  color: "#ff6b35" },
           { text: "SLA status",          sub: "breach and compliance info", color: "#ffb000" },
-          { text: "High risk",           sub: "high severity findings",     color: "#ff6b35" },
-          { text: "Compliance",          sub: "framework posture",          color: "#00ff88" },
-          { text: "Run scan",            sub: "full environment scan",      color: "#00d4ff" },
-          { text: "Isolate",             sub: "containment request",        color: "#ffb000" },
+          { text: "List findings",       sub: "show inline finding cards",  color: "#00d4ff" },
+          { text: "Isolate instance",    sub: "EC2 isolation — voice confirm required", color: "#ff6b35" },
+          { text: "Revoke key",          sub: "IAM key revoke — voice confirm required", color: "#ff0040" },
+          { text: "Disable key",         sub: "IAM key disable",            color: "#ffb000" },
+          { text: "Run scan",            sub: "full environment scan",      color: "#00ff88" },
           { text: "Navigate to [page]",  sub: "jump to any section",        color: "#00d4ff" },
         ],
-        spokenText: `Available commands: brief me, critical findings, threat level, SLA status, high risk, compliance, run scan, isolate, and navigate to any page. Standing by.`,
+        spokenText: `Available commands: brief me, critical findings, threat level, SLA status, list findings, isolate instance, revoke key, disable key, run scan, navigate. Standing by.`,
       };
     default:
       return {
         classification: "UNRECOGNIZED", priority: "normal",
         fields: [],
         items: [{ text: "Command not recognized", sub: `Say "help" for command list`, color: "rgba(100,116,139,0.5)" }],
-        spokenText: `Command not recognized. Say "help" for available commands. Standing by.`,
+        spokenText: `Command not recognized. Say "help" for available commands.`,
       };
   }
 }
@@ -356,6 +424,166 @@ const STATUS_CFG: Record<AgentStatus, { label: string; color: string }> = {
   error:      { label: "ERROR",      color: "#ff0040" },
 };
 
+// ── Finding mini-card ─────────────────────────────────────────────────────────
+function FindingMiniCard({ findings }: { findings: FindingSnippet[] }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+      {findings.map((f, i) => (
+        <div key={f.id} style={{
+          display: "grid", gridTemplateColumns: "16px 1fr auto",
+          alignItems: "center", gap: 8,
+          padding: "6px 10px",
+          background: "rgba(8,14,30,0.6)",
+          border: `1px solid ${f.color}22`,
+          borderLeft: `2px solid ${f.color}`,
+          borderRadius: 5,
+        }}>
+          <span style={{ fontSize: 7.5, fontWeight: 800, color: f.color, fontFamily: "'JetBrains Mono', monospace" }}>{i + 1}.</span>
+          <div style={{ minWidth: 0 }}>
+            <div style={{ fontSize: 10.5, color: "#cbd5e1", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.title}</div>
+            <div style={{ fontSize: 8.5, color: "rgba(100,116,139,0.55)", fontFamily: "'JetBrains Mono', monospace", marginTop: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{f.resource} · {f.region}</div>
+          </div>
+          <span style={{
+            fontSize: 7, fontWeight: 800, letterSpacing: "0.1em",
+            color: f.color, background: `${f.color}12`, border: `1px solid ${f.color}28`,
+            borderRadius: 3, padding: "1px 5px", fontFamily: "'JetBrains Mono', monospace", flexShrink: 0,
+          }}>{f.severity}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── IR Confirm card ───────────────────────────────────────────────────────────
+function IRConfirmCard({
+  data,
+  onYes,
+  onNo,
+}: {
+  data: IRConfirmData;
+  onYes: () => void;
+  onNo: () => void;
+}) {
+  const p = PRIO["warning"];
+  return (
+    <div style={{
+      background: "rgba(8,14,30,0.8)",
+      border: `1px solid ${p.border}`,
+      borderTop: `2px solid ${p.color}`,
+      borderRadius: 6, overflow: "hidden",
+    }}>
+      {/* Header */}
+      <div style={{ display: "flex", alignItems: "center", gap: 6, padding: "5px 10px", background: p.bg, borderBottom: `1px solid ${p.border}` }}>
+        <ShieldAlert size={10} style={{ color: p.color, flexShrink: 0 }} />
+        <span style={{ fontSize: 7.5, fontWeight: 800, letterSpacing: "0.14em", color: p.color, fontFamily: "'JetBrains Mono', monospace" }}>VOICE CONFIRMATION REQUIRED</span>
+        <span style={{ fontSize: 6.5, fontWeight: 700, color: p.color, background: `${p.color}18`, border: `1px solid ${p.color}30`, borderRadius: 3, padding: "0 5px", lineHeight: "13px", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.1em" }}>WARNING</span>
+      </div>
+      {/* Action details */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", borderBottom: `1px solid rgba(255,255,255,0.05)` }}>
+        <div style={{ padding: "6px 10px", borderRight: "1px solid rgba(255,255,255,0.05)" }}>
+          <div style={{ fontSize: 7.5, color: "rgba(100,116,139,0.4)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.1em", marginBottom: 2 }}>ACTION</div>
+          <div style={{ fontSize: 11, fontWeight: 700, color: "#ffb000", fontFamily: "'JetBrains Mono', monospace" }}>{data.label}</div>
+        </div>
+        <div style={{ padding: "6px 10px" }}>
+          <div style={{ fontSize: 7.5, color: "rgba(100,116,139,0.4)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.1em", marginBottom: 2 }}>TARGET</div>
+          <div style={{ fontSize: 10, color: "#cbd5e1", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{data.findingTitle}</div>
+        </div>
+      </div>
+      {/* Impact */}
+      <div style={{ padding: "6px 10px", borderBottom: `1px solid rgba(255,255,255,0.05)` }}>
+        <div style={{ fontSize: 7.5, color: "rgba(100,116,139,0.4)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.1em", marginBottom: 3 }}>IMPACT</div>
+        <div style={{ fontSize: 10.5, color: "#fbbf24", lineHeight: 1.4 }}>{data.impactSummary}</div>
+      </div>
+      {/* Confirm / cancel buttons */}
+      <div style={{ display: "flex", gap: 6, padding: "8px 10px" }}>
+        <button
+          onClick={onYes}
+          style={{
+            flex: 1, padding: "5px 0", borderRadius: 4, cursor: "pointer",
+            background: "rgba(255,0,64,0.12)", border: "1px solid rgba(255,0,64,0.35)",
+            color: "#ff0040", fontSize: 9, fontWeight: 800, letterSpacing: "0.12em",
+            fontFamily: "'JetBrains Mono', monospace", transition: "all 0.1s",
+          }}
+          onMouseEnter={e => { e.currentTarget.style.background = "rgba(255,0,64,0.22)"; }}
+          onMouseLeave={e => { e.currentTarget.style.background = "rgba(255,0,64,0.12)"; }}
+        >
+          CONFIRM (say YES)
+        </button>
+        <button
+          onClick={onNo}
+          style={{
+            flex: 1, padding: "5px 0", borderRadius: 4, cursor: "pointer",
+            background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.1)",
+            color: "rgba(148,163,184,0.6)", fontSize: 9, fontWeight: 700, letterSpacing: "0.1em",
+            fontFamily: "'JetBrains Mono', monospace", transition: "all 0.1s",
+          }}
+          onMouseEnter={e => { e.currentTarget.style.background = "rgba(255,255,255,0.07)"; e.currentTarget.style.color = "#94a3b8"; }}
+          onMouseLeave={e => { e.currentTarget.style.background = "rgba(255,255,255,0.03)"; e.currentTarget.style.color = "rgba(148,163,184,0.6)"; }}
+        >
+          CANCEL (say NO)
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── LLM Triage card ───────────────────────────────────────────────────────────
+function LLMTriageCard({ data, ts }: { data: TriageResult; ts: number }) {
+  const conf = data.confidence ?? 0;
+  const confColor = conf > 0.85 ? "#ff0040" : conf > 0.65 ? "#ffb000" : "#00ff88";
+  const timeStr = new Date(ts).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit", second: "2-digit", hour12: false });
+  return (
+    <div style={{
+      background: "rgba(8,14,30,0.7)",
+      border: "1px solid rgba(129,140,248,0.2)",
+      borderTop: "2px solid #818cf8",
+      borderRadius: 6, overflow: "hidden",
+    }}>
+      {/* Header */}
+      <div style={{
+        display: "flex", alignItems: "center", justifyContent: "space-between",
+        padding: "5px 10px", background: "rgba(129,140,248,0.06)", borderBottom: "1px solid rgba(129,140,248,0.12)",
+      }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <span style={{ fontSize: 7.5, fontWeight: 800, letterSpacing: "0.14em", color: "#818cf8", fontFamily: "'JetBrains Mono', monospace" }}>LLM TRIAGE</span>
+          <span style={{ fontSize: 6.5, fontWeight: 700, color: "#818cf8", background: "rgba(129,140,248,0.12)", border: "1px solid rgba(129,140,248,0.25)", borderRadius: 3, padding: "0 5px", lineHeight: "13px", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.1em" }}>AI</span>
+        </div>
+        <span style={{ fontSize: 7.5, color: "rgba(100,116,139,0.4)", fontFamily: "'JetBrains Mono', monospace" }}>ARGUS · {timeStr}Z</span>
+      </div>
+      {/* Confidence + MITRE strip */}
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", borderBottom: "1px solid rgba(255,255,255,0.05)" }}>
+        <div style={{ padding: "6px 10px", borderRight: "1px solid rgba(255,255,255,0.05)" }}>
+          <div style={{ fontSize: 7.5, color: "rgba(100,116,139,0.4)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.1em", marginBottom: 2 }}>CONFIDENCE</div>
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <span style={{ fontSize: 12, fontWeight: 700, color: confColor, fontFamily: "'JetBrains Mono', monospace" }}>{Math.round(conf * 100)}%</span>
+            <div style={{ flex: 1, height: 3, background: "rgba(255,255,255,0.06)", borderRadius: 2, overflow: "hidden" }}>
+              <div style={{ height: "100%", width: `${conf * 100}%`, background: confColor, borderRadius: 2 }} />
+            </div>
+          </div>
+        </div>
+        <div style={{ padding: "6px 10px" }}>
+          <div style={{ fontSize: 7.5, color: "rgba(100,116,139,0.4)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.1em", marginBottom: 2 }}>MITRE ATT&CK</div>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 3 }}>
+            {(data.mitre ?? []).slice(0, 4).map(t => (
+              <span key={t} style={{ fontSize: 8, fontWeight: 700, color: "#818cf8", background: "rgba(129,140,248,0.1)", border: "1px solid rgba(129,140,248,0.2)", borderRadius: 3, padding: "0 4px", lineHeight: "14px", fontFamily: "'JetBrains Mono', monospace" }}>{t}</span>
+            ))}
+          </div>
+        </div>
+      </div>
+      {/* Summary */}
+      <div style={{ padding: "8px 10px" }}>
+        <div style={{ fontSize: 7.5, color: "rgba(100,116,139,0.4)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.1em", marginBottom: 4 }}>ANALYSIS</div>
+        <div style={{ fontSize: 10.5, color: "#cbd5e1", lineHeight: 1.55 }}>{data.summary}</div>
+        {data.falsePositive !== undefined && (
+          <div style={{ marginTop: 6, fontSize: 9, color: "rgba(100,116,139,0.5)", fontFamily: "'JetBrains Mono', monospace" }}>
+            False positive probability: <span style={{ color: "#a78bfa" }}>{Math.round(data.falsePositive * 100)}%</span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
 // ── Response card ─────────────────────────────────────────────────────────────
 function ResponseCard({ response, ts, onSpeak }: { response: AgentResponse; ts: number; onSpeak?: () => void }) {
   const p = PRIO[response.priority];
@@ -366,7 +594,6 @@ function ResponseCard({ response, ts, onSpeak }: { response: AgentResponse; ts: 
     if (!onSpeak) return;
     setSpeaking(true);
     onSpeak();
-    // reset icon after ~3s as a visual cue (actual TTS duration varies)
     setTimeout(() => setSpeaking(false), 3000);
   }
 
@@ -375,14 +602,11 @@ function ResponseCard({ response, ts, onSpeak }: { response: AgentResponse; ts: 
       background: "rgba(8,14,30,0.7)",
       border: `1px solid ${p.border}`,
       borderTop: `2px solid ${p.color}`,
-      borderRadius: 6,
-      overflow: "hidden",
+      borderRadius: 6, overflow: "hidden",
     }}>
-      {/* Card header */}
       <div style={{
         display: "flex", alignItems: "center", justifyContent: "space-between",
-        padding: "5px 10px",
-        background: p.bg, borderBottom: `1px solid ${p.border}`,
+        padding: "5px 10px", background: p.bg, borderBottom: `1px solid ${p.border}`,
       }}>
         <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
           <span style={{ fontSize: 7.5, fontWeight: 800, letterSpacing: "0.14em", color: p.color, fontFamily: "'JetBrains Mono', monospace" }}>{response.classification}</span>
@@ -409,7 +633,6 @@ function ResponseCard({ response, ts, onSpeak }: { response: AgentResponse; ts: 
           )}
         </div>
       </div>
-      {/* Fields */}
       {response.fields && response.fields.length > 0 && (
         <div style={{
           display: "grid",
@@ -427,7 +650,6 @@ function ResponseCard({ response, ts, onSpeak }: { response: AgentResponse; ts: 
           ))}
         </div>
       )}
-      {/* Items */}
       {response.items && response.items.length > 0 && (
         <div style={{ padding: "2px 0" }}>
           {response.items.map((item, i) => (
@@ -473,36 +695,11 @@ function AuditRow({ entry, showSession }: { entry: AuditEntry; showSession: bool
           <div style={{ flex: 1, height: 1, background: "rgba(255,255,255,0.05)" }} />
         </div>
       )}
-      <div style={{
-        display: "grid",
-        gridTemplateColumns: "52px 36px 1fr",
-        gap: 8,
-        padding: "5px 0",
-        alignItems: "flex-start",
-        borderBottom: "1px solid rgba(255,255,255,0.03)",
-      }}>
-        {/* Timestamp */}
-        <span style={{ fontSize: 8.5, color: "rgba(100,116,139,0.38)", fontFamily: "'JetBrains Mono', monospace", paddingTop: 1 }}>
-          {timeStr}
-        </span>
-
-        {/* Type badge */}
-        <span style={{
-          fontSize: 7, fontWeight: 700, letterSpacing: "0.1em",
-          color: cfg.color, background: cfg.bg, border: `1px solid ${cfg.border}`,
-          borderRadius: 3, padding: "1px 0", textAlign: "center" as const,
-          fontFamily: "'JetBrains Mono', monospace",
-          alignSelf: "flex-start",
-        }}>{cfg.label}</span>
-
-        {/* Content */}
+      <div style={{ display: "grid", gridTemplateColumns: "52px 36px 1fr", gap: 8, padding: "5px 0", alignItems: "flex-start", borderBottom: "1px solid rgba(255,255,255,0.03)" }}>
+        <span style={{ fontSize: 8.5, color: "rgba(100,116,139,0.38)", fontFamily: "'JetBrains Mono', monospace", paddingTop: 1 }}>{timeStr}</span>
+        <span style={{ fontSize: 7, fontWeight: 700, letterSpacing: "0.1em", color: cfg.color, background: cfg.bg, border: `1px solid ${cfg.border}`, borderRadius: 3, padding: "1px 0", textAlign: "center" as const, fontFamily: "'JetBrains Mono', monospace", alignSelf: "flex-start" }}>{cfg.label}</span>
         <div style={{ minWidth: 0 }}>
-          <div style={{
-            fontSize: 10.5, color: entry.type === "stt" ? "#e2e8f0" : entry.type === "tts" ? "rgba(148,163,184,0.85)" : entry.type === "intent" ? "#a78bfa" : "rgba(100,116,139,0.5)",
-            lineHeight: 1.4, wordBreak: "break-word" as const,
-            fontFamily: entry.type === "intent" ? "'JetBrains Mono', monospace" : "inherit",
-            letterSpacing: entry.type === "intent" ? "0.06em" : "normal",
-          }}>
+          <div style={{ fontSize: 10.5, color: entry.type === "stt" ? "#e2e8f0" : entry.type === "tts" ? "rgba(148,163,184,0.85)" : entry.type === "intent" ? "#a78bfa" : "rgba(100,116,139,0.5)", lineHeight: 1.4, wordBreak: "break-word" as const, fontFamily: entry.type === "intent" ? "'JetBrains Mono', monospace" : "inherit", letterSpacing: entry.type === "intent" ? "0.06em" : "normal" }}>
             {entry.type === "stt" ? `"${entry.content}"` : entry.content}
           </div>
           {entry.confidence !== undefined && entry.type === "stt" && (
@@ -522,36 +719,28 @@ function AuditRow({ entry, showSession }: { entry: AuditEntry; showSession: bool
 
 // ── Main component ────────────────────────────────────────────────────────────
 export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
-  const [isOpen,    setIsOpen]    = useState(false);
-  const [tab,       setTab]       = useState<PanelTab>("live");
-  const [status,    setStatus]    = useState<AgentStatus>("standby");
-  const [messages,  setMessages]  = useState<Message[]>([
-    { id: "boot", role: "system", text: "ARGUS online — voice IR agent ready.", ts: Date.now() },
+  const [isOpen,       setIsOpen]       = useState(false);
+  const [tab,          setTab]          = useState<PanelTab>("live");
+  const [status,       setStatus]       = useState<AgentStatus>("standby");
+  const [messages,     setMessages]     = useState<Message[]>([
+    { id: "boot", role: "system", text: "ARGUS v2 online — press mic or type to begin.", ts: Date.now() },
   ]);
-  const [auditLog,  setAuditLog]  = useState<AuditEntry[]>([]);
-  const [partial,   setPartial]   = useState("");
-  const [textInput,  setTextInput]  = useState("");
-  const [inputMode,  setInputMode]  = useState<"voice" | "text">("voice");
-  const [hasMic,     setHasMic]     = useState(true);
-  const [wakeListenOn, setWakeListenOn] = useState(false);
-  const [passiveResumeTick, setPassiveResumeTick] = useState(0);
-  const [sessionId, setSessionId] = useState(() => newSessionId());
+  const [auditLog,     setAuditLog]     = useState<AuditEntry[]>([]);
+  const [partial,      setPartial]      = useState("");
+  const [textInput,    setTextInput]    = useState("");
+  const [inputMode,    setInputMode]    = useState<"voice" | "text">("voice");
+  const [hasMic,       setHasMic]       = useState(true);
+  const [pendingConfirm, setPendingConfirm] = useState<IRConfirmData | null>(null);
+  const [sessionId,    setSessionId]    = useState(() => newSessionId());
 
-  const recognitionRef = useRef<any>(null);
-  const synthRef       = useRef<SpeechSynthesis | null>(null);
-  const processing     = useRef(false);
-  const wakeListenOnRef = useRef(false);
-  const suspendWakeForPushRef = useRef(false);
-  const passiveBufferRef = useRef("");
-  const isOpenRef = useRef(isOpen);
-  const hasMicRef = useRef(hasMic);
-  const inputModeRef = useRef(inputMode);
-  const startPassiveWakeRef = useRef<() => void>(() => {});
-  const processCommandRef = useRef<(input: string, confidence?: number) => void>(() => {});
-  const [pushToTalkActive, setPushToTalkActive] = useState(false);
-  const liveScrollRef  = useRef<HTMLDivElement>(null);
-  const auditScrollRef = useRef<HTMLDivElement>(null);
-  const lastSessionRef = useRef<string>(sessionId);
+  const recognitionRef     = useRef<any>(null);
+  const synthRef           = useRef<SpeechSynthesis | null>(null);
+  const processing         = useRef(false);
+  const pendingConfirmRef  = useRef<IRConfirmData | null>(null);
+  const isOpenRef          = useRef(isOpen);
+  const liveScrollRef      = useRef<HTMLDivElement>(null);
+  const auditScrollRef     = useRef<HTMLDivElement>(null);
+  const lastSessionRef     = useRef<string>(sessionId);
 
   // ── Live data ───────────────────────────────────────────────────────────────
   const { getAllScanResults, scanResultsVersion } = useActiveScanResults();
@@ -577,6 +766,12 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
   const sc        = STATUS_CFG[status];
   const isActive  = status === "listening" || status === "speaking";
 
+  // Keep refs in sync
+  useEffect(() => {
+    isOpenRef.current = isOpen;
+    pendingConfirmRef.current = pendingConfirm;
+  }, [isOpen, pendingConfirm]);
+
   // ── Init ────────────────────────────────────────────────────────────────────
   useEffect(() => {
     const SR = (window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition;
@@ -585,18 +780,7 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
     return () => { recognitionRef.current?.abort(); synthRef.current?.cancel(); };
   }, []);
 
-  useEffect(() => {
-    wakeListenOnRef.current = wakeListenOn;
-    isOpenRef.current = isOpen;
-    hasMicRef.current = hasMic;
-    inputModeRef.current = inputMode;
-  }, [wakeListenOn, isOpen, hasMic, inputMode]);
-
-  useEffect(() => {
-    if (!wakeListenOn) passiveBufferRef.current = "";
-  }, [wakeListenOn]);
-
-  // New session + sys log on open
+  // New session on open
   useEffect(() => {
     if (isOpen) {
       const sid = newSessionId();
@@ -629,36 +813,214 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
     setAuditLog(prev => [...prev, { ...entry, id: `a-${Date.now()}-${Math.random().toString(36).slice(2, 5)}`, ts: Date.now() }]);
   }, []);
 
-  // ── TTS ─────────────────────────────────────────────────────────────────────
-  const speak = useCallback((text: string) => {
-    if (!synthRef.current) return;
-    synthRef.current.cancel();
-    const utt = new SpeechSynthesisUtterance(text);
-    utt.rate = 1.0; utt.pitch = 0.82; utt.volume = 0.9;
-    const voices = synthRef.current.getVoices();
-    const voice = voices.find(v => /google uk english male/i.test(v.name))
-      ?? voices.find(v => /daniel/i.test(v.name))
-      ?? voices.find(v => v.lang === "en-GB") ?? voices[0];
-    if (voice) utt.voice = voice;
-    utt.onstart = () => setStatus("speaking");
-    utt.onend   = () => setStatus("standby");
-    utt.onerror = () => setStatus("standby");
-    synthRef.current.speak(utt);
+  // ── TTS — Polly first, Web Speech fallback ──────────────────────────────────
+  const speak = useCallback(async (text: string) => {
+    setStatus("speaking");
+
+    // Try AWS Polly Neural TTS
+    const pollyOk = await pollySpeak(text);
+    if (pollyOk) {
+      setStatus("standby");
+      return;
+    }
+
+    // Fallback: Web Speech API
+    if (synthRef.current) {
+      synthRef.current.cancel();
+      const utt = new SpeechSynthesisUtterance(text);
+      utt.rate = 1.0; utt.pitch = 0.82; utt.volume = 0.9;
+      const voices = synthRef.current.getVoices();
+      const voice = voices.find(v => /google uk english male/i.test(v.name))
+        ?? voices.find(v => /daniel/i.test(v.name))
+        ?? voices.find(v => v.lang === "en-GB")
+        ?? voices[0];
+      if (voice) utt.voice = voice;
+      utt.onend   = () => setStatus("standby");
+      utt.onerror = () => setStatus("standby");
+      synthRef.current.speak(utt);
+    } else {
+      setStatus("standby");
+    }
+  }, []);
+
+  // ── LLM briefing side-effect ────────────────────────────────────────────────
+  const fetchLLMBriefing = useCallback(async (finding: any) => {
+    const loadId = `llm-${Date.now()}`;
+
+    // Loading placeholder
+    setMessages(p => [...p, {
+      id: loadId, role: "system", ts: Date.now(),
+      text: "Fetching LLM triage analysis…",
+    }]);
+
+    try {
+      const result = await fetchLLMActionResult("llm_triage", {
+        finding_id: String(finding.id ?? finding.finding_id ?? "unknown"),
+        severity:   finding.severity,
+        finding_type: finding.finding_type ?? finding.title,
+        resource_name: finding.resource_name,
+        description: finding.description,
+      });
+
+      if (result?.triage_summary) {
+        const triageData: TriageResult = {
+          summary:      result.triage_summary,
+          confidence:   result.confidence_score,
+          mitre:        result.mitre_techniques,
+          falsePositive: result.false_positive_probability,
+        };
+        setMessages(p => p.map(m =>
+          m.id === loadId
+            ? { ...m, role: "agent" as const, type: "llm_triage" as const, text: undefined, triageData }
+            : m
+        ));
+      } else {
+        setMessages(p => p.filter(m => m.id !== loadId));
+      }
+    } catch {
+      setMessages(p => p.filter(m => m.id !== loadId));
+    }
+  }, []);
+
+  // ── Execute IR action after voice confirmation ──────────────────────────────
+  const executeIRAction = useCallback(async (confirm: IRConfirmData) => {
+    const runId = `ir-run-${Date.now()}`;
+    setMessages(p => [...p, { id: runId, role: "system", ts: Date.now(), text: `Executing ${confirm.label}…` }]);
+
+    try {
+      const result = await triggerIRAction(confirm.actionType, {
+        finding_id: confirm.findingId,
+        resource_id: confirm.resourceName,
+      });
+
+      const statusLabel = result.approval_required ? "PENDING APPROVAL" : "EXECUTING";
+      const spoken = `${confirm.label} initiated. Job ${result.job_id.slice(-6).toUpperCase()}. Status: ${statusLabel}.`;
+
+      setMessages(p => [
+        ...p.filter(m => m.id !== runId),
+        {
+          id: `ir-ok-${Date.now()}`, role: "agent" as const, type: "ir_result" as const, ts: Date.now(),
+          response: {
+            classification: "IR ACTION INITIATED", priority: "warning" as ResponsePriority,
+            fields: [
+              { label: "ACTION", value: confirm.label,                                     color: "#ff6b35" },
+              { label: "JOB",    value: result.job_id.slice(-8).toUpperCase(),              color: "#00d4ff" },
+              { label: "STATUS", value: statusLabel, color: result.approval_required ? "#ffb000" : "#00ff88" },
+            ],
+            spokenText: spoken,
+          },
+        },
+      ]);
+      void speak(spoken);
+    } catch (e) {
+      setMessages(p => p.filter(m => m.id !== runId));
+      const errMsg = `${confirm.label} failed. ${(e as Error).message?.slice(0, 80) ?? "Unknown error."}`;
+      setMessages(p => [...p, {
+        id: `ir-err-${Date.now()}`, role: "agent" as const, ts: Date.now(),
+        response: { classification: "ACTION FAILED", priority: "critical" as ResponsePriority, fields: [], spokenText: errMsg },
+      }]);
+      void speak(errMsg);
+    }
+  }, [speak]);
+
+  // ── Voice confirmation response handler ─────────────────────────────────────
+  const handleConfirmResponse = useCallback((input: string, confidence?: number) => {
+    const confirm = pendingConfirmRef.current;
+    if (!confirm) return false;
+
+    const lower = input.toLowerCase().trim();
+    const isYes = /\b(yes|confirm|do it|proceed|execute|affirmative|approved?)\b/.test(lower);
+    const isNo  = /\b(no|cancel|abort|stop|negative|never mind)\b/.test(lower);
+
+    if (!isYes && !isNo) return false; // let processCommand handle as normal
+
+    processing.current = true;
+    setStatus("processing");
+    setPartial("");
+
+    pushAudit({ type: "stt", content: input.trim(), confidence, sessionId: lastSessionRef.current });
+    setMessages(p => [...p, { id: `u-${Date.now()}`, role: "user" as const, text: input.trim(), ts: Date.now() }]);
+
+    setPendingConfirm(null);
+    pendingConfirmRef.current = null;
+
+    setTimeout(() => {
+      processing.current = false;
+      setStatus("standby");
+
+      if (isNo) {
+        const msg = `${confirm.label} cancelled.`;
+        setMessages(p => [...p, {
+          id: `r-${Date.now()}`, role: "agent" as const, ts: Date.now(),
+          response: {
+            classification: "ACTION CANCELLED", priority: "normal" as ResponsePriority,
+            fields: [{ label: "STATUS", value: "CANCELLED", color: "rgba(100,116,139,0.5)" }],
+            spokenText: msg,
+          },
+        }]);
+        void speak(msg);
+        return;
+      }
+
+      // YES → execute
+      pushAudit({ type: "intent", content: `CONFIRMED ${confirm.actionType.toUpperCase()}`, sessionId: lastSessionRef.current });
+      void executeIRAction(confirm);
+    }, 150);
+
+    return true;
+  }, [speak, pushAudit, executeIRAction]);
+
+  // ── Show IR confirmation prompt ─────────────────────────────────────────────
+  const showIRConfirm = useCallback((intent: string, finding: any) => {
+    const typeMap: Record<string, IRActionType> = {
+      isolate:     "aws_ec2_isolate",
+      revoke:      "aws_iam_revoke_key",
+      disable_key: "aws_iam_disable_key",
+    };
+    const actionType = typeMap[intent];
+    if (!actionType) return;
+
+    const meta = ACTION_META[actionType];
+    const confirmData: IRConfirmData = {
+      actionType,
+      findingId:   String(finding.id ?? finding.finding_id ?? "unknown"),
+      findingTitle: finding.finding_type ?? finding.title ?? "Unknown Finding",
+      resourceName: finding.resource_name ?? finding.resource_arn ?? "",
+      label:        meta.label,
+      impactSummary: meta.impactSummary,
+    };
+
+    setPendingConfirm(confirmData);
+    pendingConfirmRef.current = confirmData;
+
+    setMessages(p => [...p, {
+      id: `confirm-${Date.now()}`, role: "agent" as const, type: "ir_confirm" as const, ts: Date.now(),
+      confirmData,
+    }]);
   }, []);
 
   // ── Process command ─────────────────────────────────────────────────────────
   const processCommand = useCallback((input: string, confidence?: number) => {
     if (processing.current || !input.trim()) return;
+
+    // Intercept confirmation responses first
+    if (pendingConfirmRef.current) {
+      const handled = handleConfirmResponse(input, confidence);
+      if (handled) return;
+      // Not a yes/no — treat as a new command and clear confirm state
+      setPendingConfirm(null);
+      pendingConfirmRef.current = null;
+    }
+
     processing.current = true;
     setStatus("processing");
     setPartial("");
 
     const intent = matchIntent(input);
 
-    // Log STT
     pushAudit({ type: "stt", content: input.trim(), confidence, sessionId: lastSessionRef.current });
 
-    // Navigate intent
+    // Navigation side-effect
     if (intent === "navigate") {
       const navMap: Record<string, string> = {
         iam: "iam-security", guardduty: "guardduty", alerts: "alerts",
@@ -672,138 +1034,65 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
       }
     }
 
-    // Log intent
     pushAudit({ type: "intent", content: intent.toUpperCase().replace(/_/g, " "), sessionId: lastSessionRef.current });
-
-    setMessages(p => [...p, { id: `u-${Date.now()}`, role: "user", text: input.trim(), ts: Date.now() }]);
+    setMessages(p => [...p, { id: `u-${Date.now()}`, role: "user" as const, text: input.trim(), ts: Date.now() }]);
 
     setTimeout(() => {
       const response = buildResponse(intent, stats, findings, input);
-      setMessages(p => [...p, { id: `r-${Date.now()}`, role: "agent", response, ts: Date.now() }]);
-      // Log TTS
+      setMessages(p => [...p, { id: `r-${Date.now()}`, role: "agent" as const, response, ts: Date.now() }]);
       pushAudit({ type: "tts", content: response.spokenText, sessionId: lastSessionRef.current });
       processing.current = false;
-      speak(response.spokenText);
-    }, 240 + Math.random() * 280);
-  }, [stats, findings, speak, onNavigate, pushAudit]);
+      void speak(response.spokenText);
 
-  useEffect(() => {
-    processCommandRef.current = processCommand;
-  }, [processCommand]);
+      // ── LLM enrichment for intelligence-gathering intents ────────────────
+      if (["briefing", "critical", "threat"].includes(intent) && findings.length > 0) {
+        const topFinding =
+          findings.find(f => (f.severity ?? "").toUpperCase() === "CRITICAL") ??
+          findings.find(f => (f.severity ?? "").toUpperCase() === "HIGH") ??
+          findings[0];
+        if (topFinding) void fetchLLMBriefing(topFinding);
+      }
 
-  // ── Passive "Hey Argus" listening (continuous STT; command only after wake phrase) ──
-  const startPassiveWake = useCallback(() => {
-    const SR = (window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition;
-    if (!SR) return;
-    if (!wakeListenOnRef.current || suspendWakeForPushRef.current) return;
-    if (!isOpenRef.current || !hasMicRef.current || inputModeRef.current !== "voice") return;
+      // ── Inline finding cards for list intent ─────────────────────────────
+      if (intent === "show_findings" && findings.length > 0) {
+        const snippets: FindingSnippet[] = findings.slice(0, 6).map((f, i) => ({
+          id:       String(f.id ?? f.finding_id ?? i),
+          title:    f.finding_type ?? f.title ?? "Unnamed Finding",
+          severity: (f.severity ?? "MEDIUM").toUpperCase(),
+          resource: f.resource_name ?? f.resource_arn?.split(":").slice(-1)[0] ?? "unknown",
+          region:   f.region ?? "us-east-1",
+          service:  f.service ?? "aws",
+          color:    sevColor(f.severity ?? "MEDIUM"),
+        }));
+        setMessages(p => [...p, {
+          id: `flist-${Date.now()}`, role: "agent" as const, type: "finding_list" as const, ts: Date.now(),
+          findingList: snippets,
+        }]);
+      }
 
-    recognitionRef.current?.abort();
-
-    const r = new SR();
-    r.lang = "en-US";
-    r.interimResults = true;
-    r.continuous = true;
-    r.maxAlternatives = 1;
-
-    r.onstart = () => {
-      setPushToTalkActive(false);
-      setStatus("listening");
-    };
-
-    r.onresult = (e: any) => {
-      let pieceFinal = "";
-      let lastConf = 0.85;
-      let interim = "";
-      for (let i = e.resultIndex; i < e.results.length; i++) {
-        const res = e.results[i];
-        const tr = res[0].transcript;
-        if (res.isFinal) {
-          pieceFinal += tr;
-          if (res[0].confidence != null) lastConf = res[0].confidence;
-        } else {
-          interim += tr;
+      // ── IR action confirmation flow ───────────────────────────────────────
+      if (["isolate", "revoke", "disable_key"].includes(intent) && findings.length > 0) {
+        const irFinding =
+          findings.find(f => (f.severity ?? "").toUpperCase() === "CRITICAL") ??
+          findings.find(f => (f.severity ?? "").toUpperCase() === "HIGH") ??
+          findings[0];
+        if (irFinding) {
+          setTimeout(() => showIRConfirm(intent, irFinding), 400);
         }
       }
-      if (interim) setPartial(interim.trim());
-      if (!pieceFinal) return;
+    }, 240 + Math.random() * 280);
+  }, [stats, findings, speak, onNavigate, pushAudit, handleConfirmResponse, fetchLLMBriefing, showIRConfirm]);
 
-      passiveBufferRef.current = `${passiveBufferRef.current} ${pieceFinal}`.trim();
-      if (passiveBufferRef.current.length > 400) {
-        passiveBufferRef.current = passiveBufferRef.current.slice(-220);
-      }
-
-      const cmd = extractCommandAfterLastWake(passiveBufferRef.current);
-      if (cmd && !processing.current) {
-        passiveBufferRef.current = "";
-        setPartial("");
-        r.stop();
-        processCommandRef.current(cmd, lastConf);
-      }
-    };
-
-    r.onerror = (ev: any) => {
-      if (ev.error === "no-speech" || ev.error === "aborted") return;
-      setStatus("error");
-      setTimeout(() => setStatus("standby"), 1200);
-    };
-
-    r.onend = () => {
-      if (!wakeListenOnRef.current) {
-        setStatus("standby");
-        return;
-      }
-      if (suspendWakeForPushRef.current) return;
-      if (processing.current) return;
-      queueMicrotask(() => {
-        if (!wakeListenOnRef.current || suspendWakeForPushRef.current || processing.current) return;
-        if (!isOpenRef.current || inputModeRef.current !== "voice") return;
-        startPassiveWakeRef.current();
-      });
-    };
-
-    recognitionRef.current = r;
-    try {
-      r.start();
-    } catch {
-      /* SR may throw if start called in an invalid state */
-    }
-  }, []);
-
-  useEffect(() => {
-    startPassiveWakeRef.current = startPassiveWake;
-  }, [startPassiveWake]);
-
-  useEffect(() => {
-    if (!isOpen || !wakeListenOn || !hasMic || inputMode !== "voice") {
-      recognitionRef.current?.abort();
-      return;
-    }
-    if (status === "processing" || status === "speaking") {
-      recognitionRef.current?.abort();
-      return;
-    }
-    if (suspendWakeForPushRef.current) return;
-    startPassiveWake();
-    return () => {
-      recognitionRef.current?.abort();
-    };
-  }, [isOpen, wakeListenOn, hasMic, inputMode, status, passiveResumeTick, startPassiveWake]);
-
-  // ── Speech recognition (push-to-talk — no wake phrase required) ───────────────
+  // ── Push-to-talk ────────────────────────────────────────────────────────────
   const startListening = useCallback(() => {
     const SR = (window as any).SpeechRecognition ?? (window as any).webkitSpeechRecognition;
     if (!SR) return;
-    suspendWakeForPushRef.current = true;
     recognitionRef.current?.abort();
-    passiveBufferRef.current = "";
     setPartial("");
+
     const r = new SR();
     r.lang = "en-US"; r.interimResults = true; r.continuous = false;
-    r.onstart = () => {
-      setPushToTalkActive(true);
-      setStatus("listening");
-    };
+    r.onstart  = () => setStatus("listening");
     r.onresult = (e: any) => {
       const last = e.results[e.results.length - 1];
       setPartial(last[0].transcript);
@@ -814,20 +1103,10 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
     };
     r.onerror = (e: any) => {
       if (e.error === "aborted") return;
-      if (e.error === "no-speech") setStatus("standby");
-      else {
-        setStatus("error");
-        setTimeout(() => setStatus("standby"), 1000);
-      }
+      if (e.error === "no-speech") { setStatus("standby"); }
+      else { setStatus("error"); setTimeout(() => setStatus("standby"), 1000); }
     };
-    r.onend = () => {
-      suspendWakeForPushRef.current = false;
-      setPushToTalkActive(false);
-      setStatus("standby");
-      if (wakeListenOnRef.current && isOpenRef.current && hasMicRef.current && inputModeRef.current === "voice") {
-        setPassiveResumeTick(t => t + 1);
-      }
-    };
+    r.onend = () => setStatus("standby");
     recognitionRef.current = r;
     r.start();
   }, [processCommand]);
@@ -839,21 +1118,11 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
       return;
     }
     if (status === "listening") {
-      if (suspendWakeForPushRef.current) {
-        recognitionRef.current?.stop();
-        suspendWakeForPushRef.current = false;
-        setPushToTalkActive(false);
-        setStatus("standby");
-        if (wakeListenOnRef.current) setPassiveResumeTick(t => t + 1);
-      } else if (wakeListenOnRef.current) {
-        startListening();
-      } else {
-        recognitionRef.current?.stop();
-        setPushToTalkActive(false);
-        setStatus("standby");
-      }
+      recognitionRef.current?.stop();
+      setStatus("standby");
       return;
     }
+    setInputMode("voice");
     startListening();
   }, [status, startListening]);
 
@@ -867,10 +1136,8 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
     const blob = new Blob([lines.join("\n")], { type: "text/plain" });
     const url  = URL.createObjectURL(blob);
     const a    = document.createElement("a");
-    a.href = url;
-    a.download = `argus-audit-${new Date().toISOString().slice(0, 10)}.log`;
-    a.click();
-    URL.revokeObjectURL(url);
+    a.href = url; a.download = `argus-audit-${new Date().toISOString().slice(0, 10)}.log`;
+    a.click(); URL.revokeObjectURL(url);
   }, [auditLog]);
 
   // ── Quick commands ──────────────────────────────────────────────────────────
@@ -879,11 +1146,10 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
     { label: "CRITICAL",  cmd: "show critical findings",   color: "#ff0040" },
     { label: "THREAT",    cmd: "what is the threat level", color: stats.critical > 0 ? "#ff0040" : "#ffb000" },
     { label: "SLA",       cmd: "sla status",               color: stats.slaBreached > 0 ? "#ff0040" : "#00ff88" },
+    { label: "FINDINGS",  cmd: "list findings",            color: "#00d4ff" },
     { label: "HIGH RISK", cmd: "high risk findings",       color: "#ff6b35" },
-    { label: "SCAN",      cmd: "run scan",                 color: "#00ff88" },
   ] as const;
 
-  // Group audit entries by session for dividers
   const auditWithDividers = useMemo(() => {
     let lastSid = "";
     return auditLog.map(e => {
@@ -893,12 +1159,15 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
     });
   }, [auditLog]);
 
+  const voiceBusy = status === "processing" || status === "listening";
+
   return (
     <>
       <style>{`
         @keyframes argus-pulse  { 0%,100%{opacity:1;} 50%{opacity:0.22;} }
         @keyframes argus-threat { 0%,85%,100%{opacity:1;} 87%{opacity:0.08;} }
         @keyframes argus-border { 0%,100%{box-shadow:0 0 0 1px rgba(0,212,255,0.12);} 50%{box-shadow:0 0 0 2px rgba(0,212,255,0.4);} }
+        @keyframes spin         { from{transform:rotate(0deg);} to{transform:rotate(360deg);} }
         .argus-threat  { animation: argus-threat 2s ease-in-out infinite; }
         .argus-border  { animation: argus-border 2s ease-in-out infinite; }
       `}</style>
@@ -928,18 +1197,19 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
         }}
       >
         <div style={{ position: "absolute", left: 0, top: 0, bottom: 0, width: 2, borderRadius: "6px 0 0 6px", background: isActive ? sc.color : hasThreat ? "#ff0040" : "rgba(0,212,255,0.35)", transition: "background 0.3s" }} />
-
         <span style={{ marginLeft: 4, display: "flex", alignItems: "center", color: isActive ? sc.color : hasThreat ? "#ff6b35" : "rgba(0,212,255,0.5)", transition: "color 0.2s" }}>
           {isActive ? <MiniWave active color={sc.color} /> : status === "processing" ? <Zap size={11} style={{ animation: "spin 0.65s linear infinite" }} /> : <Mic size={11} />}
         </span>
-
         <span style={{ fontSize: 9.5, fontWeight: 700, letterSpacing: "0.15em", fontFamily: "'JetBrains Mono', monospace", color: isActive ? sc.color : "rgba(148,163,184,0.7)", transition: "color 0.2s" }}>ARGUS</span>
-
         <span style={{ width: 4, height: 4, borderRadius: "50%", flexShrink: 0, background: sc.color, boxShadow: isActive ? `0 0 0 1px ${sc.color}40` : "none", animation: isActive ? "argus-pulse 0.85s ease-in-out infinite" : "none", transition: "background 0.2s" }} />
-
         {hasThreat && (
           <span className="argus-threat" style={{ fontSize: 7, fontWeight: 800, letterSpacing: "0.06em", color: "#ff0040", background: "rgba(255,0,64,0.1)", border: "1px solid rgba(255,0,64,0.25)", borderRadius: 999, padding: "0 4px", lineHeight: "14px", fontFamily: "'JetBrains Mono', monospace" }}>
             {stats.critical}C
+          </span>
+        )}
+        {pendingConfirm && (
+          <span style={{ fontSize: 7, fontWeight: 800, letterSpacing: "0.06em", color: "#ffb000", background: "rgba(255,176,0,0.1)", border: "1px solid rgba(255,176,0,0.3)", borderRadius: 999, padding: "0 4px", lineHeight: "14px", fontFamily: "'JetBrains Mono', monospace" }}>
+            CONFIRM
           </span>
         )}
       </button>
@@ -961,12 +1231,17 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
             transition: "border-color 0.3s",
           }}
         >
-          {/* ── Top bar: wordmark + status + close ── */}
+          {/* ── Top bar ── */}
           <div style={{ padding: "10px 14px", borderBottom: "1px solid rgba(255,255,255,0.055)", display: "flex", alignItems: "center", gap: 8 }}>
             <span style={{ width: 6, height: 6, borderRadius: "50%", flexShrink: 0, background: sc.color, boxShadow: isActive ? `0 0 0 1px ${sc.color}40` : "none", animation: isActive ? "argus-pulse 0.85s ease-in-out infinite" : "none", transition: "all 0.3s" }} />
             <span style={{ fontSize: 10.5, fontWeight: 700, color: "#00d4ff", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.18em" }}>ARGUS</span>
-            <span style={{ fontSize: 8, color: "rgba(100,116,139,0.38)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.06em" }}>VOICE IR AGENT</span>
+            <span style={{ fontSize: 8, color: "rgba(100,116,139,0.38)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.06em" }}>VOICE IR AGENT v2</span>
             <span style={{ fontSize: 7.5, fontWeight: 700, color: sc.color, background: `${sc.color}10`, border: `1px solid ${sc.color}22`, borderRadius: 3, padding: "1px 6px", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.12em", transition: "all 0.25s" }}>{sc.label}</span>
+            {pendingConfirm && (
+              <span style={{ fontSize: 7.5, fontWeight: 700, color: "#ffb000", background: "rgba(255,176,0,0.1)", border: "1px solid rgba(255,176,0,0.28)", borderRadius: 3, padding: "1px 6px", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.1em" }}>
+                CONFIRM?
+              </span>
+            )}
             <div style={{ flex: 1 }} />
             {stats.critical > 0 && <span style={{ fontSize: 8, fontWeight: 700, color: "#ff0040", background: "rgba(255,0,64,0.08)", border: "1px solid rgba(255,0,64,0.2)", borderRadius: 3, padding: "1px 5px", fontFamily: "'JetBrains Mono', monospace" }}>{stats.critical}C</span>}
             {stats.high > 0    && <span style={{ fontSize: 8, fontWeight: 700, color: "#ff6b35", background: "rgba(255,107,53,0.07)", border: "1px solid rgba(255,107,53,0.18)", borderRadius: 3, padding: "1px 5px", fontFamily: "'JetBrains Mono', monospace" }}>{stats.high}H</span>}
@@ -975,32 +1250,17 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
           </div>
 
           {/* ── Tab bar ── */}
-          <div style={{
-            display: "flex",
-            borderBottom: "1px solid rgba(255,255,255,0.06)",
-            background: "rgba(0,3,10,0.4)",
-          }}>
+          <div style={{ display: "flex", borderBottom: "1px solid rgba(255,255,255,0.06)", background: "rgba(0,3,10,0.4)" }}>
             {([
               { id: "live",  label: "LIVE",      badge: null },
               { id: "audit", label: "AUDIT LOG", badge: auditLog.length > 0 ? String(auditLog.length) : null },
             ] as const).map(({ id, label, badge }) => {
               const active = tab === id;
               return (
-                <button
-                  key={id}
-                  onClick={() => setTab(id)}
-                  style={{
-                    flex: 1, padding: "8px 14px",
-                    display: "flex", alignItems: "center", justifyContent: "center", gap: 6,
-                    cursor: "pointer", background: "transparent", border: "none",
-                    borderBottom: active ? `2px solid #00d4ff` : "2px solid transparent",
-                    marginBottom: -1,
-                    transition: "all 0.15s",
-                  }}
-                >
+                <button key={id} onClick={() => setTab(id)} style={{ flex: 1, padding: "8px 14px", display: "flex", alignItems: "center", justifyContent: "center", gap: 6, cursor: "pointer", background: "transparent", border: "none", borderBottom: active ? `2px solid #00d4ff` : "2px solid transparent", marginBottom: -1, transition: "all 0.15s" }}>
                   <span style={{ fontSize: 9, fontWeight: 700, letterSpacing: "0.12em", color: active ? "#00d4ff" : "rgba(100,116,139,0.4)", fontFamily: "'JetBrains Mono', monospace", transition: "color 0.15s" }}>{label}</span>
                   {badge && (
-                    <span style={{ fontSize: 7, fontWeight: 700, color: active ? "#00d4ff" : "rgba(100,116,139,0.35)", background: active ? "rgba(0,212,255,0.1)" : "rgba(255,255,255,0.04)", border: `1px solid ${active ? "rgba(0,212,255,0.22)" : "rgba(255,255,255,0.07)"}`, borderRadius: 999, padding: "0 5px", lineHeight: "14px", fontFamily: "'JetBrains Mono', monospace", transition: "all 0.15s" }}>
+                    <span style={{ fontSize: 7, fontWeight: 700, color: active ? "#00d4ff" : "rgba(100,116,139,0.35)", background: active ? "rgba(0,212,255,0.1)" : "rgba(255,255,255,0.04)", border: `1px solid ${active ? "rgba(0,212,255,0.22)" : "rgba(255,255,255,0.07)"}`, borderRadius: 999, padding: "0 5px", lineHeight: "14px", fontFamily: "'JetBrains Mono', monospace" }}>
                       {badge}
                     </span>
                   )}
@@ -1012,7 +1272,7 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
           {/* ══ LIVE TAB ════════════════════════════════════════════════════════ */}
           {tab === "live" && (
             <>
-              {/* Waveform */}
+              {/* Waveform strip */}
               <div style={{ padding: "8px 14px", borderBottom: "1px solid rgba(255,255,255,0.05)", display: "flex", alignItems: "center", gap: 12, background: "rgba(0,5,14,0.4)", minHeight: 44, opacity: inputMode === "text" && !isActive ? 0.28 : 1, transition: "opacity 0.3s" }}>
                 <Waveform active={isActive} color={sc.color} />
                 {partial && status === "listening" && (
@@ -1027,28 +1287,9 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
                 )}
               </div>
 
-              {/* Quick commands + optional wake phrase listening */}
-              <div style={{ padding: "7px 14px", borderBottom: "1px solid rgba(255,255,255,0.05)", display: "flex", flexWrap: "wrap", alignItems: "center", gap: 4 }}>
-                {hasMic && inputMode === "voice" && (
-                  <button
-                    type="button"
-                    title="When ON, the mic stays open while this panel is visible; say “Hey Argus” before your command. Turn OFF for push-to-talk only."
-                    onClick={() => setWakeListenOn(w => !w)}
-                    disabled={status === "processing" || (status === "listening" && pushToTalkActive)}
-                    style={{
-                      fontSize: 8, fontWeight: 800, letterSpacing: "0.1em",
-                      color: wakeListenOn ? "#00d4ff" : "rgba(100,116,139,0.45)",
-                      background: wakeListenOn ? "rgba(0,212,255,0.1)" : "rgba(255,255,255,0.03)",
-                      border: `1px solid ${wakeListenOn ? "rgba(0,212,255,0.35)" : "rgba(255,255,255,0.08)"}`,
-                      borderRadius: 4, padding: "3px 8px", cursor: "pointer", fontFamily: "'JetBrains Mono', monospace",
-                      opacity: status === "processing" || (status === "listening" && pushToTalkActive) ? 0.35 : 1,
-                      transition: "all 0.1s", marginRight: 4,
-                    }}
-                  >HEY ARGUS {wakeListenOn ? "ON" : "OFF"}</button>
-                )}
-                {quickCmds.map(({ label, cmd, color }) => {
-                  const voiceBusy = status === "processing" || (status === "listening" && pushToTalkActive);
-                  return (
+              {/* Quick commands */}
+              <div style={{ padding: "7px 14px", borderBottom: "1px solid rgba(255,255,255,0.05)", display: "flex", flexWrap: "wrap", gap: 4 }}>
+                {quickCmds.map(({ label, cmd, color }) => (
                   <button
                     key={cmd}
                     onClick={() => processCommand(cmd)}
@@ -1057,13 +1298,13 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
                     onMouseEnter={e => { e.currentTarget.style.background = `${color}18`; e.currentTarget.style.borderColor = `${color}38`; }}
                     onMouseLeave={e => { e.currentTarget.style.background = `${color}09`; e.currentTarget.style.borderColor = `${color}20`; }}
                   >{label}</button>
-                  );
-                })}
+                ))}
               </div>
 
               {/* Transcript */}
-              <div style={{ overflowY: "auto", maxHeight: 320, padding: "10px 14px", display: "flex", flexDirection: "column", gap: 8 }}>
+              <div style={{ overflowY: "auto", maxHeight: 340, padding: "10px 14px", display: "flex", flexDirection: "column", gap: 8 }}>
                 {messages.map(msg => {
+                  // System message
                   if (msg.role === "system") return (
                     <div key={msg.id} style={{ display: "flex", alignItems: "center", gap: 8 }}>
                       <div style={{ flex: 1, height: 1, background: "rgba(0,212,255,0.07)" }} />
@@ -1071,6 +1312,8 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
                       <div style={{ flex: 1, height: 1, background: "rgba(0,212,255,0.07)" }} />
                     </div>
                   );
+
+                  // User bubble
                   if (msg.role === "user") return (
                     <div key={msg.id} style={{ display: "flex", justifyContent: "flex-end" }}>
                       <div style={{ maxWidth: "72%", background: "rgba(0,212,255,0.06)", border: "1px solid rgba(0,212,255,0.12)", borderRadius: "6px 6px 2px 6px", padding: "5px 10px" }}>
@@ -1079,14 +1322,56 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
                       </div>
                     </div>
                   );
-                  if (msg.role === "agent" && msg.response) return (
-                    <div key={msg.id}><ResponseCard response={msg.response} ts={msg.ts} onSpeak={() => speak(msg.response!.spokenText)} /></div>
+
+                  // IR confirmation card
+                  if (msg.role === "agent" && msg.type === "ir_confirm" && msg.confirmData) return (
+                    <div key={msg.id}>
+                      <IRConfirmCard
+                        data={msg.confirmData}
+                        onYes={() => {
+                          const c = msg.confirmData!;
+                          setPendingConfirm(null);
+                          pendingConfirmRef.current = null;
+                          // Remove the confirm card from messages
+                          setMessages(p => p.filter(m => m.id !== msg.id));
+                          void executeIRAction(c);
+                        }}
+                        onNo={() => {
+                          setPendingConfirm(null);
+                          pendingConfirmRef.current = null;
+                          setMessages(p => p.filter(m => m.id !== msg.id));
+                          const cancelMsg = `${msg.confirmData!.label} cancelled.`;
+                          setMessages(p => [...p, { id: `r-${Date.now()}`, role: "agent" as const, ts: Date.now(), response: { classification: "ACTION CANCELLED", priority: "normal" as ResponsePriority, fields: [], spokenText: cancelMsg } }]);
+                          void speak(cancelMsg);
+                        }}
+                      />
+                    </div>
                   );
+
+                  // LLM triage card
+                  if (msg.role === "agent" && msg.type === "llm_triage" && msg.triageData) return (
+                    <div key={msg.id}><LLMTriageCard data={msg.triageData} ts={msg.ts} /></div>
+                  );
+
+                  // Inline finding list
+                  if (msg.role === "agent" && msg.type === "finding_list" && msg.findingList) return (
+                    <div key={msg.id}><FindingMiniCard findings={msg.findingList} /></div>
+                  );
+
+                  // Standard agent response card
+                  if (msg.role === "agent" && msg.response) return (
+                    <div key={msg.id}><ResponseCard response={msg.response} ts={msg.ts} onSpeak={() => void speak(msg.response!.spokenText)} /></div>
+                  );
+
                   return null;
                 })}
+
+                {/* Processing indicator */}
                 {status === "processing" && (
                   <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "6px 10px", background: "rgba(167,139,250,0.05)", border: "1px solid rgba(167,139,250,0.12)", borderTop: "2px solid rgba(167,139,250,0.5)", borderRadius: 6 }}>
-                    <span style={{ fontSize: 7.5, color: "#a78bfa", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.12em" }}>ANALYZING</span>
+                    <span style={{ fontSize: 7.5, color: "#a78bfa", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.12em" }}>
+                      {pendingConfirm ? "AWAITING RESPONSE" : "ANALYZING"}
+                    </span>
                     {[0, 0.14, 0.28].map((d, i) => (
                       <div key={i} style={{ width: 3, height: 3, borderRadius: "50%", background: "#a78bfa", animation: `argus-pulse 0.8s ease-in-out ${d}s infinite` }} />
                     ))}
@@ -1095,9 +1380,8 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
                 <div ref={liveScrollRef} />
               </div>
 
-              {/* Unified input footer */}
+              {/* ── Input footer ── */}
               <div style={{ borderTop: "1px solid rgba(255,255,255,0.05)", background: "rgba(0,3,10,0.5)" }}>
-                {/* Input row */}
                 <div style={{ padding: "8px 14px", display: "flex", gap: 5, alignItems: "center" }}>
                   <div style={{ flex: 1, position: "relative" as const }}>
                     <input
@@ -1105,19 +1389,25 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
                       onChange={e => { setTextInput(e.target.value); if (e.target.value) setInputMode("text"); }}
                       onFocus={() => setInputMode("text")}
                       onKeyDown={e => { if (e.key === "Enter" && textInput.trim()) { processCommand(textInput); setTextInput(""); } }}
-                      placeholder={inputMode === "voice" ? "Or type a command…" : "Type a command or question…"}
+                      placeholder={
+                        pendingConfirm
+                          ? `Confirm or cancel ${pendingConfirm.label}…`
+                          : inputMode === "voice"
+                            ? "Or type a command…"
+                            : "Type a command or question…"
+                      }
                       disabled={status === "processing"}
                       style={{
                         width: "100%", boxSizing: "border-box" as const,
-                        background: inputMode === "text" ? "rgba(0,212,255,0.04)" : "rgba(0,5,14,0.6)",
-                        border: `1px solid ${inputMode === "text" ? "rgba(0,212,255,0.22)" : "rgba(255,255,255,0.07)"}`,
+                        background: pendingConfirm ? "rgba(255,176,0,0.04)" : inputMode === "text" ? "rgba(0,212,255,0.04)" : "rgba(0,5,14,0.6)",
+                        border: `1px solid ${pendingConfirm ? "rgba(255,176,0,0.3)" : inputMode === "text" ? "rgba(0,212,255,0.22)" : "rgba(255,255,255,0.07)"}`,
                         borderRadius: 6, padding: "6px 10px", fontSize: 11,
                         color: "#e2e8f0", fontFamily: "'JetBrains Mono', monospace", outline: "none",
                         transition: "border-color 0.2s, background 0.2s",
                       }}
                     />
                   </div>
-                  {/* Send — visible when text is present */}
+                  {/* Send button */}
                   <button
                     onClick={() => { if (textInput.trim()) { processCommand(textInput); setTextInput(""); } }}
                     disabled={!textInput.trim() || status === "processing"}
@@ -1128,11 +1418,10 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
                       border: `1px solid ${textInput.trim() ? "rgba(0,212,255,0.28)" : "rgba(255,255,255,0.06)"}`,
                       color: textInput.trim() ? "#00d4ff" : "rgba(100,116,139,0.25)",
                       fontSize: 10, fontWeight: 700, fontFamily: "'JetBrains Mono', monospace",
-                      transition: "all 0.15s", opacity: status === "processing" ? 0.35 : 1,
-                      flexShrink: 0,
+                      transition: "all 0.15s", opacity: status === "processing" ? 0.35 : 1, flexShrink: 0,
                     }}
                   >→</button>
-                  {/* Mic — deprioritized in text mode */}
+                  {/* Mic button */}
                   {hasMic && (
                     <button
                       onClick={() => { setInputMode("voice"); handleMicToggle(); }}
@@ -1141,7 +1430,13 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
                         display: "flex", alignItems: "center", gap: 5,
                         fontSize: 9, fontWeight: 700, letterSpacing: "0.08em",
                         fontFamily: "'JetBrains Mono', monospace", transition: "all 0.15s",
-                        background: status === "listening" ? "rgba(0,212,255,0.12)" : status === "speaking" ? "rgba(0,255,136,0.08)" : inputMode === "text" ? "rgba(255,255,255,0.03)" : "rgba(255,255,255,0.05)",
+                        background: status === "listening"
+                          ? "rgba(0,212,255,0.12)"
+                          : status === "speaking"
+                            ? "rgba(0,255,136,0.08)"
+                            : inputMode === "text"
+                              ? "rgba(255,255,255,0.03)"
+                              : "rgba(255,255,255,0.05)",
                         border: `1px solid ${status === "listening" ? "rgba(0,212,255,0.4)" : status === "speaking" ? "rgba(0,255,136,0.25)" : inputMode === "text" ? "rgba(255,255,255,0.06)" : "rgba(255,255,255,0.1)"}`,
                         color: status === "listening" ? "#00d4ff" : status === "speaking" ? "#00ff88" : inputMode === "text" ? "rgba(100,116,139,0.3)" : "rgba(148,163,184,0.5)",
                         flexShrink: 0,
@@ -1152,26 +1447,23 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
                     </button>
                   )}
                 </div>
+
                 {/* Status line */}
                 <div style={{ padding: "0 14px 7px", display: "flex", alignItems: "center", gap: 6 }}>
-                  <span style={{ fontSize: 7.5, letterSpacing: "0.1em", fontFamily: "'JetBrains Mono', monospace", color: isActive ? sc.color : inputMode === "text" ? "rgba(0,212,255,0.35)" : "rgba(100,116,139,0.25)", transition: "color 0.25s" }}>
-                    {status === "listening" && pushToTalkActive
-                      ? "● PUSH-TO-TALK — SPEAK NOW"
-                      : status === "listening" && wakeListenOn
-                        ? "● LISTENING — SAY \"HEY ARGUS\", THEN COMMAND"
-                        : status === "listening"
-                          ? "● VOICE ACTIVE — SPEAK NOW"
-                          : status === "processing"
-                            ? "● PROCESSING COMMAND"
-                            : status === "speaking"
-                              ? "● ARGUS SPEAKING"
-                              : inputMode === "text"
-                                ? "TEXT MODE — ENTER TO SEND"
-                                : hasMic
-                                  ? wakeListenOn
-                                    ? "HEY ARGUS ON — OR PRESS MIC / TYPE"
-                                    : "VOICE READY — PRESS MIC OR TYPE"
-                                  : "TEXT MODE ACTIVE"}
+                  <span style={{ fontSize: 7.5, letterSpacing: "0.1em", fontFamily: "'JetBrains Mono', monospace", color: isActive ? sc.color : pendingConfirm ? "#ffb000" : inputMode === "text" ? "rgba(0,212,255,0.35)" : "rgba(100,116,139,0.25)", transition: "color 0.25s" }}>
+                    {status === "listening"
+                      ? "● SPEAK NOW — RELEASE TO PROCESS"
+                      : status === "processing"
+                        ? "● PROCESSING"
+                        : status === "speaking"
+                          ? "● ARGUS SPEAKING"
+                          : pendingConfirm
+                            ? `● CONFIRM ${pendingConfirm.label.toUpperCase()} — SAY YES OR NO`
+                            : inputMode === "text"
+                              ? "TEXT MODE — ENTER TO SEND"
+                              : hasMic
+                                ? "VOICE READY — PRESS MIC OR TYPE"
+                                : "TEXT MODE ACTIVE"}
                   </span>
                   {inputMode === "text" && hasMic && (
                     <button
@@ -1187,7 +1479,6 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
           {/* ══ AUDIT TAB ═══════════════════════════════════════════════════════ */}
           {tab === "audit" && (
             <>
-              {/* Audit toolbar */}
               <div style={{ padding: "8px 14px", borderBottom: "1px solid rgba(255,255,255,0.05)", display: "flex", alignItems: "center", gap: 8, background: "rgba(0,5,14,0.4)" }}>
                 <div style={{ flex: 1 }}>
                   <span style={{ fontSize: 8, color: "rgba(100,116,139,0.35)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.08em" }}>
@@ -1195,40 +1486,25 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
                   </span>
                 </div>
                 <div style={{ display: "flex", gap: 4 }}>
-                  {/* Legend */}
-                  {([
-                    { label: "STT", color: "#00d4ff" },
-                    { label: "TTS", color: "#00ff88" },
-                    { label: "INT", color: "#a78bfa" },
-                  ] as const).map(({ label, color }) => (
-                    <span key={label} style={{ fontSize: 7, fontWeight: 700, color, background: `${color}0a`, border: `1px solid ${color}20`, borderRadius: 3, padding: "1px 5px", fontFamily: "'JetBrains Mono', monospace" }}>{label}</span>
-                  ))}
+                  {(["STT", "TTS", "INT"] as const).map(label => {
+                    const c = label === "STT" ? "#00d4ff" : label === "TTS" ? "#00ff88" : "#a78bfa";
+                    return <span key={label} style={{ fontSize: 7, fontWeight: 700, color: c, background: `${c}0a`, border: `1px solid ${c}20`, borderRadius: 3, padding: "1px 5px", fontFamily: "'JetBrains Mono', monospace" }}>{label}</span>;
+                  })}
                 </div>
                 <div style={{ width: 1, height: 16, background: "rgba(255,255,255,0.06)" }} />
-                <button
-                  onClick={() => setAuditLog([])}
-                  disabled={auditLog.length === 0}
-                  title="Clear log"
-                  style={{ width: 24, height: 24, borderRadius: 4, display: "flex", alignItems: "center", justifyContent: "center", background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.07)", color: "rgba(100,116,139,0.4)", cursor: auditLog.length === 0 ? "not-allowed" : "pointer", opacity: auditLog.length === 0 ? 0.3 : 1 }}
-                >
+                <button onClick={() => setAuditLog([])} disabled={auditLog.length === 0} title="Clear log" style={{ width: 24, height: 24, borderRadius: 4, display: "flex", alignItems: "center", justifyContent: "center", background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.07)", color: "rgba(100,116,139,0.4)", cursor: auditLog.length === 0 ? "not-allowed" : "pointer", opacity: auditLog.length === 0 ? 0.3 : 1 }}>
                   <Trash2 size={10} />
                 </button>
-                <button
-                  onClick={exportAudit}
-                  disabled={auditLog.length === 0}
-                  title="Export log as .log file"
-                  style={{ width: 24, height: 24, borderRadius: 4, display: "flex", alignItems: "center", justifyContent: "center", background: auditLog.length > 0 ? "rgba(0,212,255,0.07)" : "rgba(255,255,255,0.03)", border: `1px solid ${auditLog.length > 0 ? "rgba(0,212,255,0.18)" : "rgba(255,255,255,0.07)"}`, color: auditLog.length > 0 ? "#00d4ff" : "rgba(100,116,139,0.35)", cursor: auditLog.length === 0 ? "not-allowed" : "pointer", opacity: auditLog.length === 0 ? 0.3 : 1 }}
-                >
+                <button onClick={exportAudit} disabled={auditLog.length === 0} title="Export log as .log file" style={{ width: 24, height: 24, borderRadius: 4, display: "flex", alignItems: "center", justifyContent: "center", background: auditLog.length > 0 ? "rgba(0,212,255,0.07)" : "rgba(255,255,255,0.03)", border: `1px solid ${auditLog.length > 0 ? "rgba(0,212,255,0.18)" : "rgba(255,255,255,0.07)"}`, color: auditLog.length > 0 ? "#00d4ff" : "rgba(100,116,139,0.35)", cursor: auditLog.length === 0 ? "not-allowed" : "pointer", opacity: auditLog.length === 0 ? 0.3 : 1 }}>
                   <Download size={10} />
                 </button>
               </div>
 
-              {/* Log entries */}
               <div style={{ overflowY: "auto", maxHeight: 440, padding: "6px 14px 10px" }}>
                 {auditLog.length === 0 ? (
                   <div style={{ padding: "40px 0", textAlign: "center" as const }}>
                     <div style={{ fontSize: 8.5, color: "rgba(100,116,139,0.3)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.1em" }}>NO ENTRIES YET</div>
-                    <div style={{ fontSize: 10, color: "rgba(100,116,139,0.2)", marginTop: 6 }}>Switch to LIVE and issue a voice command to begin logging.</div>
+                    <div style={{ fontSize: 10, color: "rgba(100,116,139,0.2)", marginTop: 6 }}>Switch to LIVE and issue a command to begin logging.</div>
                   </div>
                 ) : (
                   auditWithDividers.map(({ entry, showSession }) => (
@@ -1238,10 +1514,9 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
                 <div ref={auditScrollRef} />
               </div>
 
-              {/* Audit footer */}
               <div style={{ padding: "8px 14px", borderTop: "1px solid rgba(255,255,255,0.05)", display: "flex", alignItems: "center", gap: 8, background: "rgba(0,3,10,0.5)" }}>
                 <span style={{ flex: 1, fontSize: 8, color: "rgba(100,116,139,0.28)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.08em" }}>
-                  VOICE AUDIT LOG · ARGUS v1.0 · FOR QA AND COMPLIANCE USE
+                  VOICE AUDIT LOG · ARGUS v2 · FOR QA AND COMPLIANCE USE
                 </span>
                 <span style={{ fontSize: 7.5, color: "rgba(100,116,139,0.25)", fontFamily: "'JetBrains Mono', monospace" }}>↓ .log export</span>
               </div>

--- a/src/components/ui/FindingDetailPanel.tsx
+++ b/src/components/ui/FindingDetailPanel.tsx
@@ -17,7 +17,7 @@
  *   Agent Actions   → POST  /api/agents/{action}
  */
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import {
   ChevronRight,
   Copy,
@@ -36,8 +36,12 @@ import {
   UserCircle,
   FlaskConical,
   Archive,
+  Loader2,
+  RefreshCw,
 } from "lucide-react";
 import { toast } from "sonner";
+import type { IRActionRequest } from "../../types/ir";
+import { fetchLLMActionResult } from "../../services/irEngine";
 import { SeverityBadge } from "./SeverityBadge";
 import { IRActionEngine } from "../ir/IRActionEngine";
 import { EvidenceForensicsPanel } from "../ir/EvidenceForensicsPanel";
@@ -208,6 +212,24 @@ function normaliseSeverity(raw: string | number): string {
   return up;
 }
 
+function llmRequestFromFinding(finding: FindingData): IRActionRequest {
+  return {
+    finding_id: finding.id,
+    severity: normaliseSeverity(finding.severity),
+    finding_type: finding.title,
+    resource_name: finding.resource_name,
+    description: finding.description,
+    resource_arn: finding.resource_arn,
+    region: finding.region ?? "us-east-1",
+  };
+}
+
+/** Backend may set `model: "mock"` when Bedrock is not used — show neutral copy in the UI. */
+function formatLlmModelDisplay(model?: string): string {
+  if (!model) return "—";
+  return model.trim().toLowerCase() === "mock" ? "Preview" : model;
+}
+
 function sevColor(s: string): string {
   return SEV_COLOR[normaliseSeverity(s)] ?? "#64748b";
 }
@@ -316,6 +338,90 @@ export function FindingDetailPanel({
 }: FindingDetailPanelProps) {
   const [activeTab, setActiveTab] = useState<TabId>("overview");
   const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  type OverviewAiPayload = {
+    triage: string;
+    rootCause: string;
+    triageModel?: string;
+    rootModel?: string;
+    confidence?: number;
+    falsePositive?: number;
+    mitre?: string[];
+  };
+
+  const overviewAiCacheRef = useRef<Map<string, OverviewAiPayload>>(new Map());
+  const runbookAiCacheRef = useRef<Map<string, { markdown: string; model?: string }>>(new Map());
+  const findingRef = useRef(finding);
+  findingRef.current = finding;
+
+  const [overviewAi, setOverviewAi] = useState<
+    { status: "idle" | "loading" | "ready" | "error"; error?: string } & Partial<OverviewAiPayload>
+  >({ status: "idle" });
+
+  const [runbookAi, setRunbookAi] = useState<{
+    status: "idle" | "loading" | "ready" | "error";
+    error?: string;
+    markdown?: string;
+    model?: string;
+  }>({ status: "idle" });
+
+  useEffect(() => {
+    if (activeTab !== "overview") return;
+    const hit = overviewAiCacheRef.current.get(finding.id);
+    if (hit) setOverviewAi({ status: "ready", ...hit });
+    else setOverviewAi({ status: "idle" });
+  }, [activeTab, finding.id]);
+
+  useEffect(() => {
+    if (activeTab !== "runbook") return;
+    const hit = runbookAiCacheRef.current.get(finding.id);
+    if (hit) setRunbookAi({ status: "ready", markdown: hit.markdown, model: hit.model });
+    else setRunbookAi({ status: "idle" });
+  }, [activeTab, finding.id]);
+
+  const loadOverviewAi = useCallback(async (force: boolean) => {
+    const f = findingRef.current;
+    if (force) overviewAiCacheRef.current.delete(f.id);
+    setOverviewAi({ status: "loading" });
+    try {
+      const req = llmRequestFromFinding(f);
+      const triageRes = await fetchLLMActionResult("llm_triage", req);
+      const rootRes = await fetchLLMActionResult("llm_root_cause", req);
+      const payload: OverviewAiPayload = {
+        triage: (triageRes?.triage_summary as string) ?? "",
+        rootCause: (rootRes?.root_cause_narrative as string) ?? "",
+        triageModel: triageRes?.model as string | undefined,
+        rootModel: rootRes?.model as string | undefined,
+        confidence: triageRes?.confidence_score as number | undefined,
+        falsePositive: triageRes?.false_positive_probability as number | undefined,
+        mitre: triageRes?.mitre_techniques as string[] | undefined,
+      };
+      overviewAiCacheRef.current.set(f.id, payload);
+      setOverviewAi({ status: "ready", ...payload });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Request failed";
+      setOverviewAi({ status: "error", error: msg });
+      toast.error("AI overview failed", { description: msg });
+    }
+  }, []);
+
+  const loadRunbookAi = useCallback(async (force: boolean) => {
+    const f = findingRef.current;
+    if (force) runbookAiCacheRef.current.delete(f.id);
+    setRunbookAi({ status: "loading" });
+    try {
+      const req = llmRequestFromFinding(f);
+      const res = await fetchLLMActionResult("llm_runbook", req);
+      const markdown = (res?.runbook_markdown as string) ?? "";
+      const model = res?.model as string | undefined;
+      runbookAiCacheRef.current.set(f.id, { markdown, model });
+      setRunbookAi({ status: "ready", markdown, model });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "Request failed";
+      setRunbookAi({ status: "error", error: msg });
+      toast.error("AI runbook failed", { description: msg });
+    }
+  }, []);
 
   const severity    = normaliseSeverity(finding.severity);
   const riskScore   = finding.risk_score ?? defaultRiskScore(severity);
@@ -828,12 +934,264 @@ export function FindingDetailPanel({
                     )}
                   </div>
                 )}
+
+                <div
+                  style={{
+                    padding: "12px 16px",
+                    borderRadius: 8,
+                    background: "rgba(99,102,241,0.06)",
+                    border: "1px solid rgba(129,140,248,0.22)",
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+                    <div style={{ ...ls, color: "rgba(129,140,248,0.85)", marginBottom: 0 }}>AI-assisted overview</div>
+                    <div style={{ display: "flex", gap: 6, flexShrink: 0 }}>
+                      {overviewAi.status === "ready" && (
+                        <button
+                          type="button"
+                          onClick={() => void loadOverviewAi(true)}
+                          disabled={overviewAi.status === "loading"}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 4,
+                            padding: "6px 12px",
+                            borderRadius: 6,
+                            background: "rgba(129,140,248,0.12)",
+                            border: "1px solid rgba(129,140,248,0.28)",
+                            color: "#818cf8",
+                            fontSize: 11,
+                            fontWeight: 600,
+                            cursor: "pointer",
+                            ...mono,
+                          }}
+                        >
+                          <RefreshCw size={12} />
+                          Regenerate
+                        </button>
+                      )}
+                      {(overviewAi.status === "idle" || overviewAi.status === "error") && (
+                        <button
+                          type="button"
+                          onClick={() => void loadOverviewAi(false)}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 6,
+                            padding: "6px 14px",
+                            borderRadius: 6,
+                            background: "rgba(129,140,248,0.18)",
+                            border: "1px solid rgba(129,140,248,0.35)",
+                            color: "#a5b4fc",
+                            fontSize: 12,
+                            fontWeight: 600,
+                            cursor: "pointer",
+                            ...mono,
+                          }}
+                        >
+                          <Zap size={14} />
+                          Generate AI overview
+                        </button>
+                      )}
+                    </div>
+                  </div>
+
+                  {overviewAi.status === "loading" && (
+                    <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 12, color: "rgba(148,163,184,0.9)", fontSize: 12 }}>
+                      <Loader2 size={16} color="#818cf8" className="animate-spin" />
+                      Running triage, then root-cause (sequential)…
+                    </div>
+                  )}
+
+                  {overviewAi.status === "error" && (
+                    <div style={{ marginTop: 10, fontSize: 12, color: "#fb7185", lineHeight: 1.5 }}>
+                      {overviewAi.error}
+                      <button
+                        type="button"
+                        onClick={() => void loadOverviewAi(false)}
+                        style={{
+                          marginLeft: 8,
+                          padding: "2px 8px",
+                          borderRadius: 4,
+                          background: "rgba(251,113,133,0.12)",
+                          border: "1px solid rgba(251,113,133,0.3)",
+                          color: "#fb7185",
+                          fontSize: 10,
+                          cursor: "pointer",
+                          ...mono,
+                        }}
+                      >
+                        Retry
+                      </button>
+                    </div>
+                  )}
+
+                  {overviewAi.status === "ready" && (
+                    <div style={{ marginTop: 12, display: "flex", flexDirection: "column", gap: 12 }}>
+                      {(overviewAi.triageModel || overviewAi.rootModel) && (
+                        <div style={{ display: "flex", flexWrap: "wrap", gap: 8, ...mono, fontSize: 9, color: "rgba(100,116,139,0.5)" }}>
+                          {overviewAi.triageModel && (
+                            <span>Triage: {formatLlmModelDisplay(overviewAi.triageModel)}</span>
+                          )}
+                          {overviewAi.rootModel && (
+                            <span>Root-cause: {formatLlmModelDisplay(overviewAi.rootModel)}</span>
+                          )}
+                          {overviewAi.confidence !== undefined && <span>Confidence: {(overviewAi.confidence * 100).toFixed(0)}%</span>}
+                          {overviewAi.mitre && overviewAi.mitre.length > 0 && <span>MITRE: {overviewAi.mitre.join(", ")}</span>}
+                        </div>
+                      )}
+                      {overviewAi.triage ? (
+                        <div>
+                          <div style={{ ...ls, marginBottom: 6 }}>Triage</div>
+                          <p style={{ fontSize: 12, color: "#e2e8f0", lineHeight: 1.65, margin: 0, whiteSpace: "pre-wrap" }}>
+                            {overviewAi.triage}
+                          </p>
+                        </div>
+                      ) : null}
+                      {overviewAi.rootCause ? (
+                        <div>
+                          <div style={{ ...ls, marginBottom: 6 }}>Root cause</div>
+                          <p style={{ fontSize: 12, color: "#cbd5e1", lineHeight: 1.65, margin: 0, whiteSpace: "pre-wrap" }}>
+                            {overviewAi.rootCause}
+                          </p>
+                        </div>
+                      ) : null}
+                      {!overviewAi.triage && !overviewAi.rootCause && (
+                        <p style={{ fontSize: 12, color: "rgba(100,116,139,0.55)", margin: 0 }}>
+                          Empty response. Check Flask <code style={mono}>BEDROCK_API_KEY</code> and{" "}
+                          <code style={mono}>VITE_IR_API_BASE</code> (e.g. <code style={mono}>http://localhost:3001/api/v1</code>).
+                        </p>
+                      )}
+                    </div>
+                  )}
+                </div>
               </div>
             )}
 
             {/* ── RUNBOOK ─────────────────────────────────────────────── */}
             {activeTab === "runbook" && (
               <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+                <div
+                  style={{
+                    padding: "12px 16px",
+                    borderRadius: 8,
+                    background: "rgba(99,102,241,0.06)",
+                    border: "1px solid rgba(129,140,248,0.22)",
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
+                    <div>
+                      <div style={{ ...ls, color: "rgba(129,140,248,0.85)", marginBottom: 4 }}>AI runbook</div>
+                      <p style={{ fontSize: 11, color: "rgba(100,116,139,0.65)", margin: 0, lineHeight: 1.5 }}>
+                        On-demand; cached per finding until you regenerate.
+                      </p>
+                    </div>
+                    <div style={{ display: "flex", gap: 6 }}>
+                      {runbookAi.status === "ready" && (
+                        <button
+                          type="button"
+                          onClick={() => void loadRunbookAi(true)}
+                          disabled={runbookAi.status === "loading"}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 4,
+                            padding: "6px 12px",
+                            borderRadius: 6,
+                            background: "rgba(129,140,248,0.12)",
+                            border: "1px solid rgba(129,140,248,0.28)",
+                            color: "#818cf8",
+                            fontSize: 11,
+                            fontWeight: 600,
+                            cursor: "pointer",
+                            ...mono,
+                          }}
+                        >
+                          <RefreshCw size={12} />
+                          Regenerate
+                        </button>
+                      )}
+                      {(runbookAi.status === "idle" || runbookAi.status === "error") && (
+                        <button
+                          type="button"
+                          onClick={() => void loadRunbookAi(false)}
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 6,
+                            padding: "6px 14px",
+                            borderRadius: 6,
+                            background: "rgba(129,140,248,0.18)",
+                            border: "1px solid rgba(129,140,248,0.35)",
+                            color: "#a5b4fc",
+                            fontSize: 12,
+                            fontWeight: 600,
+                            cursor: "pointer",
+                            ...mono,
+                          }}
+                        >
+                          <GitBranch size={14} />
+                          Generate AI runbook
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                  {runbookAi.status === "loading" && (
+                    <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 12, color: "rgba(148,163,184,0.9)", fontSize: 12 }}>
+                      <Loader2 size={16} color="#818cf8" className="animate-spin" />
+                      Generating runbook…
+                    </div>
+                  )}
+                  {runbookAi.status === "error" && (
+                    <div style={{ marginTop: 10, fontSize: 12, color: "#fb7185" }}>
+                      {runbookAi.error}
+                      <button
+                        type="button"
+                        onClick={() => void loadRunbookAi(false)}
+                        style={{
+                          marginLeft: 8,
+                          padding: "2px 8px",
+                          borderRadius: 4,
+                          background: "rgba(251,113,133,0.12)",
+                          border: "1px solid rgba(251,113,133,0.3)",
+                          color: "#fb7185",
+                          fontSize: 10,
+                          cursor: "pointer",
+                          ...mono,
+                        }}
+                      >
+                        Retry
+                      </button>
+                    </div>
+                  )}
+                  {runbookAi.status === "ready" && runbookAi.markdown && (
+                    <div style={{ marginTop: 12 }}>
+                      {runbookAi.model && (
+                        <p style={{ ...mono, fontSize: 9, color: "rgba(100,116,139,0.5)", margin: "0 0 8px" }}>
+                          Model: {formatLlmModelDisplay(runbookAi.model)}
+                        </p>
+                      )}
+                      <pre
+                        style={{
+                          ...mono,
+                          fontSize: 11,
+                          color: "#e2e8f0",
+                          lineHeight: 1.55,
+                          margin: 0,
+                          whiteSpace: "pre-wrap",
+                          wordBreak: "break-word",
+                          maxHeight: 260,
+                          overflowY: "auto",
+                        }}
+                      >
+                        {runbookAi.markdown}
+                      </pre>
+                    </div>
+                  )}
+                </div>
+
+                <div style={{ ...ls, color: "rgba(100,116,139,0.45)" }}>Built-in playbook</div>
+
                 {/* Phase legend + time estimate */}
                 <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
                   {(Object.keys(PHASE_META) as PlaybookPhase[]).map((ph) => (

--- a/src/components/ui/FindingDetailPanel.tsx
+++ b/src/components/ui/FindingDetailPanel.tsx
@@ -455,7 +455,7 @@ export function FindingDetailPanel({
       const steps: PlaybookStep[] =
         Array.isArray(rawSteps) &&
         rawSteps.length > 0 &&
-        rawSteps.every(s => s && typeof s === "object" && VALID_PHASES.includes((s as PlaybookStep).phase))
+        rawSteps.every(s => s && typeof s === "object" && VALID_PHASES.includes((s as PlaybookStep).phase) && Array.isArray((s as PlaybookStep).commands))
           ? rawSteps
           : [];
       if (steps.length === 0) {

--- a/src/components/ui/FindingDetailPanel.tsx
+++ b/src/components/ui/FindingDetailPanel.tsx
@@ -40,7 +40,7 @@ import {
   RefreshCw,
 } from "lucide-react";
 import { toast } from "sonner";
-import type { IRActionRequest } from "../../types/ir";
+import type { IRActionRequest, PlaybookPhase, PlaybookStep } from "../../types/ir";
 import { fetchLLMActionResult } from "../../services/irEngine";
 import { SeverityBadge } from "./SeverityBadge";
 import { IRActionEngine } from "../ir/IRActionEngine";
@@ -61,7 +61,7 @@ export type WorkflowStatus =
   | "FALSE_POSITIVE";
 
 export type ActorType = "system" | "analyst" | "engineer" | "automation";
-export type PlaybookPhase = "IDENTIFY" | "CONTAIN" | "REMEDIATE" | "VERIFY";
+export type { PlaybookPhase, PlaybookStep } from "../../types/ir";
 
 export interface TimelineEvent {
   id: string;
@@ -70,15 +70,6 @@ export interface TimelineEvent {
   actor_type: ActorType;
   action: string;
   note?: string;
-}
-
-export interface PlaybookStep {
-  step: number;
-  phase: PlaybookPhase;
-  title: string;
-  description: string;
-  commands: string[];
-  estimated_time: string;
 }
 
 export interface WorkflowData {
@@ -263,6 +254,39 @@ function riskColor(score: number): string {
   return "#00ff88";
 }
 
+/**
+ * Replace generic LLM placeholders in AI-generated steps with real finding values.
+ * Uses a JSON-level string replace so every field (title, description, commands) is covered.
+ */
+function hydratePlaceholders(steps: PlaybookStep[], finding: FindingData): PlaybookStep[] {
+  const resourceName = finding.resource_name ?? "RESOURCE_NAME";
+  const resourceArn  = finding.resource_arn  ?? "RESOURCE_ARN";
+  const findingId    = finding.id;
+  const region       = finding.region        ?? "us-east-1";
+  // Derive a plausible IAM username from the ARN if resource_name looks generic
+  const iamUser = resourceArn.includes(":user/")
+    ? resourceArn.split(":user/").pop() ?? resourceName
+    : resourceArn.includes(":role/")
+    ? resourceArn.split(":role/").pop() ?? resourceName
+    : resourceName;
+
+  const pairs: [RegExp, string][] = [
+    [/\bUSERNAME\b/g,                  iamUser],
+    [/\bRESOURCE_ARN\b/g,              resourceArn],
+    [/\bAKIA_REPLACE\b/g,              resourceName],
+    [/\bFINDING_ID\b/g,                findingId],
+    [/\bPRODUCT_ARN\b/g,               resourceArn],
+    [/\b(?:IR-REPLACE|IR-001)\b/g,     `IR-${findingId.slice(0, 8).toUpperCase()}`],
+    [/\bREGION\b/g,                    region],
+  ];
+
+  let raw = JSON.stringify(steps);
+  for (const [re, val] of pairs) {
+    raw = raw.replace(re, val.replace(/\\/g, "\\\\").replace(/"/g, '\\"'));
+  }
+  return JSON.parse(raw) as PlaybookStep[];
+}
+
 function defaultPlaybook(finding: FindingData): PlaybookStep[] {
   const sev = normaliseSeverity(finding.severity);
   return [
@@ -338,6 +362,8 @@ export function FindingDetailPanel({
 }: FindingDetailPanelProps) {
   const [activeTab, setActiveTab] = useState<TabId>("overview");
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [descExpanded, setDescExpanded] = useState(false);
+  const [recExpanded,  setRecExpanded]  = useState(false);
 
   type OverviewAiPayload = {
     triage: string;
@@ -350,7 +376,7 @@ export function FindingDetailPanel({
   };
 
   const overviewAiCacheRef = useRef<Map<string, OverviewAiPayload>>(new Map());
-  const runbookAiCacheRef = useRef<Map<string, { markdown: string; model?: string }>>(new Map());
+  const runbookAiCacheRef = useRef<Map<string, { steps: PlaybookStep[]; model?: string }>>(new Map());
   const findingRef = useRef(finding);
   findingRef.current = finding;
 
@@ -361,9 +387,14 @@ export function FindingDetailPanel({
   const [runbookAi, setRunbookAi] = useState<{
     status: "idle" | "loading" | "ready" | "error";
     error?: string;
-    markdown?: string;
+    steps?: PlaybookStep[];
     model?: string;
   }>({ status: "idle" });
+
+  useEffect(() => {
+    setDescExpanded(false);
+    setRecExpanded(false);
+  }, [finding.id]);
 
   useEffect(() => {
     if (activeTab !== "overview") return;
@@ -375,7 +406,7 @@ export function FindingDetailPanel({
   useEffect(() => {
     if (activeTab !== "runbook") return;
     const hit = runbookAiCacheRef.current.get(finding.id);
-    if (hit) setRunbookAi({ status: "ready", markdown: hit.markdown, model: hit.model });
+    if (hit) setRunbookAi({ status: "ready", steps: hit.steps, model: hit.model });
     else setRunbookAi({ status: "idle" });
   }, [activeTab, finding.id]);
 
@@ -412,10 +443,27 @@ export function FindingDetailPanel({
     try {
       const req = llmRequestFromFinding(f);
       const res = await fetchLLMActionResult("llm_runbook", req);
-      const markdown = (res?.runbook_markdown as string) ?? "";
+      const rawSteps = res?.runbook_steps as PlaybookStep[] | undefined;
       const model = res?.model as string | undefined;
-      runbookAiCacheRef.current.set(f.id, { markdown, model });
-      setRunbookAi({ status: "ready", markdown, model });
+      const VALID_PHASES: PlaybookStep["phase"][] = ["IDENTIFY", "CONTAIN", "REMEDIATE", "VERIFY"];
+      const steps: PlaybookStep[] =
+        Array.isArray(rawSteps) &&
+        rawSteps.length > 0 &&
+        VALID_PHASES.includes(rawSteps[0].phase)
+          ? rawSteps
+          : [];
+      if (steps.length === 0) {
+        // Backend returned a response but no structured steps (e.g. old deployment
+        // still returning runbook_markdown). Surface as error so the user knows.
+        throw new Error(
+          res?.runbook_markdown
+            ? "Backend needs restart — still returning old runbook format"
+            : "Backend returned no structured steps"
+        );
+      }
+      const hydratedSteps = hydratePlaceholders(steps, f);
+      runbookAiCacheRef.current.set(f.id, { steps: hydratedSteps, model });
+      setRunbookAi({ status: "ready", steps: hydratedSteps, model });
     } catch (e) {
       const msg = e instanceof Error ? e.message : "Request failed";
       setRunbookAi({ status: "error", error: msg });
@@ -425,7 +473,8 @@ export function FindingDetailPanel({
 
   const severity    = normaliseSeverity(finding.severity);
   const riskScore   = finding.risk_score ?? defaultRiskScore(severity);
-  const steps       = playbook ?? defaultPlaybook(finding);
+  const aiSteps     = runbookAi.status === "ready" && runbookAi.steps?.length ? runbookAi.steps : undefined;
+  const steps       = aiSteps ?? playbook ?? defaultPlaybook(finding);
   const w           = workflow;
   const wMeta       = w ? WORKFLOW_META[w.status] : WORKFLOW_META["NEW"];
   const nextStatus  = w ? NEXT_STATUS[w.status] : undefined;
@@ -884,34 +933,8 @@ export function FindingDetailPanel({
             {/* ── OVERVIEW ────────────────────────────────────────────── */}
             {activeTab === "overview" && (
               <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
-                {/* Description */}
-                <div>
-                  <div style={{ ...ls, marginBottom: 8 }}>Description</div>
-                  <p style={{ fontSize: 13, color: "#e2e8f0", lineHeight: 1.7, margin: 0 }}>
-                    {finding.description}
-                  </p>
-                </div>
 
-                {/* Recommendation */}
-                {finding.recommendation && (
-                  <div
-                    style={{
-                      padding: "12px 16px",
-                      borderRadius: 8,
-                      background: "rgba(255,176,0,0.07)",
-                      border: "1px solid rgba(255,176,0,0.2)",
-                    }}
-                  >
-                    <div style={{ ...ls, color: "rgba(255,176,0,0.8)", marginBottom: 6 }}>
-                      Recommendation
-                    </div>
-                    <p style={{ fontSize: 12, color: "rgba(252,211,77,0.85)", lineHeight: 1.7, margin: 0 }}>
-                      {finding.recommendation}
-                    </p>
-                  </div>
-                )}
-
-                {/* Risk acceptance note */}
+                {/* Risk acceptance note — always shown when present */}
                 {w?.risk_acceptance_note && (
                   <div
                     style={{
@@ -921,9 +944,7 @@ export function FindingDetailPanel({
                       border: "1px solid rgba(251,146,60,0.2)",
                     }}
                   >
-                    <div style={{ ...ls, color: "rgba(251,146,60,0.8)", marginBottom: 4 }}>
-                      Risk Acceptance Note
-                    </div>
+                    <div style={{ ...ls, color: "rgba(251,146,60,0.8)", marginBottom: 4 }}>Risk Acceptance Note</div>
                     <p style={{ fontSize: 12, color: "#fb923c", margin: 0, lineHeight: 1.5 }}>
                       {w.risk_acceptance_note}
                     </p>
@@ -935,136 +956,267 @@ export function FindingDetailPanel({
                   </div>
                 )}
 
-                <div
-                  style={{
-                    padding: "12px 16px",
-                    borderRadius: 8,
-                    background: "rgba(99,102,241,0.06)",
-                    border: "1px solid rgba(129,140,248,0.22)",
-                  }}
-                >
-                  <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10, flexWrap: "wrap" }}>
-                    <div style={{ ...ls, color: "rgba(129,140,248,0.85)", marginBottom: 0 }}>AI-assisted overview</div>
-                    <div style={{ display: "flex", gap: 6, flexShrink: 0 }}>
-                      {overviewAi.status === "ready" && (
+                {overviewAi.status === "ready" ? (
+                  // ── AI LOADED ─────────────────────────────────────────────────────────
+                  <>
+                    {/* Confidence / MITRE / FP strip */}
+                    {(() => {
+                      const confPct = overviewAi.confidence !== undefined ? Math.round(overviewAi.confidence * 100) : null;
+                      const fpPct   = overviewAi.falsePositive !== undefined ? Math.round(overviewAi.falsePositive * 100) : null;
+                      const confColor = confPct === null ? "#64748b" : confPct >= 80 ? "#00ff88" : confPct >= 50 ? "#ffb000" : "#ff0040";
+                      const fpColor   = fpPct   === null ? "#64748b" : fpPct   <= 10 ? "#00ff88" : fpPct   <= 30 ? "#ffb000" : "#ff0040";
+                      const model = overviewAi.triageModel ?? overviewAi.rootModel;
+                      return (
+                        <div style={{ display: "flex", alignItems: "center", gap: 6, flexWrap: "wrap" }}>
+                          {confPct !== null && (
+                            <span
+                              style={{
+                                display: "inline-flex", alignItems: "center", gap: 4,
+                                padding: "3px 9px", borderRadius: 20,
+                                background: `${confColor}14`,
+                                border: `1px solid ${confColor}35`,
+                                fontSize: 11, fontWeight: 700, color: confColor,
+                                ...mono,
+                              }}
+                            >
+                              ✓ {confPct}%
+                            </span>
+                          )}
+                          {fpPct !== null && (
+                            <span
+                              style={{
+                                display: "inline-flex", alignItems: "center",
+                                padding: "3px 9px", borderRadius: 20,
+                                background: `${fpColor}10`,
+                                border: `1px solid ${fpColor}30`,
+                                fontSize: 10, fontWeight: 600, color: fpColor,
+                                ...mono,
+                              }}
+                            >
+                              FP {fpPct}%
+                            </span>
+                          )}
+                          {overviewAi.mitre?.map((t) => (
+                            <span
+                              key={t}
+                              style={{
+                                padding: "3px 8px", borderRadius: 4,
+                                background: "rgba(129,140,248,0.1)",
+                                border: "1px solid rgba(129,140,248,0.25)",
+                                fontSize: 10, fontWeight: 700, color: "#818cf8",
+                                ...mono,
+                              }}
+                            >
+                              {t}
+                            </span>
+                          ))}
+                          <span style={{ flex: 1 }} />
+                          {model && (
+                            <span style={{ ...mono, fontSize: 9, color: "rgba(100,116,139,0.4)" }}>
+                              {formatLlmModelDisplay(model)}
+                            </span>
+                          )}
+                          <button
+                            type="button"
+                            onClick={() => void loadOverviewAi(true)}
+                            title="Regenerate AI overview"
+                            style={{
+                              display: "flex", alignItems: "center", justifyContent: "center",
+                              width: 24, height: 24, borderRadius: 5,
+                              background: "rgba(129,140,248,0.08)",
+                              border: "1px solid rgba(129,140,248,0.22)",
+                              color: "rgba(129,140,248,0.6)",
+                              cursor: "pointer",
+                              flexShrink: 0,
+                            }}
+                          >
+                            <RefreshCw size={11} />
+                          </button>
+                        </div>
+                      );
+                    })()}
+
+                    {/* Triage Assessment */}
+                    {overviewAi.triage ? (
+                      <div>
+                        <div style={{ ...ls, marginBottom: 6 }}>Triage Assessment</div>
+                        <p style={{ fontSize: 13, color: "#e2e8f0", lineHeight: 1.7, margin: 0, whiteSpace: "pre-wrap" }}>
+                          {overviewAi.triage}
+                        </p>
+                      </div>
+                    ) : null}
+
+                    {/* Root Cause */}
+                    {overviewAi.rootCause ? (
+                      <div>
+                        <div style={{ ...ls, marginBottom: 6 }}>Root Cause</div>
+                        <p style={{ fontSize: 12, color: "#cbd5e1", lineHeight: 1.65, margin: 0, whiteSpace: "pre-wrap" }}>
+                          {overviewAi.rootCause}
+                        </p>
+                      </div>
+                    ) : null}
+
+                    {/* Empty AI response */}
+                    {!overviewAi.triage && !overviewAi.rootCause && (
+                      <p style={{ fontSize: 12, color: "rgba(100,116,139,0.55)", margin: 0 }}>
+                        Empty response — check <code style={mono}>BEDROCK_API_KEY</code> and{" "}
+                        <code style={mono}>VITE_IR_API_BASE</code>.
+                      </p>
+                    )}
+
+                    {/* Disclosure toggles */}
+                    <div
+                      style={{
+                        borderTop: divider,
+                        paddingTop: 10,
+                        display: "flex",
+                        gap: 6,
+                        flexWrap: "wrap",
+                      }}
+                    >
+                      {(
+                        [
+                          { label: "Raw description", expanded: descExpanded, toggle: () => setDescExpanded((x) => !x) },
+                          ...(finding.recommendation
+                            ? [{ label: "Recommendation", expanded: recExpanded, toggle: () => setRecExpanded((x) => !x) }]
+                            : []),
+                        ] as { label: string; expanded: boolean; toggle: () => void }[]
+                      ).map(({ label, expanded, toggle }) => (
                         <button
+                          key={label}
                           type="button"
-                          onClick={() => void loadOverviewAi(true)}
-                          disabled={overviewAi.status === "loading"}
+                          onClick={toggle}
                           style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 4,
-                            padding: "6px 12px",
-                            borderRadius: 6,
-                            background: "rgba(129,140,248,0.12)",
-                            border: "1px solid rgba(129,140,248,0.28)",
-                            color: "#818cf8",
-                            fontSize: 11,
-                            fontWeight: 600,
+                            display: "inline-flex", alignItems: "center", gap: 4,
+                            padding: "3px 10px", borderRadius: 4,
+                            background: expanded ? "rgba(100,116,139,0.12)" : "transparent",
+                            border: "1px solid rgba(100,116,139,0.2)",
+                            color: "rgba(100,116,139,0.65)",
+                            fontSize: 10, fontWeight: 600,
                             cursor: "pointer",
                             ...mono,
+                            textTransform: "uppercase",
+                            letterSpacing: "0.07em",
                           }}
                         >
-                          <RefreshCw size={12} />
-                          Regenerate
+                          <ChevronRight
+                            size={9}
+                            style={{
+                              transform: expanded ? "rotate(90deg)" : "none",
+                              transition: "transform 0.15s",
+                              flexShrink: 0,
+                            }}
+                          />
+                          {label}
                         </button>
-                      )}
-                      {(overviewAi.status === "idle" || overviewAi.status === "error") && (
+                      ))}
+                    </div>
+
+                    {/* Expanded description */}
+                    {descExpanded && (
+                      <p
+                        style={{
+                          fontSize: 12, color: "rgba(148,163,184,0.75)",
+                          lineHeight: 1.65, margin: 0,
+                          paddingLeft: 12,
+                          borderLeft: "2px solid rgba(100,116,139,0.18)",
+                        }}
+                      >
+                        {finding.description}
+                      </p>
+                    )}
+
+                    {/* Expanded recommendation */}
+                    {recExpanded && finding.recommendation && (
+                      <p
+                        style={{
+                          fontSize: 12, color: "rgba(252,211,77,0.8)",
+                          lineHeight: 1.65, margin: 0,
+                          paddingLeft: 12,
+                          borderLeft: "2px solid rgba(255,176,0,0.25)",
+                        }}
+                      >
+                        {finding.recommendation}
+                      </p>
+                    )}
+                  </>
+                ) : (
+                  // ── PRE-AI (idle / loading / error) ───────────────────────────────────
+                  <>
+                    {/* Description */}
+                    <div>
+                      <div style={{ ...ls, marginBottom: 8 }}>Description</div>
+                      <p style={{ fontSize: 13, color: "#e2e8f0", lineHeight: 1.7, margin: 0 }}>
+                        {finding.description}
+                      </p>
+                    </div>
+
+                    {/* Recommendation */}
+                    {finding.recommendation && (
+                      <div
+                        style={{
+                          padding: "12px 16px", borderRadius: 8,
+                          background: "rgba(255,176,0,0.07)",
+                          border: "1px solid rgba(255,176,0,0.2)",
+                        }}
+                      >
+                        <div style={{ ...ls, color: "rgba(255,176,0,0.8)", marginBottom: 6 }}>Recommendation</div>
+                        <p style={{ fontSize: 12, color: "rgba(252,211,77,0.85)", lineHeight: 1.7, margin: 0 }}>
+                          {finding.recommendation}
+                        </p>
+                      </div>
+                    )}
+
+                    {/* Loading */}
+                    {overviewAi.status === "loading" && (
+                      <div style={{ display: "flex", alignItems: "center", gap: 10, color: "rgba(148,163,184,0.9)", fontSize: 12 }}>
+                        <Loader2 size={16} color="#818cf8" className="animate-spin" />
+                        Running triage + root-cause analysis…
+                      </div>
+                    )}
+
+                    {/* Error */}
+                    {overviewAi.status === "error" && (
+                      <div style={{ fontSize: 12, color: "#fb7185", lineHeight: 1.5, display: "flex", alignItems: "center", gap: 8 }}>
+                        <span>{overviewAi.error}</span>
                         <button
                           type="button"
                           onClick={() => void loadOverviewAi(false)}
                           style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 6,
-                            padding: "6px 14px",
-                            borderRadius: 6,
-                            background: "rgba(129,140,248,0.18)",
-                            border: "1px solid rgba(129,140,248,0.35)",
-                            color: "#a5b4fc",
-                            fontSize: 12,
-                            fontWeight: 600,
-                            cursor: "pointer",
+                            padding: "2px 8px", borderRadius: 4, flexShrink: 0,
+                            background: "rgba(251,113,133,0.12)",
+                            border: "1px solid rgba(251,113,133,0.3)",
+                            color: "#fb7185", fontSize: 10, cursor: "pointer",
                             ...mono,
                           }}
                         >
-                          <Zap size={14} />
-                          Generate AI overview
+                          Retry
                         </button>
-                      )}
-                    </div>
-                  </div>
+                      </div>
+                    )}
 
-                  {overviewAi.status === "loading" && (
-                    <div style={{ display: "flex", alignItems: "center", gap: 10, marginTop: 12, color: "rgba(148,163,184,0.9)", fontSize: 12 }}>
-                      <Loader2 size={16} color="#818cf8" className="animate-spin" />
-                      Running triage, then root-cause (sequential)…
-                    </div>
-                  )}
-
-                  {overviewAi.status === "error" && (
-                    <div style={{ marginTop: 10, fontSize: 12, color: "#fb7185", lineHeight: 1.5 }}>
-                      {overviewAi.error}
+                    {/* Analyze CTA */}
+                    {(overviewAi.status === "idle" || overviewAi.status === "error") && (
                       <button
                         type="button"
                         onClick={() => void loadOverviewAi(false)}
                         style={{
-                          marginLeft: 8,
-                          padding: "2px 8px",
-                          borderRadius: 4,
-                          background: "rgba(251,113,133,0.12)",
-                          border: "1px solid rgba(251,113,133,0.3)",
-                          color: "#fb7185",
-                          fontSize: 10,
+                          width: "100%", display: "flex", alignItems: "center",
+                          justifyContent: "center", gap: 8,
+                          padding: "10px 16px", borderRadius: 8,
+                          background: "rgba(129,140,248,0.1)",
+                          border: "1px solid rgba(129,140,248,0.28)",
+                          color: "#a5b4fc", fontSize: 13, fontWeight: 600,
                           cursor: "pointer",
                           ...mono,
                         }}
                       >
-                        Retry
+                        <Zap size={14} />
+                        Analyze with AI
                       </button>
-                    </div>
-                  )}
-
-                  {overviewAi.status === "ready" && (
-                    <div style={{ marginTop: 12, display: "flex", flexDirection: "column", gap: 12 }}>
-                      {(overviewAi.triageModel || overviewAi.rootModel) && (
-                        <div style={{ display: "flex", flexWrap: "wrap", gap: 8, ...mono, fontSize: 9, color: "rgba(100,116,139,0.5)" }}>
-                          {overviewAi.triageModel && (
-                            <span>Triage: {formatLlmModelDisplay(overviewAi.triageModel)}</span>
-                          )}
-                          {overviewAi.rootModel && (
-                            <span>Root-cause: {formatLlmModelDisplay(overviewAi.rootModel)}</span>
-                          )}
-                          {overviewAi.confidence !== undefined && <span>Confidence: {(overviewAi.confidence * 100).toFixed(0)}%</span>}
-                          {overviewAi.mitre && overviewAi.mitre.length > 0 && <span>MITRE: {overviewAi.mitre.join(", ")}</span>}
-                        </div>
-                      )}
-                      {overviewAi.triage ? (
-                        <div>
-                          <div style={{ ...ls, marginBottom: 6 }}>Triage</div>
-                          <p style={{ fontSize: 12, color: "#e2e8f0", lineHeight: 1.65, margin: 0, whiteSpace: "pre-wrap" }}>
-                            {overviewAi.triage}
-                          </p>
-                        </div>
-                      ) : null}
-                      {overviewAi.rootCause ? (
-                        <div>
-                          <div style={{ ...ls, marginBottom: 6 }}>Root cause</div>
-                          <p style={{ fontSize: 12, color: "#cbd5e1", lineHeight: 1.65, margin: 0, whiteSpace: "pre-wrap" }}>
-                            {overviewAi.rootCause}
-                          </p>
-                        </div>
-                      ) : null}
-                      {!overviewAi.triage && !overviewAi.rootCause && (
-                        <p style={{ fontSize: 12, color: "rgba(100,116,139,0.55)", margin: 0 }}>
-                          Empty response. Check Flask <code style={mono}>BEDROCK_API_KEY</code> and{" "}
-                          <code style={mono}>VITE_IR_API_BASE</code> (e.g. <code style={mono}>http://localhost:3001/api/v1</code>).
-                        </p>
-                      )}
-                    </div>
-                  )}
-                </div>
+                    )}
+                  </>
+                )}
               </div>
             )}
 
@@ -1164,33 +1316,40 @@ export function FindingDetailPanel({
                       </button>
                     </div>
                   )}
-                  {runbookAi.status === "ready" && runbookAi.markdown && (
-                    <div style={{ marginTop: 12 }}>
-                      {runbookAi.model && (
-                        <p style={{ ...mono, fontSize: 9, color: "rgba(100,116,139,0.5)", margin: "0 0 8px" }}>
-                          Model: {formatLlmModelDisplay(runbookAi.model)}
-                        </p>
-                      )}
-                      <pre
-                        style={{
-                          ...mono,
-                          fontSize: 11,
-                          color: "#e2e8f0",
-                          lineHeight: 1.55,
-                          margin: 0,
-                          whiteSpace: "pre-wrap",
-                          wordBreak: "break-word",
-                          maxHeight: 260,
-                          overflowY: "auto",
-                        }}
-                      >
-                        {runbookAi.markdown}
-                      </pre>
-                    </div>
-                  )}
                 </div>
 
-                <div style={{ ...ls, color: "rgba(100,116,139,0.45)" }}>Built-in playbook</div>
+                <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                  <div style={{ ...ls, color: aiSteps ? "rgba(129,140,248,0.75)" : "rgba(100,116,139,0.45)" }}>
+                    {aiSteps ? "AI-generated playbook" : "Built-in playbook"}
+                  </div>
+                  {aiSteps && (
+                    <span
+                      style={{
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: 3,
+                        padding: "2px 7px",
+                        borderRadius: 4,
+                        background: "rgba(129,140,248,0.12)",
+                        border: "1px solid rgba(129,140,248,0.28)",
+                        fontSize: 9,
+                        fontWeight: 700,
+                        color: "#818cf8",
+                        ...mono,
+                        textTransform: "uppercase",
+                        letterSpacing: "0.07em",
+                      }}
+                    >
+                      <Bot size={9} />
+                      AI
+                    </span>
+                  )}
+                  {aiSteps && runbookAi.model && (
+                    <span style={{ marginLeft: "auto", ...mono, fontSize: 9, color: "rgba(100,116,139,0.4)" }}>
+                      {formatLlmModelDisplay(runbookAi.model)}
+                    </span>
+                  )}
+                </div>
 
                 {/* Phase legend + time estimate */}
                 <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>

--- a/src/components/ui/FindingDetailPanel.tsx
+++ b/src/components/ui/FindingDetailPanel.tsx
@@ -418,6 +418,8 @@ export function FindingDetailPanel({
       const req = llmRequestFromFinding(f);
       const triageRes = await fetchLLMActionResult("llm_triage", req);
       const rootRes = await fetchLLMActionResult("llm_root_cause", req);
+      // Discard if the user switched findings while the requests were in-flight.
+      if (findingRef.current.id !== f.id) return;
       const payload: OverviewAiPayload = {
         triage: (triageRes?.triage_summary as string) ?? "",
         rootCause: (rootRes?.root_cause_narrative as string) ?? "",
@@ -443,13 +445,17 @@ export function FindingDetailPanel({
     try {
       const req = llmRequestFromFinding(f);
       const res = await fetchLLMActionResult("llm_runbook", req);
+      // Discard if the user switched findings while the request was in-flight.
+      if (findingRef.current.id !== f.id) return;
       const rawSteps = res?.runbook_steps as PlaybookStep[] | undefined;
       const model = res?.model as string | undefined;
       const VALID_PHASES: PlaybookStep["phase"][] = ["IDENTIFY", "CONTAIN", "REMEDIATE", "VERIFY"];
+      // Validate every step — not just the first — so a bad later item can't reach
+      // PHASE_META[step.phase] and blow up the runbook tab.
       const steps: PlaybookStep[] =
         Array.isArray(rawSteps) &&
         rawSteps.length > 0 &&
-        VALID_PHASES.includes(rawSteps[0].phase)
+        rawSteps.every(s => s && typeof s === "object" && VALID_PHASES.includes((s as PlaybookStep).phase))
           ? rawSteps
           : [];
       if (steps.length === 0) {

--- a/src/env.example
+++ b/src/env.example
@@ -1,16 +1,25 @@
 # Environment Variables for IAM Dashboard
 
-# AWS API Gateway URL
-# This is the base URL for the API Gateway that connects to Lambda (cloud/prod/dev)
-VITE_API_URL=https://erh3a09d7l.execute-api.us-east-1.amazonaws.com/v1
+# --- Scan / general API (often API Gateway or Vite :3001 with /scan proxy) ---
+# VITE_API_URL=https://erh3a09d7l.execute-api.us-east-1.amazonaws.com/v1
+# VITE_API_URL=http://localhost:3001
 
-# Backend API URL (for local Python backend in Docker)
-# When running the Flask backend on localhost:3001 with prefix /v1, use:
-VITE_API_URL=http://localhost:3001/v1
+# --- IR / LLM (Flask /api/v1) — split so /scan can stay on Gateway while LLM hits Flask ---
+# Browser origin + /api/v1 → Vite proxies to Flask (see vite.config server.proxy /api/v1).
+# Docker UI on port 3001:
+# VITE_IR_API_BASE=http://localhost:3001/api/v1
+# npm run dev on port 5173:
+# VITE_IR_API_BASE=http://localhost:5173/api/v1
+# Direct to Flask (no Vite proxy):
+# VITE_IR_API_BASE=http://localhost:5001/api/v1
 
-# Optional: Connected accounts (JSON array). Each: id, label, accountId. Use [] for no accounts (UI shows empty state).
-# Default when unset: built-in mock accounts until the backend provides this list.
+# Vite proxy target for /api/v1 (Node-side; Docker frontend → Flask service)
+# VITE_FLASK_PROXY_TARGET=http://app:5000
+
+# Cap concurrent Bedrock LLM POSTs across tabs (default 2)
+# VITE_LLM_MAX_CONCURRENT=2
+
+# Optional: Connected accounts (JSON array). Each: id, label, accountId.
 # VITE_AWS_ACCOUNTS=[{"id":"acct-1","label":"Production","accountId":"123456789012"}]
 
-# Optional: Enable debug logging
 # VITE_DEBUG=true

--- a/src/hooks/useVoiceIntent.ts
+++ b/src/hooks/useVoiceIntent.ts
@@ -1,0 +1,111 @@
+/**
+ * useVoiceIntent — Two-tier voice intent resolution
+ *
+ * Tier 1: regex fast-path via matchIntent() — synchronous, zero network.
+ * Tier 2: Bedrock fallback via fetchVoiceIntent() — async, only on "unknown".
+ *
+ * The 14 regex patterns previously lived in VoiceIRAgent.tsx. Moving them here
+ * makes them independently testable without mounting React.
+ *
+ * isThinking: true only during a live Bedrock call. Never true for regex-resolved
+ * intents or in mock mode (fetchVoiceIntent returns null immediately).
+ */
+
+import { useState, useCallback } from "react";
+import { fetchVoiceIntent } from "../services/voiceIntentService";
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+export interface ResolvedIntent {
+  /** One of the 14 named intents or "unknown" */
+  intent: string;
+  /**
+   * Present when source === "bedrock". Use this for TTS instead of
+   * buildResponse().spokenText so Bedrock's context-aware reply is spoken.
+   */
+  spokenReply?: string;
+  /** Structured args extracted by Bedrock (e.g. { resource: "i-0abc" }). */
+  args?: Record<string, unknown>;
+  /** Bedrock model confidence 0–1. Informational only. */
+  confidence?: number;
+  /** "regex" = resolved synchronously; "bedrock" = Bedrock resolved */
+  source: "regex" | "bedrock";
+}
+
+export interface ConversationTurn {
+  role: "user" | "agent";
+  text: string;
+}
+
+export interface FindingContext {
+  id?: string;
+  severity?: string;
+  finding_type?: string;
+  resource_name?: string;
+  service?: string;
+}
+
+// ── Regex intent matcher ──────────────────────────────────────────────────────
+
+function matchIntent(input: string): string {
+  const t = input.toLowerCase().trim();
+  if (/\b(brief|briefing|situation|status|sitrep|what('s| is) (going on|happening|the situation))\b/.test(t)) return "briefing";
+  if (/\b(critical|crit findings?|show critical|critical alerts?)\b/.test(t)) return "critical";
+  if (/\b(threat level|threat assessment|current threat)\b/.test(t)) return "threat";
+  if (/\b(sla|breach|breached|overdue)\b/.test(t)) return "sla";
+  if (/\b(latest|new findings?|recent|last scan)\b/.test(t)) return "latest";
+  if (/\b(show findings?|list findings?|findings? list|all findings?)\b/.test(t)) return "show_findings";
+  if (/\b(compliance|score|posture|frameworks?)\b/.test(t)) return "compliance";
+  if (/\b(scan|run scan|start scan)\b/.test(t)) return "scan";
+  if (/\b(help|commands?|what can you)\b/.test(t)) return "help";
+  if (/\b(high (risk|findings?|severity)|high risk)\b/.test(t)) return "high";
+  if (/\b(isolate|contain|lock down|quarantine)\b/.test(t)) return "isolate";
+  if (/\b(revoke|delete key|remove key|kill key)\b/.test(t)) return "revoke";
+  if (/\b(disable key|deactivate key|suspend key)\b/.test(t)) return "disable_key";
+  if (/\b(go to|navigate|open|take me)\b/.test(t)) return "navigate";
+  return "unknown";
+}
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+export function useVoiceIntent() {
+  const [isThinking, setIsThinking] = useState(false);
+
+  const resolveIntent = useCallback(
+    async (
+      utterance: string,
+      contextTurns: ConversationTurn[] = [],
+      findingContext: FindingContext | null = null
+    ): Promise<ResolvedIntent> => {
+      // Tier 1 — synchronous fast-path
+      const regexResult = matchIntent(utterance);
+      if (regexResult !== "unknown") {
+        return { intent: regexResult, source: "regex" };
+      }
+
+      // Tier 2 — Bedrock fallback
+      setIsThinking(true);
+      try {
+        const result = await fetchVoiceIntent(utterance, contextTurns, findingContext);
+        if (!result) {
+          // mock mode or network failure — keep "unknown" with no spinner shown
+          return { intent: "unknown", source: "regex" };
+        }
+        return {
+          intent:      result.intent,
+          spokenReply: result.spoken_reply ?? undefined,
+          args:        result.args ?? undefined,
+          confidence:  result.confidence,
+          source:      "bedrock",
+        };
+      } catch {
+        return { intent: "unknown", source: "regex" };
+      } finally {
+        setIsThinking(false);
+      }
+    },
+    [] // stable — fetchVoiceIntent is a module-level import
+  );
+
+  return { resolveIntent, isThinking };
+}

--- a/src/hooks/useVoiceIntent.ts
+++ b/src/hooks/useVoiceIntent.ts
@@ -49,10 +49,12 @@ export interface FindingContext {
 
 function matchIntent(input: string): string {
   const t = input.toLowerCase().trim();
-  if (/\b(brief|briefing|situation|status|sitrep|what('s| is) (going on|happening|the situation))\b/.test(t)) return "briefing";
+  // SLA must be tested before briefing — "sla status" would match the (now-removed)
+  // bare "status" token in the old briefing regex, returning "briefing" instead.
+  if (/\b(sla|breach|breached|overdue)\b/.test(t)) return "sla";
+  if (/\b(brief|briefing|situation|sitrep|what('s| is) (going on|happening|the situation))\b/.test(t)) return "briefing";
   if (/\b(critical|crit findings?|show critical|critical alerts?)\b/.test(t)) return "critical";
   if (/\b(threat level|threat assessment|current threat)\b/.test(t)) return "threat";
-  if (/\b(sla|breach|breached|overdue)\b/.test(t)) return "sla";
   if (/\b(latest|new findings?|recent|last scan)\b/.test(t)) return "latest";
   if (/\b(show findings?|list findings?|findings? list|all findings?)\b/.test(t)) return "show_findings";
   if (/\b(compliance|score|posture|frameworks?)\b/.test(t)) return "compliance";

--- a/src/mock/irMock.ts
+++ b/src/mock/irMock.ts
@@ -16,6 +16,7 @@ import type {
   ApprovalRequest,
   ForensicsCapture,
   EvidenceRecord,
+  PlaybookStep,
 } from "../types/ir";
 
 // ─── In-memory job store ──────────────────────────────────────────────────────
@@ -78,34 +79,58 @@ function mockResult(type: IRActionType, findingId: string): IRActionResult {
 
     case "llm_runbook":
       return {
-        runbook_markdown: `## IR Runbook — ${findingId}
-
-### Phase 1 — IDENTIFY (15 min)
-1. Confirm finding is true positive via CloudTrail lookup
-2. Identify all resources touched since first_seen
-3. Cross-reference source IP against threat intel feeds
-
-\`\`\`bash
-aws cloudtrail lookup-events \\
-  --lookup-attributes AttributeKey=AccessKeyId,AttributeValue=AKIA... \\
-  --start-time $(date -u -d '-24 hours' +%FT%TZ) \\
-  --max-results 50
-\`\`\`
-
-### Phase 2 — CONTAIN (30 min)
-1. **Revoke access key** — use IR Engine → IAM Revoke Key action
-2. **Isolate EC2 instance** if used — use IR Engine → EC2 Isolate action
-
-### Phase 3 — REMEDIATE (60 min)
-1. Rotate all credentials in affected account
-2. Review IAM policies for least-privilege
-3. Enable CloudTrail log validation
-4. Enable MFA on root account
-
-### Phase 4 — VERIFY (20 min)
-1. Re-run Security Hub scan
-2. Confirm no active sessions from suspicious IP
-3. Update ticket and close workflow`,
+        runbook_steps: [
+          {
+            step: 1,
+            phase: "IDENTIFY" as PlaybookStep["phase"],
+            title: "Validate Finding via CloudTrail",
+            description: `Confirm true positive for ${findingId}. Query CloudTrail for API calls from the suspicious principal within the finding window and cross-reference source IPs against threat intel.`,
+            commands: [
+              "# Lookup events by access key",
+              `aws cloudtrail lookup-events --lookup-attributes AttributeKey=AccessKeyId,AttributeValue=AKIA... --start-time $(date -u -d '-24 hours' +%FT%TZ) --max-results 50`,
+              "# Cross-reference source IP against threat intel feeds",
+              "aws guardduty list-findings --detector-id DETECTOR_ID --finding-criteria '{\"Criterion\":{\"service.action.awsApiCallAction.remoteIpDetails.ipAddressV4\":{\"Eq\":[\"SOURCE_IP\"]}}}'",
+            ],
+            estimated_time: "15",
+          },
+          {
+            step: 2,
+            phase: "CONTAIN" as PlaybookStep["phase"],
+            title: "Revoke Compromised Credentials",
+            description: "Immediately disable the access key to stop ongoing access. Use IR Engine → IAM Revoke Key for approval-gated permanent revocation.",
+            commands: [
+              "# Disable key (reversible — safe first step)",
+              "aws iam update-access-key --access-key-id AKIA... --status Inactive --user-name USERNAME",
+              "# Tag resource for IR tracking",
+              "aws resourcegroupstaggingapi tag-resources --resource-arn-list RESOURCE_ARN --tags IncidentId=IR-001,ContainedAt=$(date -u +%FT%TZ)",
+            ],
+            estimated_time: "10",
+          },
+          {
+            step: 3,
+            phase: "REMEDIATE" as PlaybookStep["phase"],
+            title: "Rotate Credentials and Harden IAM",
+            description: "Issue a new key for legitimate workloads, apply least-privilege policy, enable MFA, and audit IAM trust boundaries to prevent recurrence.",
+            commands: [
+              "aws iam create-access-key --user-name USERNAME",
+              "aws iam list-attached-user-policies --user-name USERNAME",
+              "# Apply least-privilege — remove wildcard actions",
+              "aws iam create-virtual-mfa-device --virtual-mfa-device-name USERNAME-mfa --outfile /tmp/mfa-qr.png --bootstrap-method QRCodePNG",
+            ],
+            estimated_time: "60",
+          },
+          {
+            step: 4,
+            phase: "VERIFY" as PlaybookStep["phase"],
+            title: "Confirm Closure and Re-scan",
+            description: "Re-run the scanner, verify no active sessions from the suspicious principal, resolve the Security Hub finding, and close the workflow ticket.",
+            commands: [
+              "aws iam list-access-keys --user-name USERNAME",
+              "aws securityhub batch-update-findings --finding-identifiers ProductArn=PRODUCT_ARN,Id=FINDING_ID --note Text='Remediated by IR workflow',UpdatedBy=analyst --workflow Status=RESOLVED",
+            ],
+            estimated_time: "20",
+          },
+        ] satisfies PlaybookStep[],
       };
 
     case "aws_ec2_isolate":

--- a/src/services/irEngine.ts
+++ b/src/services/irEngine.ts
@@ -22,6 +22,7 @@ import type {
   IRActionType,
   IRActionRequest,
   IRActionResponse,
+  IRActionResult,
   IRJobStatusResponse,
   ForensicsCapture,
   EvidenceRecord,
@@ -36,7 +37,9 @@ import {
   mockEvidenceRecord,
 } from "../mock/irMock";
 
-const API_BASE_URL =
+/** IR/LLM base (Flask /api/v1). Split from VITE_API_URL so /scan can stay on API Gateway via Vite proxy. */
+const IR_API_BASE_URL =
+  import.meta.env.VITE_IR_API_BASE ||
   import.meta.env.VITE_API_URL ||
   import.meta.env.VITE_API_GATEWAY_URL ||
   "https://erh3a09d7l.execute-api.us-east-1.amazonaws.com/v1";
@@ -44,13 +47,36 @@ const API_BASE_URL =
 const DATA_MODE = (import.meta.env.VITE_DATA_MODE || "live").toLowerCase();
 const IS_MOCK = DATA_MODE === "mock";
 
+const LLM_MAX_CONCURRENT = Math.max(1, Number(import.meta.env.VITE_LLM_MAX_CONCURRENT || 2));
+let llmInFlight = 0;
+const llmWaitQueue: Array<() => void> = [];
+
+async function withLlmLimit<T>(fn: () => Promise<T>): Promise<T> {
+  while (llmInFlight >= LLM_MAX_CONCURRENT) {
+    await new Promise<void>((resolve) => {
+      llmWaitQueue.push(resolve);
+    });
+  }
+  llmInFlight++;
+  try {
+    return await fn();
+  } finally {
+    llmInFlight--;
+    llmWaitQueue.shift()?.();
+  }
+}
+
+function isLlmActionType(t: IRActionType): boolean {
+  return t === "llm_triage" || t === "llm_root_cause" || t === "llm_runbook";
+}
+
 // ─── Internal fetch helper ────────────────────────────────────────────────────
 
 async function irFetch<T>(
   path: string,
   options: RequestInit = {}
 ): Promise<T> {
-  const url = `${API_BASE_URL}${path}`;
+  const url = `${IR_API_BASE_URL}${path}`;
   const res = await fetch(url, {
     ...options,
     headers: {
@@ -59,8 +85,15 @@ async function irFetch<T>(
     },
   });
   if (!res.ok) {
-    const err = await res.json().catch(() => ({ message: res.statusText }));
-    throw new Error(err.message || `HTTP ${res.status}`);
+    const text = await res.text();
+    let detail = res.statusText;
+    try {
+      const err = JSON.parse(text) as { message?: string; error?: string };
+      detail = err.message || err.error || detail;
+    } catch {
+      if (text.trim()) detail = text.trim().slice(0, 240);
+    }
+    throw new Error(`${detail} (${res.status})`);
   }
   return res.json() as Promise<T>;
 }
@@ -102,6 +135,21 @@ function requiresApproval(type: IRActionType): boolean {
 // ─── Public API ───────────────────────────────────────────────────────────────
 
 /**
+ * Run an LLM IR action. Live Flask returns `result` on POST; mock mode may need polling.
+ * LLM calls share a global concurrency limit (VITE_LLM_MAX_CONCURRENT).
+ */
+export async function fetchLLMActionResult(
+  actionType: "llm_triage" | "llm_root_cause" | "llm_runbook",
+  request: IRActionRequest
+): Promise<IRActionResult | undefined> {
+  const response = await triggerIRAction(actionType, request);
+  if (response.result) return response.result;
+  if (!response.job_id) return undefined;
+  const final = await pollUntilDone(response.job_id, () => {}, 400, 30);
+  return final?.result;
+}
+
+/**
  * Trigger an IR action. Returns the initial job state.
  * For high-impact actions, returns status=pending_approval with an approval object.
  */
@@ -123,10 +171,16 @@ export async function triggerIRAction(
     idempotency_key: idempotencyKey,
   };
 
-  return irFetch<IRActionResponse>(endpoint, {
-    method: "POST",
-    body: JSON.stringify(body),
-  });
+  const post = () =>
+    irFetch<IRActionResponse>(endpoint, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+
+  if (isLlmActionType(actionType)) {
+    return withLlmLimit(post);
+  }
+  return post();
 }
 
 /**

--- a/src/services/irEngine.ts
+++ b/src/services/irEngine.ts
@@ -47,7 +47,8 @@ const IR_API_BASE_URL =
 const DATA_MODE = (import.meta.env.VITE_DATA_MODE || "live").toLowerCase();
 const IS_MOCK = DATA_MODE === "mock";
 
-const LLM_MAX_CONCURRENT = Math.max(1, Number(import.meta.env.VITE_LLM_MAX_CONCURRENT || 2));
+const _parsedMax = Number(import.meta.env.VITE_LLM_MAX_CONCURRENT);
+const LLM_MAX_CONCURRENT = Number.isFinite(_parsedMax) && _parsedMax > 0 ? Math.floor(_parsedMax) : 2;
 let llmInFlight = 0;
 const llmWaitQueue: Array<() => void> = [];
 

--- a/src/services/ttsService.ts
+++ b/src/services/ttsService.ts
@@ -1,0 +1,68 @@
+/**
+ * ttsService.ts — AWS Polly Neural TTS client with Web Speech API fallback
+ *
+ * Usage:
+ *   const done = await pollySpeak("Two critical findings require action.");
+ *   // done === true  → Polly audio played to completion
+ *   // done === false → Polly unavailable; caller should use browser TTS
+ *
+ * The service returns false immediately in mock mode so VoiceIRAgent can
+ * fall through to speechSynthesis without a round-trip.
+ */
+
+const IR_BASE =
+  import.meta.env.VITE_IR_API_BASE ||
+  import.meta.env.VITE_API_URL ||
+  "";
+
+const IS_MOCK = (import.meta.env.VITE_DATA_MODE || "live").toLowerCase() === "mock";
+
+/** Default voice for the SOC context — Matthew is AWS Polly Neural US English Male */
+const DEFAULT_VOICE = "Matthew";
+
+/**
+ * Synthesize `text` via AWS Polly Neural TTS (proxied through Flask).
+ * Returns a Promise that resolves to `true` when the audio finishes playing,
+ * or `false` if Polly is unavailable (mock mode, network error, non-2xx).
+ * The caller is responsible for triggering a browser TTS fallback on false.
+ */
+export async function pollySpeak(
+  text: string,
+  voice = DEFAULT_VOICE
+): Promise<boolean> {
+  if (IS_MOCK) return false;
+  if (!text.trim()) return false;
+
+  try {
+    const resp = await fetch(`${IR_BASE}/api/v1/tts/synthesize`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: text.slice(0, 3000), voice, engine: "neural" }),
+      signal: AbortSignal.timeout(10_000),
+    });
+
+    if (!resp.ok) return false;
+
+    const blob = await resp.blob();
+    if (!blob.size) return false;
+
+    const url = URL.createObjectURL(blob);
+
+    return new Promise<boolean>((resolve) => {
+      const audio = new Audio(url);
+
+      const cleanup = (result: boolean) => {
+        URL.revokeObjectURL(url);
+        resolve(result);
+      };
+
+      audio.onended = () => cleanup(true);
+      audio.onerror = () => cleanup(false);
+
+      // Some browsers require a user gesture for audio.play()
+      audio.play().catch(() => cleanup(false));
+    });
+  } catch {
+    return false;
+  }
+}

--- a/src/services/ttsService.ts
+++ b/src/services/ttsService.ts
@@ -34,7 +34,11 @@ export async function pollySpeak(
   if (!text.trim()) return false;
 
   try {
-    const resp = await fetch(`${IR_BASE}/api/v1/tts/synthesize`, {
+    // VITE_IR_API_BASE is documented as already ending in /api/v1 (e.g.
+    // http://localhost:3001/api/v1), so appending the full path again would
+    // produce a double-segment URL. Strip the suffix if present.
+    const ttsBase = IR_BASE.endsWith("/api/v1") ? IR_BASE : `${IR_BASE}/api/v1`;
+    const resp = await fetch(`${ttsBase}/tts/synthesize`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ text: text.slice(0, 3000), voice, engine: "neural" }),

--- a/src/services/voiceIntentService.ts
+++ b/src/services/voiceIntentService.ts
@@ -1,0 +1,55 @@
+/**
+ * voiceIntentService.ts — Thin client for POST /api/v1/voice/intent
+ *
+ * Returns null in mock mode or on any failure. The hook treats null as
+ * "Bedrock unavailable — keep the regex result."
+ *
+ * Mirrors the irFetch() pattern from irEngine.ts: same base URL resolution,
+ * same IS_MOCK guard, same null-on-error contract.
+ */
+
+import type { ConversationTurn, FindingContext } from "../hooks/useVoiceIntent";
+
+const IR_API_BASE_URL =
+  import.meta.env.VITE_IR_API_BASE ||
+  import.meta.env.VITE_API_URL ||
+  import.meta.env.VITE_API_GATEWAY_URL ||
+  "https://erh3a09d7l.execute-api.us-east-1.amazonaws.com/v1";
+
+const DATA_MODE = (import.meta.env.VITE_DATA_MODE || "live").toLowerCase();
+const IS_MOCK = DATA_MODE === "mock";
+
+export interface VoiceIntentResponse {
+  intent: string;
+  spoken_reply?: string | null;
+  args?: Record<string, unknown> | null;
+  confidence?: number;
+}
+
+export async function fetchVoiceIntent(
+  utterance: string,
+  contextTurns: ConversationTurn[],
+  findingContext: FindingContext | null
+): Promise<VoiceIntentResponse | null> {
+  if (IS_MOCK) return null;
+
+  try {
+    const res = await fetch(`${IR_API_BASE_URL}/voice/intent`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        utterance,
+        context_turns: contextTurns.slice(-3),
+        finding_context: findingContext,
+      }),
+    });
+
+    if (!res.ok) return null;
+
+    const data = (await res.json()) as VoiceIntentResponse;
+    if (typeof data.intent !== "string") return null;
+    return data;
+  } catch {
+    return null;
+  }
+}

--- a/src/types/ir.ts
+++ b/src/types/ir.ts
@@ -203,6 +203,11 @@ export interface IRActionRequest {
   dry_run?: boolean;
   parameters?: Record<string, unknown>;
   idempotency_key?: string;
+  /** POST /llm/* — backend prompt fields */
+  severity?: string;
+  finding_type?: string;
+  resource_name?: string;
+  description?: string;
 }
 
 export interface IRActionResponse {

--- a/src/types/ir.ts
+++ b/src/types/ir.ts
@@ -8,6 +8,20 @@
  *                    → /api/evidence/preserve
  */
 
+// ─── Playbook types (shared between IR engine and FindingDetailPanel) ─────────
+
+export type PlaybookPhase = "IDENTIFY" | "CONTAIN" | "REMEDIATE" | "VERIFY";
+
+export interface PlaybookStep {
+  step: number;
+  phase: PlaybookPhase;
+  title: string;
+  description: string;
+  commands: string[];
+  /** Numeric string — minutes */
+  estimated_time: string;
+}
+
 // ─── Action taxonomy ─────────────────────────────────────────────────────────
 
 export type IRActionType =
@@ -73,6 +87,7 @@ export interface IRActionResult {
   root_cause_narrative?: string;
   mitre_techniques?: string[];
   runbook_markdown?: string;
+  runbook_steps?: PlaybookStep[];
   // Containment results
   isolation_sg_id?: string;
   original_sg_ids?: string[];

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,12 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import path from 'path';
 
-export default defineConfig(async () => {
+export default defineConfig(async ({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  /** Vite dev server proxies /api/v1 → Flask. Docker frontend: VITE_FLASK_PROXY_TARGET=http://app:5000 */
+  const flaskProxyTarget = env.VITE_FLASK_PROXY_TARGET || 'http://127.0.0.1:5001';
+
   const { default: tailwindcss } = await import('@tailwindcss/vite');
   return {
     plugins: [react(), tailwindcss()],
@@ -69,6 +73,10 @@ export default defineConfig(async () => {
           changeOrigin: true,
           rewrite: (requestPath) => `/v1${requestPath}`,
           headers: { 'Origin': 'http://localhost:3001' },
+        },
+        '/api/v1': {
+          target: flaskProxyTarget,
+          changeOrigin: true,
         },
       },
       watch: {


### PR DESCRIPTION
**Implements A17** — defines and documents data retention policies for Prometheus, Grafana, DynamoDB, and PostgreSQL, and implements cleanup where it was missing.

**Documentation**

- Created docs/data-retention-policy.md with recommended retention periods, current state vs. recommended gap analysis, and operational notes for each system

**Prometheus**

- Updated docker-compose.yml: changed retention from 200h (~8.3 days) to 15d

**Grafana**

- Added annotation and snapshot retention env vars to docker-compose.yml:

- GF_ALERTING_MAX_ANNOTATIONS_TO_KEEP=1000

- GF_ANNOTATIONS_CLEANUPJOB_BATCHSIZE=100

- GF_SNAPSHOTS_EXTERNAL_ENABLED=false

**DynamoDB**

- Added TTL block (expires_at, 90 days) to scan_results table in Terraform

- Added new iam_findings Terraform resource with TTL enabled

- Fixed delete_old_records() to use paginated scans with LastEvaluatedKey

- New items written with expires_at epoch automatically set at creation

**PostgreSQL**

- Added cleanup_old_records(days=90) to database_service.py for security_findings and performance_metrics tables with rollback safety

**Retention Scheduler**

- New backend/api/retention.py with manual trigger via POST /api/v1/system/retention (protected by RETENTION_RUN_KEY)

- Daemon thread in app.py runs cleanup daily (configurable via RETENTION_SCHEDULER_INTERVAL_SEC, can be disabled with RETENTION_SCHEDULER_ENABLED=false)

**Tested**

- Route registered and confirmed in app.py

- Pagination verified in delete_old_records()

- Rollback handling verified in cleanup_old_records()

- TTL blocks confirmed enabled in Terraform for both tables

**Notes**

- Run terraform plan before applying — existing iam_findings table may need to be imported if already created manually in AWS

- RETENTION_RUN_KEY must be set in env to enable the manual trigger endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic data retention and cleanup for metrics (15 days), DynamoDB items (90 days) and DB records (90 days).
  * Background scheduler runs periodic cleanup (configurable interval, starts shortly after launch).
  * Manual retention trigger endpoint (HTTP POST) protected by a run key; accepts optional days parameter with sensible bounds.

* **Documentation**
  * Added data retention policy with configuration and enforcement details.

* **Chores**
  * Infrastructure updated to enable TTL and a new DynamoDB table for IAM findings; Grafana/Prometheus retention settings adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->