### PR TITLE
docs(security): add S16 backend authorization review

### DIFF
--- a/docs/backend/S16-Backend-Authorization-Review.md
+++ b/docs/backend/S16-Backend-Authorization-Review.md
@@ -1,0 +1,72 @@
+# S16 — Backend Authorization Review
+
+**Scope:** Scanner Lambda (`infra/lambda/lambda_function.py`) — HTTP traffic via API Gateway for `POST /scan/{scanner_type}`.  
+**Related:** [RBAC_Flow.md](./RBAC_Flow.md)
+
+---
+
+## 1. Authentication (session cookie, 401)
+
+- The browser sends an HttpOnly session cookie named **`iamdash_session`**. The Lambda reads it from the API Gateway **`cookies`** array and/or the **`Cookie`** header.
+- The cookie value is a **`session_id`**. The Lambda loads the session from **DynamoDB** (`SESSION_TABLE_NAME`). Missing row, expired `expires_at`, or absent cookie → **`UnauthorizedError`** → **HTTP 401** with body `{"error": "Authentication required"}`.
+- If DynamoDB access fails during session read/delete, the Lambda returns **HTTP 500** `{"error": "Unable to process request"}` (fail closed; no anonymous fallback).
+
+**Applies only when the event is treated as an HTTP API Gateway invocation** (`httpMethod` or `requestContext` present in the event). Other event shapes skip this path.
+
+---
+
+## 2. Authorization (Cognito groups, 403, admin vs non-admin)
+
+- After a valid session, the Lambda uses the session’s **`groups`** list (normalized strings). These reflect **Cognito group membership captured at login** (see [RBAC_Flow.md](./RBAC_Flow.md)).
+- **`require_groups`** enforces which **`scanner_type`** the caller may run:
+  - Users in **`admin`** may invoke **any** supported scanner, including **`full`**.
+  - **`full`** is **admin-only**; any authenticated non-admin receives **`ForbiddenError`** → **HTTP 403** with a forbidden message in the JSON body.
+  - For other types, each non-admin group maps to at most one scanner via **`SCANNER_GROUP_MAP`** (e.g. `iam` → `iam`, `ec2` → `ec2`, `securityhub` → `security-hub`, plus `guardduty`, `config`, `inspector`, `macie`). The user must hold a group whose mapped type matches the requested path.
+- Users with multiple groups receive the **union** of permitted scanner types.
+
+---
+
+## 3. Findings (what is working)
+
+| Area | Observation |
+|------|-------------|
+| **Session-bound authn** | HTTP scan requests require a valid server-side session; anonymous callers get **401**. |
+| **Group-based authz** | Non-admin users are restricted to scanner types aligned with their Cognito groups; mismatches yield **403**. |
+| **Privileged operation** | **`full`** scan is explicitly restricted to **`admin`**. |
+| **Session store failures** | Auth store errors surface as **500**, not silent allow. |
+| **Documentation** | RBAC behavior and direct-invoke semantics are described in [RBAC_Flow.md](./RBAC_Flow.md). |
+
+---
+
+## 4. Gaps
+
+| Gap | Detail |
+|-----|--------|
+| **No dedicated viewer role** | There is no first-class **read-only** vs **scan** permission in the Lambda. Groups not in `SCANNER_GROUP_MAP` cannot run scans but there is no separate “viewer” capability defined here. |
+| **No per-account (or per-tenant) scoping** | Authorization does not bind a user to specific AWS accounts. Scans execute under the **Lambda execution role**; the UI’s account selection is not a server-side access-control boundary in this handler. |
+| **Direct Lambda invocation bypass** | Events without HTTP API Gateway shape **do not** run session or group checks. Anyone with **`lambda:InvokeFunction`** on this function can trigger scans without Cognito/session. |
+| **API Gateway may not enforce auth** | Scan routes may use `authorization_type = NONE` at the gateway while the Lambda enforces the session. Unauthenticated requests still reach the Lambda (then **401**). Defense-in-depth depends on gateway/WAF configuration and operational discipline. |
+| **No separate VPC scanner RBAC** | Supported types include `iam`, `ec2`, `s3`, etc. VPC-oriented flows that call **`/scan/ec2`** are governed by **EC2** group membership only. |
+
+---
+
+## 5. Risks
+
+- **Over-privileged invoke principals:** Broad `lambda:InvokeFunction` grants negate Cognito/RBAC for batch jobs, compromised credentials, or misconfigured roles.
+- **Shared execution identity:** All authorized HTTP users effectively delegate AWS access to the **same** Lambda role; compromise of the function or role has wide blast radius.
+- **Session fixation / theft:** Standard cookie and session hygiene (TLS, `Secure`/`HttpOnly`, rotation, short TTL) matter; this document does not audit the auth Lambda or cookie flags.
+- **Confused deputy / UI mismatch:** Users may believe the dashboard “account switcher” limits backend access; without server-side account binding, that belief is unsafe.
+
+---
+
+## 6. Recommendations
+
+1. **Treat direct invoke as a controlled interface:** Restrict invocation to specific roles; use tools/scanners only via HTTP path if Cognito alignment is required; document exceptions.
+2. **Add per-account (or org) authorization** if multi-account is a requirement: e.g. map users to allowed account IDs and assume role / resource policy checks before `execute_scan`.
+3. **Introduce a viewer / read-only model** if product needs it: separate routes and checks (e.g. `GET` latest results) with a Cognito group that **cannot** `POST /scan/*`.
+4. **Optional API Gateway hardening:** Consider JWT or custom authorizer at the edge **in addition to** session validation if defense-in-depth or uniform policy is desired (coordinate with cookie-based session design).
+5. **Operational monitoring:** Alert on high **401/403** rates and on **direct** invocations if distinguishable in logs/metrics.
+
+---
+
+*This review reflects the scanner Lambda as implemented in the repository at the time of writing.*

--- a/docs/infra/S23-API-Gateway-rate-limiting.md
+++ b/docs/infra/S23-API-Gateway-rate-limiting.md
@@ -1,0 +1,59 @@
+# S23 — API Gateway rate limiting (task record)
+
+This document matches **GitHub issue S23** (*Rate limiting on API Gateway*): what was asked, what the platform supports, and what this repository configures.
+
+## Task objective
+
+- **Protect** scan and auth HTTP endpoints from abuse.
+- **Throttle** using API Gateway controls: steady **requests per second (RPS)** and **burst** capacity.
+- **Document** chosen limits and how operators can change them when scaling.
+- The original issue also mentioned **usage plans** and **per-day** limits; see *Platform constraints* below.
+
+## Requirements (from the issue)
+
+| Requirement | Notes |
+|-------------|--------|
+| Throttling on API Gateway | Applied at the HTTP API **stage**, with **per-route overrides** where needed. |
+| Scan endpoints | All `POST /scan/*` routes; **`POST /scan/full`** is throttled more strictly than single-service scans. |
+| Auth endpoints | `POST /auth/login`, `POST /auth/logout`, `GET /auth/session`. |
+| Requests per second | Configured via `throttling_*_rate_limit` variables (steady-state RPS). |
+| Burst | Configured via `throttling_*_burst_limit` variables (token-bucket burst). |
+| Per day | **Not enforced natively** on HTTP APIs; options are documented below. |
+| Usage plans | **REST APIs (v1)** feature. This project uses an **HTTP API (v2)**; equivalent abuse protection is **stage + route throttling** unless we migrate or add another layer. |
+
+## Platform constraints (HTTP API vs usage plans)
+
+- **HTTP API (API Gateway v2)** supports **throttling** (RPS + burst) on the stage default and on individual routes. It does **not** support **usage plans**, **API keys**, or built-in **daily quotas**.
+- To add **hard per-day quotas** later, typical approaches are: **REST API + usage plans** (often with a server-side caller, not a browser-held API key), **application-level** counters (e.g. DynamoDB + Lambda), or **WAF** / edge rules for abuse patterns—not a single toggle on HTTP API.
+
+## Configured limits (defaults)
+
+Source of truth: Terraform in `infra/api-gateway/` (`main.tf`, `variables.tf`). Summary:
+
+| Route group | Steady RPS | Burst |
+|-------------|------------|-------|
+| Individual scans (`POST /scan/*` except `/full`) | 25 | 50 |
+| Full scan (`POST /scan/full`) | 5 | 10 |
+| Auth (`/auth/login`, `/auth/logout`, `/auth/session`) | 35 | 70 |
+
+The deprecated standalone auth HTTP API (`infra/API_Gateway_Auth/`) uses stage throttling aligned with the auth numbers above when that stack is still deployed.
+
+## How to change limits (scaling)
+
+1. Edit **`infra/api-gateway/variables.tf`** (or pass module inputs from **`infra/main.tf`** if you add root-level variables).
+2. From the **`infra/`** directory: `terraform plan` then `terraform apply` (with your usual backend / credentials).
+3. Clients exceeding limits receive **429 Too Many Requests** from API Gateway.
+
+Detailed operator notes and verification (access logs, 429s) live in **`infra/api-gateway/README.md`** (section *Rate limiting*).
+
+## Verification
+
+- CloudWatch access logs for the stage: log group pattern `/aws/apigwv2/<api-name>/<stage>/access`.
+- Filter for HTTP **429** responses after controlled load tests.
+
+## Related files
+
+- `infra/api-gateway/main.tf` — stage `default_route_settings` and `route_settings` overrides.
+- `infra/api-gateway/variables.tf` — all throttling variables and defaults.
+- `infra/api-gateway/README.md` — endpoint list and rate-limiting runbook.
+- `infra/API_Gateway_Auth/main.tf` — optional legacy auth API stage limits.

--- a/docs/planning/GITHUB_ISSUES_BACKLOG.md
+++ b/docs/planning/GITHUB_ISSUES_BACKLOG.md
@@ -290,7 +290,7 @@ This is **expected behavior**, not failure.
 | S20 | (SEMESTER) Gitleaks baseline & allowlist | M3 |
 | S21 | (SEMESTER) IAM least-privilege audit (Lambda, GitHub Actions) | M5 |
 | S22 | (SEMESTER) Security headers on API responses | M4 |
-| S23 | (SEMESTER) Rate limiting on API Gateway | M5 |
+| S23 | (SEMESTER) Rate limiting on API Gateway — [implementation & task record](../infra/S23-API-Gateway-rate-limiting.md) | M5 |
 | S24 | (SEMESTER) Audit logging for sensitive actions | M5 |
 | S25 | (SEMESTER) CORS configuration review | M3 |
 | S26 | (SEMESTER) Remediation content security review (pairs with AI) | M4 |

--- a/docs/team-scope/security.md
+++ b/docs/team-scope/security.md
@@ -67,7 +67,7 @@ Week 6 March 24 – March 30
 - Test throttling behavior.
 - Document scaling considerations.
 
-Dev will configure API Gateway usage plans.
+Dev will configure API Gateway throttling (HTTP API: per-route RPS/burst in Terraform; per-day caps need REST usage plans or app/WAF if required).
 Jade will test throttling edge cases.
 Sebas will monitor logs during load testing.
 Tibo will document rate limiting configuration.

--- a/infra/API_Gateway_Auth/main.tf
+++ b/infra/API_Gateway_Auth/main.tf
@@ -37,6 +37,11 @@ resource "aws_apigatewayv2_stage" "auth" {
   name        = var.stage_name
   auto_deploy = true
 
+  default_route_settings {
+    throttling_burst_limit = var.throttling_burst_limit
+    throttling_rate_limit  = var.throttling_rate_limit
+  }
+
   tags = {
     Name      = "${var.api_name}-${var.stage_name}"
     Project   = var.project_name

--- a/infra/API_Gateway_Auth/variables.tf
+++ b/infra/API_Gateway_Auth/variables.tf
@@ -49,3 +49,15 @@ variable "lambda_function_arn" {
   description = "ARN for the BFF-Auth lambda function"
   type        = string
 }
+
+variable "throttling_burst_limit" {
+  description = "Stage burst limit for this standalone auth HTTP API (RPS bucket)."
+  type        = number
+  default     = 70
+}
+
+variable "throttling_rate_limit" {
+  description = "Steady-state requests per second for this auth API stage."
+  type        = number
+  default     = 35
+}

--- a/infra/api-gateway/README.md
+++ b/infra/api-gateway/README.md
@@ -48,7 +48,7 @@ terraform apply
 - **Protocol**: HTTP API (v2)
 - **Stage**: `v1`
 - **CORS**: Enabled with configurable origins
-- **Throttling**: 100 burst, 50 rate limit per second
+- **Throttling**: Per-route limits on the stage (see below)
 - **Routes**: Added route definitions for 12 routes. 9 scanner, 3 authentication
 - **Lambda Integration**: Integrated the scanner routes with the scanner lambda and auth routes with the auth lambda
 - **Request/Response Mapping**: Configure request/response transformations
@@ -111,4 +111,33 @@ API Gateway will:
 3. Transform responses back to HTTP
 4. Handle CORS for browser requests
 5. Provide throttling and rate limiting
+
+## ⏱️ Rate limiting (throttling)
+
+This API is an **HTTP API (API Gateway v2)**. Throttling uses **steady RPS** plus **burst** (token bucket) on the stage. HTTP APIs do **not** support REST-style **usage plans**, **API keys**, or a built-in **per-day quota**; those require a REST API or another layer (for example application quotas or WAF).
+
+### Chosen limits (defaults)
+
+| Route group | Routes | Steady RPS | Burst | Terraform variables |
+|-------------|--------|------------|-------|---------------------|
+| Individual scans | `POST /scan/security-hub`, `guardduty`, `config`, `inspector`, `macie`, `iam`, `ec2`, `s3` | 25 | 50 | `throttling_rate_limit`, `throttling_burst_limit` |
+| Full scan | `POST /scan/full` | 5 | 10 | `throttling_scan_full_rate_limit`, `throttling_scan_full_burst_limit` |
+| Auth | `POST /auth/login`, `POST /auth/logout`, `GET /auth/session` | 35 | 70 | `throttling_auth_rate_limit`, `throttling_auth_burst_limit` |
+
+Individual scan routes inherit **default_route_settings**. `POST /scan/full` and the auth routes use **route_settings** overrides on the same stage.
+
+### Per-day caps
+
+There is **no native per-day limit** on HTTP API throttling. To add a daily cap later, options include: migrate sensitive routes to a **REST API** with usage plans and quotas, enforce quotas in **Lambda** (for example DynamoDB counters), or use **WAF** / edge rules for abuse patterns. Until then, use CloudWatch on `429` responses and Lambda invocations for monitoring.
+
+### How to change limits for scaling
+
+1. Edit defaults in `variables.tf` or pass overrides when calling the module from `infra/main.tf`.
+2. Run `terraform plan` and `terraform apply` from the `infra` root (or this module directory if applied standalone).
+3. After deploy, clients exceeding limits receive **429 Too Many Requests** from API Gateway.
+
+### Verifying throttling
+
+- Use stage **access logs** (CloudWatch log group `/aws/apigwv2/<api-name>/<stage>/access`) and filter for `status` 429.
+- Load-test gradually; burst allows short spikes above steady RPS.
 

--- a/infra/api-gateway/main.tf
+++ b/infra/api-gateway/main.tf
@@ -73,6 +73,28 @@ resource "aws_apigatewayv2_stage" "default" {
     throttling_rate_limit  = var.throttling_rate_limit
   }
 
+  # Overrides default_route_settings for expensive or user-facing routes.
+  route_settings {
+    route_key              = "POST /scan/full"
+    throttling_burst_limit = var.throttling_scan_full_burst_limit
+    throttling_rate_limit  = var.throttling_scan_full_rate_limit
+  }
+  route_settings {
+    route_key              = "POST /auth/login"
+    throttling_burst_limit = var.throttling_auth_burst_limit
+    throttling_rate_limit  = var.throttling_auth_rate_limit
+  }
+  route_settings {
+    route_key              = "POST /auth/logout"
+    throttling_burst_limit = var.throttling_auth_burst_limit
+    throttling_rate_limit  = var.throttling_auth_rate_limit
+  }
+  route_settings {
+    route_key              = "GET /auth/session"
+    throttling_burst_limit = var.throttling_auth_burst_limit
+    throttling_rate_limit  = var.throttling_auth_rate_limit
+  }
+
   access_log_settings {
     destination_arn = aws_cloudwatch_log_group.apigw_access.arn
     format = jsonencode({

--- a/infra/api-gateway/variables.tf
+++ b/infra/api-gateway/variables.tf
@@ -61,16 +61,41 @@ variable "cors_allowed_headers" {
   default     = ["Content-Type", "Authorization", "X-Requested-With"]
 }
 
+# Stage default_route_settings apply to individual scan routes (POST /scan/* except /scan/full).
 variable "throttling_burst_limit" {
-  description = "API Gateway throttling burst limit"
+  description = "Burst limit (concurrent bucket) for individual scan routes; steady rate is throttling_rate_limit RPS."
   type        = number
-  default     = 100
+  default     = 50
 }
 
 variable "throttling_rate_limit" {
-  description = "API Gateway throttling rate limit"
+  description = "Steady-state requests per second for individual scan routes (POST /scan/* except /scan/full)."
   type        = number
-  default     = 50
+  default     = 25
+}
+
+variable "throttling_scan_full_burst_limit" {
+  description = "Burst limit for POST /scan/full (runs all scanners; kept low to reduce abuse and cost)."
+  type        = number
+  default     = 10
+}
+
+variable "throttling_scan_full_rate_limit" {
+  description = "Steady-state RPS for POST /scan/full."
+  type        = number
+  default     = 5
+}
+
+variable "throttling_auth_burst_limit" {
+  description = "Burst limit for auth routes (login/logout/session)."
+  type        = number
+  default     = 70
+}
+
+variable "throttling_auth_rate_limit" {
+  description = "Steady-state RPS for auth routes."
+  type        = number
+  default     = 35
 }
 
 variable "lambda_function_arn" {


### PR DESCRIPTION

## Summary
Performed a backend authorization review of scanner endpoints.

## Findings
- Session-based authentication is enforced (401 for unauthenticated users)
- Role-based access control (RBAC) is implemented using Cognito groups (403 for unauthorized access)
- Admin users have access to all scan types

## Gaps
- No distinct "viewer" (read-only) role
- No per-account authorization enforcement
- Direct Lambda invocation bypasses authentication and authorization checks
- API Gateway may not enforce authentication if not configured with an authorizer
- No fine-grained resource-level access control

## Risk
- Over-permissioned users may perform unintended actions
- Cross-account access is not restricted
- Direct invocation path could be abused if IAM permissions are not tightly controlled

## Recommendation
- Introduce viewer vs operator roles
- Enforce account-level authorization
- Restrict Lambda invocation via IAM policies
- Consider adding API Gateway JWT authorizers for additional enforcement

Fixes: #128 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Configured API Gateway request throttling with differentiated rate limits for individual scans (50 req/s burst, 25 req/s steady), full scans (10 burst, 5 steady), and authentication endpoints (70 burst, 35 steady).

* **Documentation**
  * Added backend authorization review and API Gateway rate-limiting implementation documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->