### PR TITLE
feat(security): add S24 audit logging for sensitive actions

### DIFF
--- a/docs/backend/S24-Sensitive-Audit-Logging.md
+++ b/docs/backend/S24-Sensitive-Audit-Logging.md
@@ -1,0 +1,90 @@
+# S24 — Audit logging for sensitive actions
+
+**Issue:** S24 / #186 — security review and compliance for sensitive operations.  
+**Log destination:** [Amazon CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/WhatIsCloudWatchLogs.html).
+
+---
+
+## 1. CloudWatch log groups and retention
+
+| Source | Log group pattern | Retention (Terraform) | Notes |
+|--------|-------------------|----------------------|--------|
+| Scanner Lambda | `/aws/lambda/<scanner-function-name>` | **365 days** (`infra/lambda/main.tf`) | Emits structured `SENSITIVE_AUDIT` lines (see §2). |
+| HTTP API (main API) | `/aws/apigwv2/<api-name>/<stage>/access` | **365 days** (`infra/api-gateway/main.tf`) | JSON access fields: `requestId`, `ip`, `routeKey`, `httpMethod`, `status`, `userAgent`, `requestTime`. |
+| Auth Lambda | `/aws/lambda/<auth-function-name>` | Set in AWS Console or Terraform for that function | **Source code is not in this repository**; login/logout/session validation should emit the same schema (§2) when implemented there. |
+
+If a log group already existed before Terraform managed it, import or align retention manually so it matches policy.
+
+---
+
+## 2. Structured audit schema (`iamdash_sensitive_action_v1`)
+
+Scanner Lambda writes **one log line per event** with the literal prefix `SENSITIVE_AUDIT` followed by a JSON object (parse the substring after the prefix for analysis).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `audit_schema` | string | Constant: `iamdash_sensitive_action_v1`. |
+| `timestamp_utc` | string | ISO-8601 UTC time of the record. |
+| `action` | string | `scan_triggered`, `scan_access_denied`, or (from other services) `login`, `logout`, `account_connected`, `role_changed`. |
+| `resource` | string | Logical resource, e.g. `scan:iam`, `scan:full`. |
+| `actor_username` | string or null | Cognito username from session, or `lambda_direct_invocation` for non-HTTP invokes, or null when unknown. |
+| `actor_groups` | array of string | Cognito groups from session (scanner path only); omitted when not applicable. |
+| `environment` | string | Lambda `ENVIRONMENT`. |
+| `project` | string | Lambda `PROJECT_NAME`. |
+| `details` | object | Context: `scanner_type`, `region`, `scan_id`, `target_account_id` (from request body when present), `reason` (`unauthenticated` / `insufficient_privilege`), etc. |
+| `http` | object | When the call is HTTP: `request_id`, `source_ip`, `user_agent`, `http_method`, `path` when available from API Gateway. |
+
+### Example (scan allowed)
+
+```json
+{
+  "audit_schema": "iamdash_sensitive_action_v1",
+  "timestamp_utc": "2026-04-13T12:00:00.000000Z",
+  "action": "scan_triggered",
+  "resource": "scan:iam",
+  "actor_username": "jdoe",
+  "actor_groups": ["iam"],
+  "environment": "prod",
+  "project": "IAMDash",
+  "details": {
+    "scanner_type": "iam",
+    "region": "us-east-1",
+    "scan_id": "iam-2026-04-13T12:00:00",
+    "target_account_id": "123456789012"
+  },
+  "http": {
+    "request_id": "abc-123",
+    "source_ip": "198.51.100.10",
+    "user_agent": "Mozilla/5.0 ...",
+    "http_method": "POST",
+    "path": "/scan/iam"
+  }
+}
+```
+
+### CloudWatch Logs Insights (scanner)
+
+- **Log group:** `/aws/lambda/<scanner-function-name>`
+- **Filter:** `@message like /SENSITIVE_AUDIT/`
+- Parse JSON: use `parse @message /SENSITIVE_AUDIT (?<audit>.*)/` then `parse audit @audit` if your query language supports chained parse, or export to S3/OpenSearch for heavy analytics.
+
+---
+
+## 3. Event coverage vs. implementation
+
+| Event | Where it should be logged | Status in repo |
+|-------|---------------------------|----------------|
+| Login | Auth Lambda (after successful Cognito auth) | **Documented only** — implement in auth Lambda codebase with `action: login` and `http` context; do not log passwords. |
+| Logout | Auth Lambda (session removed) | **Documented only** — same schema with `action: logout`. |
+| Scan trigger | Scanner Lambda | **Implemented** — `scan_triggered` after authorization succeeds. |
+| Scan denied (401/403) | Scanner Lambda | **Implemented** — `scan_access_denied` with `reason` in `details`. |
+| Account connection | Account-registration API / Lambda (when deployed) | **Not in repo** — use `action: account_connected` (or `account_disconnected`) and `details` with `account_id` / `account_name` (avoid secrets). |
+| Role / group changes | Cognito admin operations | Prefer **AWS CloudTrail** (`cognito-idp` events such as `AdminAddUserToGroup`) for IAM/Cognito changes; optionally mirror with `action: role_changed` in the component that performs the change. |
+
+---
+
+## 4. Compliance notes
+
+- **Who / what / when / context:** Covered by `actor_username`, `actor_groups`, `resource`, `details`, `timestamp_utc`, and `http` (IP, request id).
+- **Secrets:** Scanner logging continues to redact cookies in generic `Received event` logs (`sanitize_event_for_logging`); audit lines must never include session cookies or passwords.
+- **Retention:** Align all production log groups to organizational policy (365 days matches current API Gateway Terraform).

--- a/infra/lambda/lambda_function.py
+++ b/infra/lambda/lambda_function.py
@@ -151,6 +151,72 @@ class SessionStoreError(Exception):
     """Raised when session storage cannot be read safely."""
 
 
+def _http_request_audit_context(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Correlation and client context from API Gateway (HTTP API v2 or REST) for audit logs."""
+    ctx: Dict[str, Any] = {}
+    rc = event.get('requestContext') or {}
+    if not isinstance(rc, dict):
+        return ctx
+    ctx['request_id'] = rc.get('requestId')
+    http = rc.get('http') or {}
+    if isinstance(http, dict):
+        if http.get('sourceIp'):
+            ctx['source_ip'] = http.get('sourceIp')
+        if http.get('userAgent'):
+            ctx['user_agent'] = http.get('userAgent')
+        if http.get('method'):
+            ctx['http_method'] = http.get('method')
+        if http.get('path'):
+            ctx['path'] = http.get('path')
+    ident = rc.get('identity') or {}
+    if isinstance(ident, dict):
+        if 'source_ip' not in ctx and ident.get('sourceIp'):
+            ctx['source_ip'] = ident.get('sourceIp')
+        if 'user_agent' not in ctx and ident.get('userAgent'):
+            ctx['user_agent'] = ident.get('userAgent')
+    return {k: v for k, v in ctx.items() if v is not None}
+
+
+def emit_sensitive_audit_record(
+    action: str,
+    *,
+    actor_username: Optional[str] = None,
+    actor_groups: Optional[list] = None,
+    resource: str = '',
+    details: Optional[Dict[str, Any]] = None,
+    http_context: Optional[Dict[str, Any]] = None,
+) -> None:
+    """
+    Emit one JSON audit record to CloudWatch Logs (Lambda platform log stream).
+    Prefix with SENSITIVE_AUDIT for CloudWatch Logs Insights: filter @message like /SENSITIVE_AUDIT/
+    """
+    record: Dict[str, Any] = {
+        'audit_schema': 'iamdash_sensitive_action_v1',
+        'timestamp_utc': datetime.utcnow().isoformat() + 'Z',
+        'action': action,
+        'resource': resource,
+        'actor_username': actor_username,
+        'environment': ENVIRONMENT,
+        'project': PROJECT_NAME,
+        'details': details or {},
+    }
+    if actor_groups is not None:
+        record['actor_groups'] = actor_groups
+    if http_context:
+        record['http'] = http_context
+    try:
+        logger.info('SENSITIVE_AUDIT %s', json.dumps(record, default=json_serial))
+    except (TypeError, ValueError) as exc:
+        logger.warning('SENSITIVE_AUDIT serialization failed: %s', exc)
+
+
+def _target_account_from_scan_params(params: Dict[str, Any]) -> Optional[str]:
+    raw = params.get('account_id') if isinstance(params.get('account_id'), str) else params.get('accountId')
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return None
+
+
 def _cors_allowed_origins_set() -> set:
     raw = os.environ.get('CORS_ALLOWED_ORIGINS', '')
     return {o.strip() for o in raw.split(',') if o.strip()}
@@ -403,12 +469,72 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
                 'error': f'Invalid scanner type. Must be one of: {", ".join(valid_scanners)}'
             })
 
+        session: Optional[Dict[str, Any]] = None
         if is_http_request:
-            session = require_authenticated_session(event)
-            require_groups(session, scanner_type)
-        
+            http_audit_ctx = _http_request_audit_context(event)
+            session = get_request_session(event)
+            target_account = _target_account_from_scan_params(scan_params)
+            if not session:
+                emit_sensitive_audit_record(
+                    'scan_access_denied',
+                    resource=f'scan:{scanner_type}',
+                    details={
+                        'reason': 'unauthenticated',
+                        'scanner_type': scanner_type,
+                        'region': region,
+                        'target_account_id': target_account,
+                    },
+                    http_context=http_audit_ctx,
+                )
+                raise UnauthorizedError('Authentication required.')
+            try:
+                require_groups(session, scanner_type)
+            except ForbiddenError:
+                emit_sensitive_audit_record(
+                    'scan_access_denied',
+                    actor_username=session.get('username') if isinstance(session.get('username'), str) else None,
+                    actor_groups=normalize_groups(session.get('groups')),
+                    resource=f'scan:{scanner_type}',
+                    details={
+                        'reason': 'insufficient_privilege',
+                        'scanner_type': scanner_type,
+                        'region': region,
+                        'target_account_id': target_account,
+                    },
+                    http_context=http_audit_ctx,
+                )
+                raise
+
         # Execute scan
         scan_id = f"{scanner_type}-{datetime.utcnow().isoformat()}"
+        target_account = _target_account_from_scan_params(scan_params)
+        if is_http_request and session is not None:
+            emit_sensitive_audit_record(
+                'scan_triggered',
+                actor_username=session.get('username') if isinstance(session.get('username'), str) else None,
+                actor_groups=normalize_groups(session.get('groups')),
+                resource=f'scan:{scanner_type}',
+                details={
+                    'scanner_type': scanner_type,
+                    'region': region,
+                    'scan_id': scan_id,
+                    'target_account_id': target_account,
+                },
+                http_context=_http_request_audit_context(event),
+            )
+        elif not is_http_request:
+            emit_sensitive_audit_record(
+                'scan_triggered',
+                actor_username='lambda_direct_invocation',
+                resource=f'scan:{scanner_type}',
+                details={
+                    'scanner_type': scanner_type,
+                    'region': region,
+                    'scan_id': scan_id,
+                    'target_account_id': target_account,
+                    'invocation': 'direct',
+                },
+            )
         logger.info(f"Starting scan: {scan_id} for type: {scanner_type}")
         
         try:

--- a/infra/lambda/main.tf
+++ b/infra/lambda/main.tf
@@ -99,3 +99,17 @@ resource "aws_lambda_function" "scanner" {
 
   depends_on = [aws_iam_role_policy.lambda_policy]
 }
+
+# Scanner Lambda logs (structured SENSITIVE_AUDIT lines + platform messages)
+resource "aws_cloudwatch_log_group" "scanner_lambda" {
+  name              = "/aws/lambda/${var.lambda_function_name}"
+  retention_in_days = 365
+
+  tags = {
+    Name      = "${var.lambda_function_name}-logs"
+    Project   = var.project_name
+    Env       = var.environment
+    ManagedBy = "terraform"
+    Purpose   = "audit-scanner"
+  }
+}


### PR DESCRIPTION
## Summary
Implemented and documented audit logging for sensitive actions in the scanner backend.

## Changes
- Added structured audit logs for key events:
  - `scan_triggered`
  - `scan_access_denied`
- Logs include important context:
  - user_id
  - scanner_type
  - region
  - timestamp
  - optional account_id and HTTP request metadata
- Configured CloudWatch logging with 365-day retention
- Documented audit logging schema, log groups, and retention strategy

## Findings
- Audit logging is now in place for critical scan-related actions
- Some gaps remain in broader coverage (e.g., login/logout, full account scoping)

## Risk
- Without full coverage, some user actions may still lack traceability
- Missing logs could impact incident response and auditing

## Recommendation
- Expand audit logging to include authentication events (login/logout)
- Ensure all sensitive actions are consistently logged
- Standardize logging format across all services

Fixes: #186 