### PR TITLE
feat(deploy): verify releases with /health endpoint (D13, #139)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,3 +123,29 @@ jobs:
         done
         echo "Lambda update failed after $MAX_ATTEMPTS attempts (concurrent updates)"
         exit "${RC:-254}"
+
+    - name: Wait for Lambda update to activate
+      run: |
+        LAMBDA_FUNCTION_NAME="${{ steps.deployment-vars.outputs.lambda_function }}"
+        echo "Waiting for $LAMBDA_FUNCTION_NAME to reach LastUpdateStatus=Successful..."
+        aws lambda wait function-updated --function-name "$LAMBDA_FUNCTION_NAME"
+        echo "Lambda function is active."
+
+    - name: Verify deployment health (D13)
+      env:
+        HEALTH_CHECK_URL: ${{ vars.HEALTH_CHECK_URL }}
+      run: |
+        if [ -z "$HEALTH_CHECK_URL" ]; then
+          echo "::warning::HEALTH_CHECK_URL not set; skipping verification"
+          exit 0
+        fi
+        for attempt in 1 2 3 4 5 6; do
+          echo "Health check $attempt/6: $HEALTH_CHECK_URL"
+          if curl -fsS -m 10 "$HEALTH_CHECK_URL"; then
+            echo; echo "Deployment verified"
+            exit 0
+          fi
+          [ "$attempt" -lt 6 ] && sleep $((attempt * 5))
+        done
+        echo "::error::/health did not return 200 after 6 attempts"
+        exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -141,11 +141,14 @@ jobs:
         fi
         for attempt in 1 2 3 4 5 6; do
           echo "Health check $attempt/6: $HEALTH_CHECK_URL"
-          if curl -fsS -m 10 "$HEALTH_CHECK_URL"; then
-            echo; echo "Deployment verified"
+          if BODY=$(curl -fsS -m 10 "$HEALTH_CHECK_URL") \
+             && echo "$BODY" | grep -q '"status"[[:space:]]*:[[:space:]]*"healthy"'; then
+            echo "$BODY"
+            echo "Deployment verified"
             exit 0
           fi
+          [ -n "${BODY:-}" ] && echo "Unexpected response body: $BODY"
           [ "$attempt" -lt 6 ] && sleep $((attempt * 5))
         done
-        echo "::error::/health did not return 200 after 6 attempts"
+        echo "::error::/health did not return 200 with status=healthy after 6 attempts"
         exit 1

--- a/infra/README.md
+++ b/infra/README.md
@@ -250,6 +250,22 @@ This directory is scanned by:
 - **OPA** - Policy validation using Terraform policies
 - **Terraform Plan** - Built-in security checks
 
+## Deployment Verification (D13)
+
+After the `Deploy IAM Dashboard` workflow updates the scanner Lambda, it calls
+`aws lambda wait function-updated` and then hits `GET /health` on the API
+Gateway. A non-200 response after 6 retries with backoff fails the pipeline.
+
+- `/health` is an early return inside `lambda_handler`
+  (`infra/lambda/lambda_function.py`) routed via `aws_apigatewayv2_route.health`
+  with `authorization_type = "NONE"`.
+- The verification step reads the URL from the **repository variable**
+  `HEALTH_CHECK_URL`. After Terraform first applies the new route, copy the
+  `health_check_url` Terraform output (e.g.
+  `https://<api-id>.execute-api.us-east-1.amazonaws.com/v1/health`) into that
+  variable. If it is unset, the step logs a warning and exits 0 so the pipeline
+  is not blocked before setup is complete.
+
 ## Getting Started
 
 1. Install Terraform: https://terraform.io/downloads

--- a/infra/api-gateway/main.tf
+++ b/infra/api-gateway/main.tf
@@ -164,6 +164,18 @@ resource "aws_lambda_permission" "auth" {
   source_arn    = "${aws_apigatewayv2_api.api.execution_arn}/*/*"
 }
 
+# ── Health route ──────────────────────────────────────────────────────────────
+
+# Deployment verification (D13). authorization_type is hardcoded to NONE so
+# monitoring and CI never need credentials, even if var.route_authorization_type
+# is later flipped for scan/auth routes.
+resource "aws_apigatewayv2_route" "health" {
+  api_id             = aws_apigatewayv2_api.api.id
+  route_key          = "GET /health"
+  authorization_type = "NONE"
+  target             = "integrations/${aws_apigatewayv2_integration.lambda.id}"
+}
+
 # ── Scanner routes ────────────────────────────────────────────────────────────
 
 # Routes for all 9 security scan endpoints

--- a/infra/api-gateway/outputs.tf
+++ b/infra/api-gateway/outputs.tf
@@ -23,3 +23,8 @@ output "api_gateway_stage_id" {
   value       = aws_apigatewayv2_stage.default.id
 }
 
+output "health_check_url" {
+  description = "Full URL of the GET /health endpoint used by deploy verification (D13)"
+  value       = "${aws_apigatewayv2_api.api.api_endpoint}/${var.stage_name}/health"
+}
+

--- a/infra/lambda/lambda_function.py
+++ b/infra/lambda/lambda_function.py
@@ -430,8 +430,19 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
     
     try:
         logger.info("Received event: %s", json.dumps(sanitize_event_for_logging(event)))
-        
+
         is_http_request = 'httpMethod' in event or 'requestContext' in event
+
+        # Deployment verification (D13): answer GET /health with no downstream calls.
+        if is_http_request:
+            req_path = event.get('path') or event.get('requestContext', {}).get('http', {}).get('path', '')
+            req_method = event.get('httpMethod') or event.get('requestContext', {}).get('http', {}).get('method', '')
+            if req_method == 'GET' and req_path and req_path.rstrip('/').endswith('/health'):
+                return create_response(200, {
+                    'status': 'healthy',
+                    'timestamp': datetime.utcnow().isoformat() + 'Z',
+                    'function_version': getattr(context, 'function_version', None),
+                }, event)
 
         # Parse event (API Gateway or direct invocation)
         if is_http_request:

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -18,6 +18,11 @@ output "api_gateway_id" {
   value       = module.api_gateway.api_gateway_id
 }
 
+output "health_check_url" {
+  description = "Public /health URL surfaced for the deploy-verification GitHub Actions step (D13)"
+  value       = module.api_gateway.health_check_url
+}
+
 output "github_actions_role_arn" {
   description = "GitHub Actions IAM role ARN"
   value       = module.github_actions.github_actions_role_arn


### PR DESCRIPTION
Adds `GET /health` to the scanner Lambda via API Gateway and verifies it from the deploy workflow.

**POST MERGE SETUP (once and done)** 

The verification step reads `vars.HEALTH_CHECK_URL`. If unset, it logs a warning and exits 0, so merging does not break the pipeline.

1. Let `terraform-apply.yml` run on merge — it creates the new route.
2. Grab the URL: `terraform -chdir=infra output -raw health_check_url`
3. Confirm it works: `curl -i <url>` → 200 with `"status":"healthy"`
4. Add repo variable **Settings → Secrets and variables → Actions → Variables**:
   - Name: `HEALTH_CHECK_URL`
   - Value: the URL from step 2
5. Re-run a deploy to confirm the verification step passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added health verification checks to deployment pipeline that validates Lambda function status post-deployment
  * Introduced a new health monitoring endpoint for deployment verification

* **Chores**
  * Updated deployment workflow to include post-update validation with automatic retry logic
  * Added infrastructure documentation for deployment verification process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->