### PR TITLE
feat(retention): document and enforce scan/metrics retention 

### DIFF
--- a/backend/services/dynamodb_service.py
+++ b/backend/services/dynamodb_service.py
@@ -5,12 +5,17 @@ DynamoDB Service for data persistence and management
 import os
 import logging
 import json
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, List, Optional, Any
 import boto3
 from botocore.exceptions import ClientError
 
 logger = logging.getLogger(__name__)
+
+
+def _scan_item_expires_at_epoch() -> int:
+    days = int(os.environ.get('SCAN_RESULTS_TTL_DAYS', '365'))
+    return int((datetime.utcnow() + timedelta(days=days)).timestamp())
 
 
 class DynamoDBService:
@@ -49,7 +54,8 @@ class DynamoDBService:
                 'findings_count': scan_data.get('findings_count', 0),
                 'metadata': scan_data.get('metadata', {}),
                 'created_at': datetime.utcnow().isoformat(),
-                'updated_at': datetime.utcnow().isoformat()
+                'updated_at': datetime.utcnow().isoformat(),
+                'expires_at': scan_data.get('expires_at', _scan_item_expires_at_epoch()),
             }
             
             self.scan_results.put_item(Item=item)

--- a/backend/sql/retention_cleanup.sql
+++ b/backend/sql/retention_cleanup.sql
@@ -1,0 +1,20 @@
+-- Periodic retention cleanup for PostgreSQL (A17 / issue #196).
+-- Run on a schedule, for example from repo root (Docker Compose):
+--   docker compose exec -T db psql -U postgres -d cybersecurity_db < backend/sql/retention_cleanup.sql
+-- Or with DATABASE_URL on the host:
+--   psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f backend/sql/retention_cleanup.sql
+--
+-- Adjust intervals below to match docs/operations/DATA_RETENTION.md and your compliance needs.
+
+BEGIN;
+
+-- Application performance samples (dashboard / metrics table)
+DELETE FROM performance_metrics
+WHERE timestamp < NOW() - INTERVAL '90 days';
+
+-- Optional: long-lived resolved findings (uncomment if you want automatic pruning)
+-- DELETE FROM security_findings
+-- WHERE resolved = TRUE
+--   AND updated_at < NOW() - INTERVAL '730 days';
+
+COMMIT;

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -1,3 +1,7 @@
+# Scrape configuration for Docker Compose. Time-series retention is not set here;
+# it is configured on the Prometheus process (see docker-compose.yml and
+# docs/operations/DATA_RETENTION.md).
+
 global:
   scrape_interval: 15s
   evaluation_interval: 15s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - SMTP_USERNAME=${SMTP_USERNAME:-}
       - SMTP_PASSWORD=${SMTP_PASSWORD:-}
       - SMTP_FROM=${SMTP_FROM:-no-reply@local.test}
+      - SCAN_RESULTS_TTL_DAYS=${SCAN_RESULTS_TTL_DAYS:-365}
     volumes:
       - ./logs:/app/logs
       - ./data:/app/data
@@ -113,16 +114,22 @@ services:
     container_name: cybersecurity-prometheus
     ports:
       - "9090:9090"
+    environment:
+      # Time-series retention; override via host .env or export (see docs/operations/DATA_RETENTION.md)
+      - PROMETHEUS_RETENTION_TIME=${PROMETHEUS_RETENTION_TIME:-200h}
     volumes:
       - ./config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus_data:/prometheus
+    entrypoint: ["/bin/sh", "-c"]
     command:
-      - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.console.libraries=/etc/prometheus/console_libraries'
-      - '--web.console.templates=/etc/prometheus/consoles'
-      - '--storage.tsdb.retention.time=200h'
-      - '--web.enable-lifecycle'
+      - >-
+        exec /bin/prometheus
+        --config.file=/etc/prometheus/prometheus.yml
+        --storage.tsdb.path=/prometheus
+        --web.console.libraries=/etc/prometheus/console_libraries
+        --web.console.templates=/etc/prometheus/consoles
+        --storage.tsdb.retention.time=$$PROMETHEUS_RETENTION_TIME
+        --web.enable-lifecycle
     networks:
       - cybersecurity-network
     restart: unless-stopped

--- a/docs/operations/DATA_RETENTION.md
+++ b/docs/operations/DATA_RETENTION.md
@@ -1,0 +1,60 @@
+# Data retention policy (A17 / #196)
+
+This document defines how long **metrics**, **findings**, and **scans** are kept across observability stacks, the application database, AWS persistence, and the browser. Defaults target a balance between troubleshooting history and storage cost; production teams may tighten or extend periods via Terraform variables, Docker Compose environment values, or scheduled jobs.
+
+## Summary
+
+| Data | Where | Default retention | Cleanup mechanism |
+|------|--------|---------------------|-------------------|
+| Time-series metrics | Prometheus (Docker) | Configurable; default **200 hours (~8.3 days)** | Prometheus TSDB compaction and retention (`--storage.tsdb.retention.time`) |
+| Dashboards / users / annotations | Grafana SQLite volume | **Indefinite** (until volume is reset) | Operational: backup or prune volume; not time-based |
+| Metrics queried in Grafana | Same as Prometheus | Same as Prometheus | N/A (Grafana does not store scraped samples) |
+| `performance_metrics` rows | PostgreSQL | **90 days** (recommended) | `backend/sql/retention_cleanup.sql` (scheduled `psql`) |
+| Resolved `security_findings` | PostgreSQL | **730 days** (recommended) | Same SQL script (optional section) |
+| Open / unresolved findings | PostgreSQL | **Until resolved** then subject to resolved row policy | Manual or SQL script |
+| Scan payloads | DynamoDB `scan_id` + `timestamp` | **365 days** after write (default) | DynamoDB **TTL** on attribute `expires_at` |
+| Scan JSON objects | S3 prefix `scan-results/` | **365 days** (default, matches DynamoDB) | S3 lifecycle expiration |
+| Scan snapshots (Reports UI) | Browser `sessionStorage` key `iam-dashboard-scan-results` | **Until the tab is closed** | Browser; user **Clear** in app |
+| S3 access logs (site bucket) | Separate logging bucket | **90 days** | Terraform lifecycle (`infra/s3`) |
+| API Gateway execution logs | CloudWatch Logs | **365 days** | `retention_in_days` in `infra/api-gateway` |
+
+## Prometheus (local / Docker Compose)
+
+- Retention is controlled by the Prometheus flag `--storage.tsdb.retention.time`.
+- In this repository, Compose sets `PROMETHEUS_RETENTION_TIME` (default **`200h`**) so operators can change retention without editing the YAML structure.
+- Longer retention increases disk use under the `prometheus_data` volume.
+
+## Grafana
+
+- **Dashboards, folders, users, and API keys** live in Grafana’s database on the `grafana_data` Docker volume. There is no automatic expiry.
+- **Panels** read metrics from Prometheus; historical depth for charts equals Prometheus retention, not Grafana’s disk usage for dashboards.
+- For production, document who may delete dashboards and how volumes are backed up or rotated.
+
+## PostgreSQL (`performance_metrics`, `security_findings`)
+
+- Application models live in `backend/services/database_service.py`. Rows are not purged automatically by the app.
+- Run `backend/sql/retention_cleanup.sql` on a schedule (for example weekly) using `psql` and `DATABASE_URL`, or equivalent automation against the `db` service.
+- Adjust `INTERVAL` values in the script if your compliance regime requires different periods.
+
+## AWS DynamoDB and S3 (Lambda-stored scans)
+
+- **DynamoDB:** Terraform enables TTL on the `expires_at` numeric attribute (Unix epoch seconds). The scanner Lambda and the Python `DynamoDBService` set `expires_at` at write time using `SCAN_RESULTS_TTL_DAYS` (default **365**). Items **without** `expires_at` are not removed by TTL until updated or migrated.
+- **S3:** Objects under `scan-results/` share the static-site bucket; a lifecycle rule expires them after `scan_results_s3_retention_days` (default **365**), aligned with DynamoDB for consistent reconstruction windows.
+
+## Changing defaults
+
+| Knob | Location |
+|------|-----------|
+| Prometheus retention | `PROMETHEUS_RETENTION_TIME` in `.env` or Compose environment |
+| DynamoDB TTL attribute | Terraform `module.dynamodb` → `dynamodb_ttl_attribute_name`, `enable_dynamodb_ttl` |
+| TTL horizon (days) | Terraform `scan_results_ttl_days` → Lambda `SCAN_RESULTS_TTL_DAYS`; set `SCAN_RESULTS_TTL_DAYS` for local/backend writers |
+| S3 scan object expiry | Terraform `scan_results_s3_retention_days` |
+| Postgres deletes | Edit intervals in `backend/sql/retention_cleanup.sql` |
+
+## References
+
+- `docker-compose.yml` — Prometheus and Grafana services  
+- `infra/dynamodb/main.tf` — DynamoDB TTL  
+- `infra/s3/main.tf` — Lifecycle rules including `scan-results/`  
+- `infra/lambda/lambda_function.py` — `store_results` writes `expires_at`  
+- `backend/services/dynamodb_service.py` — Scan record writes  

--- a/infra/README.md
+++ b/infra/README.md
@@ -26,11 +26,13 @@ infra/
 - **Bucket**: `iam-dashboard-project` (static hosting)
 - **Bucket**: `iam-dashboard-scan-results-{random}` (scan results storage)
 - **Purpose**: Static site hosting and storing scan results
+- **Lifecycle**: JSON written by the scanner under `scan-results/` expires after `scan_results_retention_days` (default **365**); see [Data retention policy](../docs/operations/DATA_RETENTION.md).
 
 ### DynamoDB (`infra/dynamodb/`)
 - **Table**: `iam-dashboard-scan-results`
 - **Purpose**: Store security scan results from AWS scanners and OPA policies
-- **Schema**: Partition key `scanner_type`, Sort key `scan_id`
+- **Schema**: Partition key `scan_id`, Sort key `timestamp`
+- **Retention**: TTL on numeric attribute `expires_at` when enabled in Terraform; writers use `SCAN_RESULTS_TTL_DAYS` / `scan_results_ttl_days` (default **365**). Details: [Data retention policy](../docs/operations/DATA_RETENTION.md).
 
 ### Lambda (`infra/lambda/`)
 - **Function**: `iam-dashboard-scanner`
@@ -42,6 +44,10 @@ infra/
 - **API**: `iam-dashboard-api`
 - **Purpose**: REST API endpoints for triggering scans (9 endpoints planned)
 - **Status**: Placeholder structure, routes will be added when Lambda is ready
+
+## Data retention
+
+Prometheus metrics retention, Grafana behavior, PostgreSQL cleanup, DynamoDB TTL, S3 lifecycle for `scan-results/`, and browser storage are documented in **[docs/operations/DATA_RETENTION.md](../docs/operations/DATA_RETENTION.md)**. Terraform root variables include `scan_results_ttl_days`, `scan_results_s3_retention_days`, `enable_dynamodb_scan_ttl`, and `dynamodb_ttl_attribute_name`.
 
 ## Terraform state bucket (important)
 

--- a/infra/dynamodb/main.tf
+++ b/infra/dynamodb/main.tf
@@ -62,6 +62,14 @@ resource "aws_dynamodb_table" "scan_results" {
   # Enable deletion protection in production
   deletion_protection_enabled = var.environment == "prod"
 
+  dynamic "ttl" {
+    for_each = var.enable_ttl ? [1] : []
+    content {
+      attribute_name = var.ttl_attribute_name
+      enabled        = true
+    }
+  }
+
   tags = {
     Name        = var.dynamodb_table_name
     Project     = var.project_name

--- a/infra/dynamodb/variables.tf
+++ b/infra/dynamodb/variables.tf
@@ -38,3 +38,15 @@ variable "dynamodb_kms_key_arn" {
   description = "ARN of the shared/root KMS CMK to use for DynamoDB table encryption"
   type        = string
 }
+
+variable "enable_ttl" {
+  description = "Enable DynamoDB TTL on expires_at for automatic removal of old scan items"
+  type        = bool
+  default     = true
+}
+
+variable "ttl_attribute_name" {
+  description = "Numeric Unix epoch attribute used by DynamoDB TTL (writers must populate this)"
+  type        = string
+  default     = "expires_at"
+}

--- a/infra/lambda/lambda_function.py
+++ b/infra/lambda/lambda_function.py
@@ -7,7 +7,7 @@ import json
 import os
 import logging
 import boto3
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Dict, Any, Optional
 from botocore.exceptions import ClientError
 from decimal import Decimal
@@ -106,6 +106,7 @@ DYNAMODB_TABLE_NAME = os.environ.get('DYNAMODB_TABLE_NAME', 'iam-dashboard-scan-
 S3_BUCKET_NAME = os.environ.get('S3_BUCKET_NAME', 'iam-dashboard-project')
 PROJECT_NAME = os.environ.get('PROJECT_NAME', 'IAMDash')
 ENVIRONMENT = os.environ.get('ENVIRONMENT', 'dev')
+SCAN_RESULTS_TTL_DAYS = int(os.environ.get('SCAN_RESULTS_TTL_DAYS', '365'))
 
 
 def publish_metric(metric_name: str, value: float, dimensions: Dict[str, str] = None):
@@ -1598,6 +1599,7 @@ def store_results(scan_id: str, scanner_type: str, region: str, scan_result: Dic
     """Store scan results in DynamoDB and S3"""
     try:
         timestamp = datetime.utcnow().isoformat()
+        expires_at = int((datetime.utcnow() + timedelta(days=SCAN_RESULTS_TTL_DAYS)).timestamp())
         
         # Store in DynamoDB
         try:
@@ -1610,7 +1612,8 @@ def store_results(scan_id: str, scanner_type: str, region: str, scan_result: Dic
                     'timestamp': timestamp,
                     'results': scan_result,
                     'project': PROJECT_NAME,
-                    'environment': ENVIRONMENT
+                    'environment': ENVIRONMENT,
+                    'expires_at': expires_at,
                 }
             )
             logger.info(f"Stored results in DynamoDB: {scan_id}")

--- a/infra/lambda/main.tf
+++ b/infra/lambda/main.tf
@@ -76,10 +76,11 @@ resource "aws_lambda_function" "scanner" {
     variables = merge(
       var.lambda_environment_variables,
       {
-        DYNAMODB_TABLE_NAME = var.dynamodb_table_name
-        S3_BUCKET_NAME      = var.s3_bucket_name
-        PROJECT_NAME        = var.project_name
-        ENVIRONMENT         = var.environment
+        DYNAMODB_TABLE_NAME   = var.dynamodb_table_name
+        S3_BUCKET_NAME        = var.s3_bucket_name
+        PROJECT_NAME          = var.project_name
+        ENVIRONMENT           = var.environment
+        SCAN_RESULTS_TTL_DAYS = tostring(var.scan_results_ttl_days)
       }
     )
   }

--- a/infra/lambda/variables.tf
+++ b/infra/lambda/variables.tf
@@ -100,3 +100,9 @@ variable "s3_bucket_name" {
   type        = string
   default     = "iam-dashboard-project"
 }
+
+variable "scan_results_ttl_days" {
+  description = "Days from write until DynamoDB item TTL (expires_at)"
+  type        = number
+  default     = 365
+}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -35,12 +35,13 @@ data "aws_kms_key" "logs" {
 module "s3" {
   source = "./s3"
 
-  aws_region             = var.aws_region
-  environment            = var.environment
-  project_name           = var.project_name
-  s3_bucket_name         = var.s3_bucket_name
-  s3_kms_key_arn         = data.aws_kms_key.logs.arn
-  s3_logging_bucket_name = "${var.s3_bucket_name}-access-logs"
+  aws_region                  = var.aws_region
+  environment                 = var.environment
+  project_name                = var.project_name
+  s3_bucket_name              = var.s3_bucket_name
+  s3_kms_key_arn              = data.aws_kms_key.logs.arn
+  s3_logging_bucket_name      = "${var.s3_bucket_name}-access-logs"
+  scan_results_retention_days = var.scan_results_s3_retention_days
 }
 
 # DynamoDB Module
@@ -53,19 +54,22 @@ module "dynamodb" {
   dynamodb_table_name           = var.dynamodb_table_name
   dynamodb_kms_key_arn          = data.aws_kms_key.logs.arn
   enable_point_in_time_recovery = true
+  enable_ttl                    = var.enable_dynamodb_scan_ttl
+  ttl_attribute_name            = var.dynamodb_ttl_attribute_name
 }
 
 # Lambda Module
 module "lambda" {
   source = "./lambda"
 
-  aws_region           = var.aws_region
-  environment          = var.environment
-  project_name         = var.project_name
-  lambda_function_name = var.lambda_function_name
-  dynamodb_table_name  = var.dynamodb_table_name
-  s3_bucket_name       = var.s3_bucket_name
-  lambda_kms_key_arn   = data.aws_kms_key.logs.arn
+  aws_region            = var.aws_region
+  environment           = var.environment
+  project_name          = var.project_name
+  lambda_function_name  = var.lambda_function_name
+  dynamodb_table_name   = var.dynamodb_table_name
+  s3_bucket_name        = var.s3_bucket_name
+  lambda_kms_key_arn    = data.aws_kms_key.logs.arn
+  scan_results_ttl_days = var.scan_results_ttl_days
 }
 
 # API Gateway Module

--- a/infra/s3/main.tf
+++ b/infra/s3/main.tf
@@ -63,6 +63,19 @@ resource "aws_s3_bucket_lifecycle_configuration" "frontend" {
       noncurrent_days = 30
     }
   }
+
+  rule {
+    id     = "expire-lambda-scan-results"
+    status = "Enabled"
+
+    filter {
+      prefix = "scan-results/"
+    }
+
+    expiration {
+      days = var.scan_results_retention_days
+    }
+  }
 }
 
 # S3 bucket public access block (optional - disabled for static site hosting)

--- a/infra/s3/variables.tf
+++ b/infra/s3/variables.tf
@@ -43,3 +43,14 @@ variable "s3_logging_bucket_name" {
   description = "Name of the S3 bucket for storing access logs"
   type        = string
 }
+
+variable "scan_results_retention_days" {
+  description = "Expire objects under the scan-results/ prefix after this many days (aligned with DynamoDB scan TTL)"
+  type        = number
+  default     = 365
+
+  validation {
+    condition     = var.scan_results_retention_days >= 1 && var.scan_results_retention_days <= 3650
+    error_message = "scan_results_retention_days must be between 1 and 3650."
+  }
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -46,6 +46,30 @@ variable "dynamodb_table_name" {
   default     = "iam-dashboard-scan-results"
 }
 
+variable "scan_results_ttl_days" {
+  description = "Days until DynamoDB scan items expire (TTL on expires_at); passed to Lambda as SCAN_RESULTS_TTL_DAYS"
+  type        = number
+  default     = 365
+}
+
+variable "scan_results_s3_retention_days" {
+  description = "S3 lifecycle expiration (days) for objects under scan-results/"
+  type        = number
+  default     = 365
+}
+
+variable "enable_dynamodb_scan_ttl" {
+  description = "When true, enable DynamoDB TTL on the scan results table"
+  type        = bool
+  default     = true
+}
+
+variable "dynamodb_ttl_attribute_name" {
+  description = "DynamoDB TTL attribute (numeric epoch seconds); must match application writers"
+  type        = string
+  default     = "expires_at"
+}
+
 variable "lambda_function_name" {
   description = "Lambda function name"
   type        = string


### PR DESCRIPTION
## Summary
This PR implements and documents a data retention policy for scans and metrics across the system.

## What’s Included
- Added `docs/operations/DATA_RETENTION.md` outlining retention policies for:
  - Prometheus
  - Grafana
  - PostgreSQL
  - DynamoDB
  - S3
  - Browser session storage

- Enabled DynamoDB TTL:
  - Configured `expires_at` field
  - Set via Lambda and DynamoDB service using `SCAN_RESULTS_TTL_DAYS`

- Added S3 lifecycle policy:
  - Automatically expires objects under the `scan-results/` prefix

- Implemented PostgreSQL cleanup:
  - Added scheduled pruning script for `performance_metrics`

- Made Prometheus retention configurable:
  - Uses `PROMETHEUS_RETENTION_TIME` in Docker Compose
  - Documented configuration in `prometheus.yml`

- Updated infrastructure documentation:
  - Fixed DynamoDB key schema references
  - Linked retention policy where relevant

## Why this matters
This ensures scan results and metrics do not grow indefinitely, improving system performance, storage management, and operational reliability.

## Notes
- Retention duration is controlled via environment variables and infrastructure configuration
- Policies are aligned across services where possible (e.g. TTL + S3 lifecycle)

Fixes: #196 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automated data retention policies across all storage systems.
  * Scan results now automatically expire after 365 days (configurable).
  * Historical performance metrics automatically cleaned up after 90 days.
  * Old security findings automatically removed after 730 days.
  * Prometheus time-series metrics retention is now configurable (default: 200 hours).

* **Documentation**
  * Added comprehensive data retention policy documentation covering all data stores and their cleanup mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->