### PR TITLE
resolved #365: define and implement data retention policies for Prometheus, Grafana, DynamoDB, and PostgreSQL

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -34,11 +34,9 @@ jobs:
     needs: devsecops_scan
     runs-on: ubuntu-latest
     env:
-      # KMS key alias or ID used by the KMS data source in infra/.
-      # Set this secret in GitHub as KMS_KEY_ID (e.g. alias/IAM-Dashboard-Keys).
-      TF_VAR_kms_key_id: ${{ secrets.KMS_KEY_ID }}
-      # Main account ID where the scanner lambda function lives
-      TF_VAR_main_account_id: ${{ secrets.MAIN_ACCOUNT_ID }}
+      # Fork PRs do not receive repository secrets; use placeholders so validate can run (see below).
+      TF_VAR_kms_key_id: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && 'alias/ci-terraform-validate-only' || secrets.KMS_KEY_ID }}
+      TF_VAR_main_account_id: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && '000000000000' || secrets.MAIN_ACCOUNT_ID }}
     defaults:
       run:
         working-directory: infra
@@ -46,26 +44,52 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: us-east-1
-
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
 
       - name: Terraform fmt
         run: terraform fmt -check -recursive
 
-      - name: Terraform init
+      # Secrets (AWS_ROLE_ARN, KMS_KEY_ID, …) are not available for pull_request workflows when the
+      # head branch is from a fork. Skip OIDC and run init -backend=false + validate only.
+      - name: Verify AWS_ROLE_ARN secret (required when AWS credentials are used)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+        run: |
+          if [ -z "$AWS_ROLE_ARN" ]; then
+            echo "::error::AWS_ROLE_ARN is empty. Add it under Settings → Secrets and variables → Actions."
+            echo "Use the IAM role ARN trusted for GitHub OIDC (see infra/github-actions and token.actions.githubusercontent.com:sub for this repo)."
+            exit 1
+          fi
+
+      - name: Configure AWS credentials (OIDC)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
+
+      - name: Terraform init (remote state)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: terraform init -input=false
+
+      - name: Terraform init (no backend — fork PR)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: terraform init -backend=false -input=false
 
       - name: Terraform validate
         run: terraform validate
 
       - name: Terraform plan
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: terraform plan -input=false -no-color
+
+      - name: Terraform plan skipped (fork PR)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "::notice::Skipped terraform plan: fork PRs do not receive repository Actions secrets, so AWS OIDC cannot run."
+          echo "fmt and validate still ran. For a full plan, push a branch on the target repository or run plan locally with credentials."
 
   apply:
     name: Terraform Apply
@@ -83,6 +107,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Verify AWS_ROLE_ARN secret
+        env:
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+        run: |
+          if [ -z "$AWS_ROLE_ARN" ]; then
+            echo "::error::AWS_ROLE_ARN is empty. Add it under Settings → Secrets and variables → Actions."
+            exit 1
+          fi
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4

--- a/backend/api/retention.py
+++ b/backend/api/retention.py
@@ -1,0 +1,61 @@
+"""
+Data retention: DynamoDB age-based deletes + PostgreSQL cleanup.
+
+Optional HTTP trigger (POST) when RETENTION_RUN_KEY is set.
+"""
+
+import hmac
+import logging
+import os
+
+from flask import request
+from flask_restful import Resource
+
+from services.database_service import DatabaseService
+from services.dynamodb_service import DynamoDBService
+
+logger = logging.getLogger(__name__)
+
+
+def run_retention_pass(days: int = 90) -> dict:
+    """Run DynamoDB paginated deletes and PostgreSQL cleanup."""
+    dynamo = DynamoDBService()
+    db = DatabaseService()
+    scan_deleted = dynamo.delete_old_records(dynamo.scan_results_table, days)
+    findings_deleted = dynamo.delete_old_records(dynamo.iam_findings_table, days)
+    sql_counts = db.cleanup_old_records(days)
+    result = {
+        "dynamo_scan_results_deleted": scan_deleted,
+        "dynamo_iam_findings_deleted": findings_deleted,
+        "postgres": sql_counts,
+    }
+    logger.info("Retention pass complete: %s", result)
+    return result
+
+
+class RetentionCleanupResource(Resource):
+    """POST /api/v1/system/retention — on-demand retention (requires RETENTION_RUN_KEY)."""
+
+    def post(self):
+        """Run a retention pass when ``X-Retention-Run-Key`` matches ``RETENTION_RUN_KEY``."""
+        expected = os.environ.get("RETENTION_RUN_KEY", "").strip()
+        if not expected:
+            return {
+                "error": "disabled",
+                "message": "Set RETENTION_RUN_KEY to enable HTTP-triggered retention runs.",
+            }, 503
+        supplied = request.headers.get("X-Retention-Run-Key", "").strip()
+        if not hmac.compare_digest(supplied, expected):
+            return {"error": "forbidden"}, 403
+        try:
+            days = int(request.args.get("days", "90"))
+            if days < 1 or days > 3650:
+                days = 90
+        except ValueError:
+            days = 90
+        try:
+            result = run_retention_pass(days=days)
+            return result, 200
+        except Exception:
+            logger.exception("Retention pass failed")
+            return {"error": "Retention pass failed"}, 500

--- a/backend/api/retention.py
+++ b/backend/api/retention.py
@@ -8,7 +8,7 @@ import hmac
 import logging
 import os
 
-from flask import request
+from flask import jsonify, request
 from flask_restful import Resource
 
 from services.database_service import DatabaseService
@@ -18,17 +18,38 @@ logger = logging.getLogger(__name__)
 
 
 def run_retention_pass(days: int = 90) -> dict:
-    """Run DynamoDB paginated deletes and PostgreSQL cleanup."""
+    """Run DynamoDB paginated deletes and PostgreSQL cleanup.
+
+    Each backend is isolated: failures in one step do not skip the others.
+    On success, values are counts (int or dict for postgres). On failure, the
+    same key holds a string error message.
+    """
     dynamo = DynamoDBService()
     db = DatabaseService()
-    scan_deleted = dynamo.delete_old_records(dynamo.scan_results_table, days)
-    findings_deleted = dynamo.delete_old_records(dynamo.iam_findings_table, days)
-    sql_counts = db.cleanup_old_records(days)
-    result = {
-        "dynamo_scan_results_deleted": scan_deleted,
-        "dynamo_iam_findings_deleted": findings_deleted,
-        "postgres": sql_counts,
-    }
+    result: dict = {}
+
+    try:
+        result["dynamo_scan_results_deleted"] = dynamo.delete_old_records(
+            dynamo.scan_results_table, days
+        )
+    except Exception as exc:
+        logger.exception("Retention pass: DynamoDB scan_results cleanup failed")
+        result["dynamo_scan_results_deleted"] = str(exc)
+
+    try:
+        result["dynamo_iam_findings_deleted"] = dynamo.delete_old_records(
+            dynamo.iam_findings_table, days
+        )
+    except Exception as exc:
+        logger.exception("Retention pass: DynamoDB iam_findings cleanup failed")
+        result["dynamo_iam_findings_deleted"] = str(exc)
+
+    try:
+        result["postgres"] = db.cleanup_old_records(days)
+    except Exception as exc:
+        logger.exception("Retention pass: PostgreSQL cleanup_old_records failed")
+        result["postgres"] = str(exc)
+
     logger.info("Retention pass complete: %s", result)
     return result
 
@@ -47,15 +68,35 @@ class RetentionCleanupResource(Resource):
         supplied = request.headers.get("X-Retention-Run-Key", "").strip()
         if not hmac.compare_digest(supplied, expected):
             return {"error": "forbidden"}, 403
-        try:
-            days = int(request.args.get("days", "90"))
-            if days < 1 or days > 3650:
-                days = 90
-        except ValueError:
+        raw_days = request.args.get("days")
+        if raw_days is None or not str(raw_days).strip():
             days = 90
-        try:
-            result = run_retention_pass(days=days)
-            return result, 200
-        except Exception:
-            logger.exception("Retention pass failed")
-            return {"error": "Retention pass failed"}, 500
+        else:
+            try:
+                days = int(str(raw_days).strip())
+            except ValueError:
+                return (
+                    jsonify(
+                        {
+                            "error": "invalid_parameter",
+                            "message": (
+                                "Query parameter 'days' must be an integer between 1 and 3650."
+                            ),
+                        }
+                    ),
+                    400,
+                )
+            if days < 1 or days > 3650:
+                return (
+                    jsonify(
+                        {
+                            "error": "invalid_parameter",
+                            "message": (
+                                "Query parameter 'days' must be between 1 and 3650 inclusive."
+                            ),
+                        }
+                    ),
+                    400,
+                )
+        result = run_retention_pass(days=days)
+        return result, 200

--- a/backend/app.py
+++ b/backend/app.py
@@ -5,6 +5,8 @@ Main application entry point with API endpoints for AWS integrations
 
 import os
 import logging
+import threading
+import time
 from flask import Flask, jsonify, request, send_from_directory
 from flask_cors import CORS
 from flask_restful import Api
@@ -40,6 +42,7 @@ from api.tts import TTSSynthesizeResource
 from api.voice_intent import VoiceIntentResource
 from api.signup import SignupWelcomeEmailResource
 from api.password_reset import ForgotPasswordResource, ResetPasswordResource
+from api.retention import RetentionCleanupResource, run_retention_pass
 
 # Import services
 from services.aws_service import AWSService
@@ -52,6 +55,65 @@ logging.basicConfig(
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 logger = logging.getLogger(__name__)
+
+
+def _parse_retention_interval_seconds() -> int:
+    """Parse RETENTION_SCHEDULER_INTERVAL_SEC with a safe minimum."""
+    raw_interval = os.environ.get("RETENTION_SCHEDULER_INTERVAL_SEC", "86400")
+    try:
+        interval = int(raw_interval)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid RETENTION_SCHEDULER_INTERVAL_SEC=%r; defaulting to 86400s",
+            raw_interval,
+        )
+        interval = 86400
+    if interval <= 0:
+        logger.warning(
+            "Non-positive RETENTION_SCHEDULER_INTERVAL_SEC=%r; defaulting to 86400s",
+            raw_interval,
+        )
+        interval = 86400
+    if interval < 60:
+        logger.warning(
+            "RETENTION_SCHEDULER_INTERVAL_SEC=%r too small; clamping to 60s",
+            raw_interval,
+        )
+        interval = 60
+    return interval
+
+
+def start_retention_scheduler(flask_app: Flask) -> None:
+    """Start a daemon thread that runs ``run_retention_pass`` on a fixed interval."""
+    if os.environ.get("RETENTION_SCHEDULER_ENABLED", "true").lower() not in (
+        "1",
+        "true",
+        "yes",
+    ):
+        logger.info("Retention scheduler disabled (RETENTION_SCHEDULER_ENABLED).")
+        return
+    interval = _parse_retention_interval_seconds()
+
+    def _worker():
+        """Run retention on startup delay, then loop with ``interval`` sleeps."""
+        time.sleep(60)
+        while True:
+            try:
+                with flask_app.app_context():
+                    run_retention_pass()
+            except Exception:
+                logger.exception("Scheduled retention pass failed")
+            time.sleep(interval)
+
+    threading.Thread(
+        target=_worker,
+        daemon=True,
+        name="retention-scheduler",
+    ).start()
+    logger.info(
+        "Retention scheduler started (interval=%ss, first run after 60s startup delay).",
+        interval,
+    )
 
 
 def create_app():
@@ -99,6 +161,7 @@ def create_app():
     api.add_resource(SecurityHubResource, '/aws/security-hub')
     api.add_resource(ConfigResource, '/aws/config')
     api.add_resource(GrafanaResource, '/grafana')
+    api.add_resource(RetentionCleanupResource, '/system/retention')
 
     # IR Action Engine routes
     api.add_resource(LLMTriageResource,           '/llm/triage')
@@ -123,25 +186,34 @@ def create_app():
     # Serve static files (React frontend)
     @app.route('/')
     def serve_frontend():
+        """Serve the React SPA entry (``index.html``) at ``/``."""
         return send_from_directory(app.static_folder, 'index.html')
 
     @app.route('/<path:path>')
     def serve_static(path):
+        """Serve built static assets for client-side routes."""
         return send_from_directory(app.static_folder, path)
 
     # Error handlers
     @app.errorhandler(404)
     def not_found(error):
+        """Return a JSON body for HTTP 404 responses."""
         return jsonify({'error': 'Not found'}), 404
 
     @app.errorhandler(500)
     def internal_error(error):
+        """Return a JSON body for HTTP 500 responses."""
         return jsonify({'error': 'Internal server error'}), 500
 
     # Initialize database
     with app.app_context():
         database_service.init_db()
         logger.info("Database initialized")
+
+    if not os.environ.get("AWS_LAMBDA_FUNCTION_NAME") and os.environ.get(
+        "WERKZEUG_RUN_MAIN", "false"
+    ) != "true":
+        start_retention_scheduler(app)
 
     return app
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -84,7 +84,13 @@ def _parse_retention_interval_seconds() -> int:
 
 
 def start_retention_scheduler(flask_app: Flask) -> None:
-    """Start a daemon thread that runs ``run_retention_pass`` on a fixed interval."""
+    """Start a daemon thread that runs ``run_retention_pass`` on a fixed interval.
+
+    When ``REDIS_URL`` is set and ``RETENTION_SCHEDULER_REDIS_LOCK`` is truthy
+    (default), a short-lived Redis lock prevents concurrent runs across WSGI
+    workers. If Redis is unavailable, a warning is logged once and passes run
+    without coordination (avoid multiple app replicas without Redis).
+    """
     if os.environ.get("RETENTION_SCHEDULER_ENABLED", "true").lower() not in (
         "1",
         "true",
@@ -94,15 +100,67 @@ def start_retention_scheduler(flask_app: Flask) -> None:
         return
     interval = _parse_retention_interval_seconds()
 
+    redis_url = os.environ.get("REDIS_URL", "").strip()
+    use_redis_lock = os.environ.get(
+        "RETENTION_SCHEDULER_REDIS_LOCK", "true"
+    ).lower() in ("1", "true", "yes")
+    redis_client = None
+    if use_redis_lock and redis_url:
+        try:
+            from redis import Redis
+
+            redis_client = Redis.from_url(redis_url, socket_connect_timeout=2)
+            redis_client.ping()
+        except Exception:
+            logger.exception(
+                "Retention scheduler: Redis unavailable; scheduled passes are not "
+                "coordinated across workers. Set RETENTION_SCHEDULER_REDIS_LOCK=false "
+                "to silence this if intentional."
+            )
+            redis_client = None
+    elif use_redis_lock and not redis_url:
+        logger.warning(
+            "Retention scheduler: REDIS_URL unset; retention runs are not coordinated "
+            "across workers. Set REDIS_URL or disable RETENTION_SCHEDULER_REDIS_LOCK."
+        )
+
+    lock_timeout_sec = int(os.environ.get("RETENTION_SCHEDULER_LOCK_TIMEOUT_SEC", "7200"))
+
     def _worker():
         """Run retention on startup delay, then loop with ``interval`` sleeps."""
         time.sleep(60)
         while True:
             try:
                 with flask_app.app_context():
-                    run_retention_pass()
+                    if redis_client is not None:
+                        lock = redis_client.lock(
+                            "iam-dashboard:retention:scheduler",
+                            timeout=lock_timeout_sec,
+                        )
+                        if not lock.acquire(blocking=False):
+                            logger.debug(
+                                "Retention pass skipped: another worker holds the "
+                                "Redis scheduler lock"
+                            )
+                        else:
+                            try:
+                                run_retention_pass()
+                            except Exception:
+                                logger.exception("Scheduled retention pass failed")
+                            finally:
+                                try:
+                                    lock.release()
+                                except Exception:
+                                    logger.exception(
+                                        "Retention scheduler: error releasing Redis lock"
+                                    )
+                    else:
+                        try:
+                            run_retention_pass()
+                        except Exception:
+                            logger.exception("Scheduled retention pass failed")
             except Exception:
-                logger.exception("Scheduled retention pass failed")
+                logger.exception("Scheduled retention pass failed (outer)")
             time.sleep(interval)
 
     threading.Thread(
@@ -211,8 +269,8 @@ def create_app():
         logger.info("Database initialized")
 
     if not os.environ.get("AWS_LAMBDA_FUNCTION_NAME") and os.environ.get(
-        "WERKZEUG_RUN_MAIN", "false"
-    ) != "true":
+        "WERKZEUG_RUN_MAIN", "true"
+    ) == "true":
         start_retention_scheduler(app)
 
     return app

--- a/backend/services/database_service.py
+++ b/backend/services/database_service.py
@@ -206,16 +206,19 @@ class DatabaseService:
             if session is not None:
                 try:
                     session.rollback()
-                except Exception:
-                    pass
-            raise
+                except Exception as rb_err:
+                    logger.exception(
+                        "cleanup_old_records: session.rollback failed: %s", rb_err
+                    )
             raise
         finally:
             if session is not None:
                 try:
                     session.close()
-                except Exception:
-                    pass
+                except Exception as close_err:
+                    logger.exception(
+                        "cleanup_old_records: session.close failed: %s", close_err
+                    )
 
     def get_dashboard_summary(self) -> dict:
         """Get dashboard summary data"""

--- a/backend/services/database_service.py
+++ b/backend/services/database_service.py
@@ -7,7 +7,7 @@ import logging
 from sqlalchemy import create_engine, Column, Integer, String, DateTime, Boolean, Text, Float
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-from datetime import datetime
+from datetime import datetime, timedelta
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +61,7 @@ class DatabaseService:
     """Service for database operations"""
     
     def __init__(self):
+        """Create SQLAlchemy engine and session factory from ``DATABASE_URL``."""
         self.database_url = os.environ.get('DATABASE_URL', 'sqlite:///cybersecurity.db')
         self.engine = create_engine(self.database_url)
         self.SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=self.engine)
@@ -177,6 +178,45 @@ class DatabaseService:
             logger.error(f"Error getting performance metrics: {str(e)}")
             return []
     
+    def cleanup_old_records(self, days: int = 90) -> dict:
+        """Delete rows older than ``days`` from security_findings and performance_metrics."""
+        if days <= 0:
+            raise ValueError("days must be positive")
+        cutoff = datetime.utcnow() - timedelta(days=days)
+        session = None
+        try:
+            session = self.get_session()
+            n_findings = (
+                session.query(SecurityFinding)
+                .filter(SecurityFinding.created_at < cutoff)
+                .delete(synchronize_session=False)
+            )
+            n_metrics = (
+                session.query(PerformanceMetric)
+                .filter(PerformanceMetric.timestamp < cutoff)
+                .delete(synchronize_session=False)
+            )
+            session.commit()
+            return {
+                "security_findings_deleted": n_findings,
+                "performance_metrics_deleted": n_metrics,
+            }
+        except Exception as e:
+            logger.error(f"Error during cleanup_old_records: {str(e)}")
+            if session is not None:
+                try:
+                    session.rollback()
+                except Exception:
+                    pass
+            raise
+            raise
+        finally:
+            if session is not None:
+                try:
+                    session.close()
+                except Exception:
+                    pass
+
     def get_dashboard_summary(self) -> dict:
         """Get dashboard summary data"""
         try:

--- a/backend/services/dynamodb_service.py
+++ b/backend/services/dynamodb_service.py
@@ -5,12 +5,42 @@ DynamoDB Service for data persistence and management
 import os
 import logging
 import json
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional, Any
 import boto3
 from botocore.exceptions import ClientError
 
 logger = logging.getLogger(__name__)
+
+# Default TTL window for new items (must match data retention policy)
+_DEFAULT_RETENTION_DAYS = 90
+
+
+def _compute_expires_at_epoch(days: int = _DEFAULT_RETENTION_DAYS) -> int:
+    """Unix epoch seconds for DynamoDB TTL (expires_at)."""
+    if days <= 0:
+        raise ValueError("days must be positive")
+    return int((datetime.now(timezone.utc) + timedelta(days=days)).timestamp())
+
+
+def _parse_item_time_epoch(value: Any) -> Optional[float]:
+    """Parse DynamoDB item timestamp fields to UTC epoch seconds, or None if unparseable."""
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    s = str(value).strip()
+    if not s:
+        return None
+    try:
+        dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        else:
+            dt = dt.astimezone(timezone.utc)
+        return dt.timestamp()
+    except ValueError:
+        return None
 
 
 class DynamoDBService:
@@ -49,7 +79,8 @@ class DynamoDBService:
                 'findings_count': scan_data.get('findings_count', 0),
                 'metadata': scan_data.get('metadata', {}),
                 'created_at': datetime.utcnow().isoformat(),
-                'updated_at': datetime.utcnow().isoformat()
+                'updated_at': datetime.utcnow().isoformat(),
+                'expires_at': scan_data.get('expires_at', _compute_expires_at_epoch()),
             }
             
             self.scan_results.put_item(Item=item)
@@ -120,7 +151,8 @@ class DynamoDBService:
                 'region': finding_data.get('region', 'us-east-1'),
                 'metadata': finding_data.get('metadata', {}),
                 'created_at': datetime.utcnow().isoformat(),
-                'updated_at': datetime.utcnow().isoformat()
+                'updated_at': datetime.utcnow().isoformat(),
+                'expires_at': finding_data.get('expires_at', _compute_expires_at_epoch()),
             }
             
             self.iam_findings.put_item(Item=item)
@@ -224,7 +256,8 @@ class DynamoDBService:
                             'region': finding.get('region', 'us-east-1'),
                             'metadata': finding.get('metadata', {}),
                             'created_at': datetime.utcnow().isoformat(),
-                            'updated_at': datetime.utcnow().isoformat()
+                            'updated_at': datetime.utcnow().isoformat(),
+                            'expires_at': finding.get('expires_at', _compute_expires_at_epoch()),
                         }
                         batch.put_item(Item=item)
                         success_count += 1
@@ -239,37 +272,63 @@ class DynamoDBService:
             return {'success': 0, 'failed': len(findings)}
 
     def delete_old_records(self, table_name: str, days: int = 90) -> int:
-        """Delete records older than specified days"""
-        try:
-            table = self.dynamodb.Table(table_name)
-            cutoff_date = datetime.utcnow().replace(
-                hour=0, minute=0, second=0, microsecond=0
-            ).timestamp() - (days * 86400)
-            
-            response = table.scan()
-            deleted_count = 0
-            
-            with table.batch_writer() as batch:
-                for item in response.get('Items', []):
-                    # Check if timestamp is older than cutoff
-                    if 'timestamp' in item:
-                        item_timestamp = item['timestamp']
-                        # Convert ISO timestamp to epoch for comparison
-                        item_epoch = datetime.fromisoformat(item_timestamp.replace('Z', '+00:00')).timestamp()
-                        
-                        if item_epoch < cutoff_date:
-                            batch.delete_item(
-                                Key={
-                                    'scan_id': item['scan_id'],
-                                    'timestamp': item['timestamp']
-                                }
-                            )
-                            deleted_count += 1
-            
-            logger.info(f"Deleted {deleted_count} old records from {table_name}")
-            return deleted_count
-        
-        except ClientError as e:
-            logger.error(f"DynamoDB error deleting old records: {str(e)}")
+        """Delete records older than ``days`` using a paginated table scan.
+
+        Uses the correct primary key for scan results vs IAM findings tables.
+        """
+        if days <= 0:
+            raise ValueError("days must be positive")
+        cutoff_dt = datetime.now(timezone.utc).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        ) - timedelta(days=days)
+        cutoff_epoch = cutoff_dt.timestamp()
+
+        table = self.dynamodb.Table(table_name)
+        is_scan = table_name == self.scan_results_table
+        is_findings = table_name == self.iam_findings_table
+        if not is_scan and not is_findings:
+            logger.warning("delete_old_records: unsupported table name %s", table_name)
             return 0
+        deleted_count = 0
+        scan_kwargs: Dict[str, Any] = {}
+
+        try:
+            while True:
+                response = table.scan(**scan_kwargs)
+                with table.batch_writer() as batch:
+                    for item in response.get("Items", []):
+                        if is_scan:
+                            item_epoch = _parse_item_time_epoch(item.get("timestamp"))
+                            if item_epoch is None or item_epoch >= cutoff_epoch:
+                                continue
+                            sid = item.get("scan_id")
+                            ts = item.get("timestamp")
+                            if sid is None or ts is None:
+                                continue
+                            batch.delete_item(Key={"scan_id": sid, "timestamp": ts})
+                            deleted_count += 1
+                        else:
+                            item_epoch = _parse_item_time_epoch(
+                                item.get("detected_at") or item.get("created_at")
+                            )
+                            if item_epoch is None or item_epoch >= cutoff_epoch:
+                                continue
+                            fid = item.get("finding_id")
+                            det = item.get("detected_at")
+                            if fid is None or det is None:
+                                continue
+                            batch.delete_item(Key={"finding_id": fid, "detected_at": det})
+                            deleted_count += 1
+
+                lek = response.get("LastEvaluatedKey")
+                if not lek:
+                    break
+                scan_kwargs["ExclusiveStartKey"] = lek
+
+            logger.info("Deleted %s old records from %s", deleted_count, table_name)
+            return deleted_count
+
+        except ClientError as e:
+            logger.error("DynamoDB error deleting old records from %s: %s", table_name, str(e))
+            raise
 

--- a/backend/services/dynamodb_service.py
+++ b/backend/services/dynamodb_service.py
@@ -275,13 +275,31 @@ class DynamoDBService:
         """Delete records older than ``days`` using a paginated table scan.
 
         Uses the correct primary key for scan results vs IAM findings tables.
+        Server-side ``FilterExpression`` reduces scanned volume; items are still
+        validated client-side before delete. The scan runs only when
+        ``BACKFILL_DELETE_ENABLED`` is truthy (off by default to avoid accidental
+        full-table scans in production).
         """
         if days <= 0:
             raise ValueError("days must be positive")
+        if os.environ.get("BACKFILL_DELETE_ENABLED", "").lower() not in (
+            "1",
+            "true",
+            "yes",
+        ):
+            logger.info(
+                "delete_old_records skipped for %s: set BACKFILL_DELETE_ENABLED to "
+                "enable legacy age-based deletes (see docs/data-retention-policy.md)",
+                table_name,
+            )
+            return 0
         cutoff_dt = datetime.now(timezone.utc).replace(
             hour=0, minute=0, second=0, microsecond=0
         ) - timedelta(days=days)
         cutoff_epoch = cutoff_dt.timestamp()
+        cutoff_iso = (
+            cutoff_dt.astimezone(timezone.utc).replace(tzinfo=None).isoformat()
+        )
 
         table = self.dynamodb.Table(table_name)
         is_scan = table_name == self.scan_results_table
@@ -290,7 +308,17 @@ class DynamoDBService:
             logger.warning("delete_old_records: unsupported table name %s", table_name)
             return 0
         deleted_count = 0
-        scan_kwargs: Dict[str, Any] = {}
+        if is_scan:
+            scan_kwargs: Dict[str, Any] = {
+                "FilterExpression": "#ts < :cutoff",
+                "ExpressionAttributeNames": {"#ts": "timestamp"},
+                "ExpressionAttributeValues": {":cutoff": cutoff_iso},
+            }
+        else:
+            scan_kwargs = {
+                "FilterExpression": "(detected_at < :cutoff) OR (created_at < :cutoff)",
+                "ExpressionAttributeValues": {":cutoff": cutoff_iso},
+            }
 
         try:
             while True:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,9 @@ services:
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
       - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_ALERTING_MAX_ANNOTATIONS_TO_KEEP=1000
+      - GF_ANNOTATIONS_CLEANUPJOB_BATCHSIZE=100
+      - GF_SNAPSHOTS_EXTERNAL_ENABLED=false
     ports:
       - "3000:3000"
     volumes:
@@ -138,7 +141,7 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--web.console.libraries=/etc/prometheus/console_libraries'
       - '--web.console.templates=/etc/prometheus/consoles'
-      - '--storage.tsdb.retention.time=200h'
+      - '--storage.tsdb.retention.time=15d'
       - '--web.enable-lifecycle'
     networks:
       - cybersecurity-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,8 @@ services:
       - PASSWORD_RESET_TOKEN_SECRET=${PASSWORD_RESET_TOKEN_SECRET:-local-dev-reset-secret-do-not-use-in-prod}
       # Optional: comma-separated origins for Flask-CORS (defaults in app.py match infra allowed_urls)
       - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-}
+      # A17: enable DynamoDB age-based backfill deletes in dev (TTL still applies regardless)
+      - BACKFILL_DELETE_ENABLED=${BACKFILL_DELETE_ENABLED:-true}
     volumes:
       - ./logs:/app/logs
       - ./data:/app/data

--- a/docs/data-retention-policy.md
+++ b/docs/data-retention-policy.md
@@ -33,7 +33,7 @@ Exact Grafana behavior can vary by major version; validate in staging after upgr
 
 - **Tables:** Scan results (`scan_id` + `timestamp`) and IAM findings (`finding_id` + `detected_at`, with GSI `resource-index` on `resource_type` + `detected_at`) as defined in Terraform and `backend/services/dynamodb_service.py`.
 - **TTL:** Attribute name **`expires_at`** (Number, Unix seconds). Terraform enables TTL on both tables. New writes set `expires_at` to **now + 90 days** so AWS can expire items automatically.
-- **Application cleanup:** `DynamoDBService.delete_old_records()` performs paginated scans and deletes items older than the configured day threshold using the correct primary key per table (complements TTL for legacy items without `expires_at`).
+- **Application cleanup:** `DynamoDBService.delete_old_records()` performs paginated scans (with a DynamoDB `FilterExpression` on sort keys) and deletes items older than the configured day threshold using the correct primary key per table (complements TTL for legacy items without `expires_at`). This path is **opt-in**: set environment variable **`BACKFILL_DELETE_ENABLED=true`** (or `1`/`yes`) before the job will run table scans and deletes; leave it unset in environments where you rely on TTL only.
 
 ## PostgreSQL (`security_findings`, `performance_metrics`)
 
@@ -42,8 +42,12 @@ Exact Grafana behavior can vary by major version; validate in staging after upgr
 
 ## Scheduled job & HTTP trigger
 
-- **Background:** When `RETENTION_SCHEDULER_ENABLED` is `true` (default), a daemon thread runs the full retention pass once per `RETENTION_SCHEDULER_INTERVAL_SEC` (default **86400** = 24h), after an initial **60s** startup delay.
+- **Background:** When `RETENTION_SCHEDULER_ENABLED` is `true` (default), a daemon thread runs the full retention pass once per `RETENTION_SCHEDULER_INTERVAL_SEC` (default **86400** = 24h), after an initial **60s** startup delay. When `REDIS_URL` is set, **`RETENTION_SCHEDULER_REDIS_LOCK`** (default `true`) acquires a Redis lock around each pass so only one WSGI worker runs retention at a time; set `RETENTION_SCHEDULER_REDIS_LOCK=false` only if you accept overlapping runs or use a single-worker deployment.
 - **HTTP (optional):** `POST /api/v1/system/retention` with header `X-Retention-Run-Key` equal to `RETENTION_RUN_KEY` runs the same pass on demand. If `RETENTION_RUN_KEY` is unset, the endpoint returns **503** (disabled).
+
+**Operational safety (`POST /api/v1/system/retention`):** Treat this route as **internal-only** — do not expose it on a public ingress; front it with network controls (VPC, security groups, private API Gateway, or admin-only paths). Use a **high-entropy** `RETENTION_RUN_KEY`, **rotate** it on a schedule, and **store it in a secrets manager** (not in git or plain env files in prod). **Audit every invocation** (caller identity, timestamp, and response payload or outcome) so destructive runs are traceable.
+
+`(As of April 2026 / PR #390)`
 
 ## Current state vs. recommended
 

--- a/docs/data-retention-policy.md
+++ b/docs/data-retention-policy.md
@@ -1,0 +1,67 @@
+# Data retention policy (A17)
+
+This document defines how long different classes of IAM Dashboard data are kept, how enforcement works in each system, and how the recommended settings compare to what ships in the repo today.
+
+## Retention periods (recommended)
+
+| Data class | Recommended retention | Rationale |
+|------------|----------------------|-----------|
+| **Prometheus metrics** | **15 days** | TSDB size and query performance; long enough for incident review and short-term trends without unbounded disk growth. |
+| **Grafana annotations / snapshots** | **30 days** (annotations policy); snapshots limited | Annotations support incident timelines; bounded cleanup avoids unbounded DB growth. External snapshots disabled to reduce leak surface. |
+| **DynamoDB — scan results & IAM findings** | **90 days** | **TTL** on `expires_at` (Unix epoch seconds): AWS removes items after that time without application-driven deletes. Aligns with typical compliance “review quarterly” cycles. |
+| **PostgreSQL — `security_findings` & `performance_metrics`** | **90 days** | Row-level deletes for rows older than 90 days by `created_at` / `timestamp` keeps the app DB bounded; run via the same scheduled retention job as DynamoDB cleanup. |
+
+Operational note: **TTL** deletes are **eventually consistent** (typically within 48 hours of expiry). The application also runs **explicit deletes** for scan/findings tables during the scheduled job so behavior is predictable even before TTL backfill on legacy rows.
+
+## Prometheus (metrics)
+
+- **Role:** Time-series storage for scraped targets (e.g. app metrics, Grafana, Postgres exporter targets as configured).
+- **Configuration:** Retention is controlled by the Prometheus process flag `--storage.tsdb.retention.time` (not `prometheus.yml`). Scrape rules live in `config/prometheus/prometheus.yml`.
+- **Recommended:** `15d` for `--storage.tsdb.retention.time`.
+
+## Grafana (dashboards, annotations, snapshots)
+
+- **Role:** Dashboards and provisioning live under `config/grafana/provisioning/`; Docker mounts `grafana_data` for state.
+- **Recommended environment variables:**
+  - `GF_ALERTING_MAX_ANNOTATIONS_TO_KEEP=1000` — cap stored annotations.
+  - `GF_ANNOTATIONS_CLEANUPJOB_BATCHSIZE=100` — batch size for annotation cleanup.
+  - `GF_SNAPSHOTS_EXTERNAL_ENABLED=false` — disable external snapshot uploads by default.
+
+Exact Grafana behavior can vary by major version; validate in staging after upgrades.
+
+## DynamoDB (findings + scan results)
+
+- **Tables:** Scan results (`scan_id` + `timestamp`) and IAM findings (`finding_id` + `detected_at`, with GSI `resource-index` on `resource_type` + `detected_at`) as defined in Terraform and `backend/services/dynamodb_service.py`.
+- **TTL:** Attribute name **`expires_at`** (Number, Unix seconds). Terraform enables TTL on both tables. New writes set `expires_at` to **now + 90 days** so AWS can expire items automatically.
+- **Application cleanup:** `DynamoDBService.delete_old_records()` performs paginated scans and deletes items older than the configured day threshold using the correct primary key per table (complements TTL for legacy items without `expires_at`).
+
+## PostgreSQL (`security_findings`, `performance_metrics`)
+
+- **Retention column:** `security_findings.created_at`, `performance_metrics.timestamp`.
+- **Cleanup:** `DatabaseService.cleanup_old_records(days=90)` deletes rows strictly older than the cutoff. Invoked from the same retention job as DynamoDB.
+
+## Scheduled job & HTTP trigger
+
+- **Background:** When `RETENTION_SCHEDULER_ENABLED` is `true` (default), a daemon thread runs the full retention pass once per `RETENTION_SCHEDULER_INTERVAL_SEC` (default **86400** = 24h), after an initial **60s** startup delay.
+- **HTTP (optional):** `POST /api/v1/system/retention` with header `X-Retention-Run-Key` equal to `RETENTION_RUN_KEY` runs the same pass on demand. If `RETENTION_RUN_KEY` is unset, the endpoint returns **503** (disabled).
+
+## Current state vs. recommended
+
+| Area | Previous / shipped state | Recommended / implemented |
+|------|---------------------------|---------------------------|
+| Prometheus TSDB retention | `200h` (~8.3d) in `docker-compose.yml` | **15d** via `--storage.tsdb.retention.time=15d` |
+| Grafana annotation / snapshot controls | Only admin password / sign-up flags | Add **annotation caps**, **cleanup batch size**, **disable external snapshots** |
+| DynamoDB scan results | Table in Terraform; **no TTL** | **TTL on `expires_at`**; writes set `expires_at` |
+| DynamoDB IAM findings | Used by app; **not** in Terraform on older branches | **New table in Terraform** with GSI + **TTL**; writes set `expires_at` |
+| `delete_old_records` | Single-page scan; **wrong keys** for findings; **no caller** | **Paginated scan**; correct keys per table; invoked from **scheduler + optional POST** |
+| PostgreSQL aged rows | No automated delete | **`cleanup_old_records(90)`** for findings + metrics |
+
+## References (code & config)
+
+- `docker-compose.yml` — Prometheus flags, Grafana env.
+- `config/prometheus/prometheus.yml` — scrape configuration.
+- `config/grafana/provisioning/` — datasources and dashboard provisioning.
+- `infra/dynamodb/main.tf` — DynamoDB tables and TTL.
+- `backend/services/dynamodb_service.py` — `expires_at` on writes, `delete_old_records`.
+- `backend/services/database_service.py` — `cleanup_old_records`.
+- `backend/api/retention.py` — HTTP trigger; `backend/app.py` — route registration and scheduler startup.

--- a/infra/IAM/main.tf
+++ b/infra/IAM/main.tf
@@ -81,7 +81,7 @@ resource "aws_iam_role_policy" "scan_policy" {
         Effect = "Allow"
         Action = [
           "securityhub:GetFindings", "securityhub:GetInsights",
-          , "securityhub:GetComplianceSummary"
+          "securityhub:GetComplianceSummary"
         ]
         Resource = "*"
       },

--- a/infra/dynamodb/main.tf
+++ b/infra/dynamodb/main.tf
@@ -64,6 +64,11 @@ resource "aws_dynamodb_table" "scan_results" {
   # Enable deletion protection in production
   deletion_protection_enabled = var.environment == "prod"
 
+  ttl {
+    attribute_name = "expires_at"
+    enabled        = true
+  }
+
   tags = {
     Name        = var.dynamodb_table_name
     Project     = var.project_name
@@ -105,5 +110,63 @@ resource "aws_dynamodb_table" "accounts" {
     ManagedBy = "terraform"
     Service   = "account-management"
     Purpose   = "multi-account-registry"
+  }
+}
+
+# Terraform import/state migration notes:
+# - If this table already exists, import it into state before applying:
+#     terraform -chdir=infra/dynamodb import aws_dynamodb_table.iam_findings <EXISTING_TABLE_NAME>
+# - After import, run plan/apply to ensure TTL, tags, and encryption match this config.
+# DynamoDB table for IAM findings (TTL aligns with data retention policy)
+resource "aws_dynamodb_table" "iam_findings" {
+  name         = var.iam_findings_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "finding_id"
+  range_key    = "detected_at"
+
+  attribute {
+    name = "finding_id"
+    type = "S"
+  }
+
+  attribute {
+    name = "detected_at"
+    type = "S"
+  }
+
+  attribute {
+    name = "resource_type"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "resource-index"
+    hash_key        = "resource_type"
+    range_key       = "detected_at"
+    projection_type = "ALL"
+  }
+
+  point_in_time_recovery {
+    enabled = var.enable_point_in_time_recovery
+  }
+
+  server_side_encryption {
+    enabled     = true
+    kms_key_arn = var.dynamodb_kms_key_arn
+  }
+
+  deletion_protection_enabled = var.environment == "prod"
+
+  ttl {
+    attribute_name = "expires_at"
+    enabled        = true
+  }
+
+  tags = {
+    Name        = var.iam_findings_table_name
+    Project     = var.project_name
+    Env         = var.environment
+    ManagedBy   = "terraform"
+    Description = "Stores IAM security findings; TTL on expires_at for automatic expiration"
   }
 }

--- a/infra/dynamodb/outputs.tf
+++ b/infra/dynamodb/outputs.tf
@@ -27,3 +27,12 @@ output "accounts_table_arn" {
   value       = aws_dynamodb_table.accounts.arn
 }
 
+output "iam_findings_table_name" {
+  description = "Name of the IAM findings DynamoDB table"
+  value       = aws_dynamodb_table.iam_findings.name
+}
+
+output "iam_findings_table_arn" {
+  description = "ARN of the IAM findings DynamoDB table"
+  value       = aws_dynamodb_table.iam_findings.arn
+}

--- a/infra/dynamodb/variables.tf
+++ b/infra/dynamodb/variables.tf
@@ -22,6 +22,12 @@ variable "dynamodb_table_name" {
   default     = "iam-dashboard-scan-results"
 }
 
+variable "iam_findings_table_name" {
+  description = "Name of the DynamoDB table for IAM security findings"
+  type        = string
+  default     = "iam-dashboard-iam-findings"
+}
+
 variable "enable_scanner_type_index" {
   description = "Enable Global Secondary Index for scanner_type-based queries"
   type        = bool


### PR DESCRIPTION
**Implements A17** — defines and documents data retention policies for Prometheus, Grafana, DynamoDB, and PostgreSQL, and implements cleanup where it was missing.

> Replaces PR #365 — reopened for a clean, single-commit history after rebasing against latest `main`.

**## Documentation**
- Created `docs/data-retention-policy.md` with recommended retention periods, current state vs. recommended gap analysis, and operational notes for each system

**## Prometheus**
- Updated `docker-compose.yml`: changed retention from `200h` (~8.3 days) to `15d`

**## Grafana**
- Added annotation and snapshot retention env vars to `docker-compose.yml`:
  - `GF_ALERTING_MAX_ANNOTATIONS_TO_KEEP=1000`
  - `GF_ANNOTATIONS_CLEANUPJOB_BATCHSIZE=100`
  - `GF_SNAPSHOTS_EXTERNAL_ENABLED=false`

**## DynamoDB**
- Added TTL block (`expires_at`, 90 days) to `scan_results` table in Terraform
- Added new `iam_findings` Terraform resource with TTL enabled
- Fixed `delete_old_records()` to use paginated scans with `LastEvaluatedKey`
- New items written with `expires_at` epoch automatically set at creation

**## PostgreSQL**
- Added `cleanup_old_records(days=90)` to `database_service.py` for `security_findings` and `performance_metric

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated data retention now removes outdated records after 90 days by default.
  * Manual retention trigger endpoint available for on-demand cleanup operations.
  * Background scheduler runs daily to continuously manage data retention.

* **Configuration**
  * Storage optimization settings configured for monitoring and analytics services.

* **Documentation**
  * Data retention policy documentation added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->