### PR TITLE
Claude bedorck updated AI Agents working locally.

### DIFF
--- a/backend/api/ir.py
+++ b/backend/api/ir.py
@@ -27,6 +27,7 @@ Architecture notes:
 
 import json
 import logging
+import re
 import uuid
 import time
 import os
@@ -58,7 +59,7 @@ def _get_bedrock_client():
     # Without an API key, boto3 discovers credentials normally (env vars, IAM role, etc.)
     return boto3.client("bedrock-runtime", region_name=region)
 
-MODEL_ID = os.environ.get("BEDROCK_MODEL_ID", "anthropic.claude-haiku-4-5-20251001")
+MODEL_ID = os.environ.get("BEDROCK_MODEL_ID", "anthropic.claude-3-haiku-20240307-v1:0")
 
 # ─── Runbook structured-output constants ──────────────────────────────────────
 
@@ -223,6 +224,35 @@ def _mock_execute_job(job_id: str) -> None:
     job["_mock_complete_at"] = time.time() + 3
 
 
+# ─── LLM prose extractors ─────────────────────────────────────────────────────
+
+_CONFIDENCE_RE = re.compile(
+    r"confidence[^0-9]*([0-1](?:\.\d+)?|\.\d+)",
+    re.IGNORECASE,
+)
+_MITRE_RE = re.compile(r"\bT\d{4}(?:\.\d{3})?\b")
+
+
+def _extract_confidence(text: str) -> float | None:
+    """Parse first confidence score (0–1) from Claude's prose."""
+    m = _CONFIDENCE_RE.search(text)
+    if not m:
+        return None
+    try:
+        val = float(m.group(1))
+        return round(max(0.0, min(1.0, val)), 4)
+    except ValueError:
+        return None
+
+
+def _extract_mitre(text: str) -> list[str]:
+    """Extract unique MITRE ATT&CK technique IDs (e.g. T1078) from prose."""
+    seen: dict[str, None] = {}
+    for t in _MITRE_RE.findall(text):
+        seen[t] = None
+    return list(seen.keys())
+
+
 # ─── LLM endpoints ────────────────────────────────────────────────────────────
 
 class LLMTriageResource(Resource):
@@ -264,13 +294,15 @@ class LLMTriageResource(Resource):
         job = _job_store[job_id]
         job["status"] = "succeeded"
         job["completed_at"] = _now_iso()
-        # When Bedrock returns real prose, omit mock confidence/MITRE fields — mixing
-        # fabricated metadata with real LLM text misleads the operator.
         if llm_response:
-            job["result"] = {
-                "triage_summary": llm_response,
-                "model": MODEL_ID,
-            }
+            result: dict = {"triage_summary": llm_response, "model": MODEL_ID}
+            conf = _extract_confidence(llm_response)
+            if conf is not None:
+                result["confidence_score"] = conf
+            mitre = _extract_mitre(llm_response)
+            if mitre:
+                result["mitre_techniques"] = mitre
+            job["result"] = result
         else:
             job["result"] = {**mock, "model": "mock"}
 
@@ -322,12 +354,12 @@ class LLMRootCauseResource(Resource):
         job = _job_store[job_id]
         job["status"] = "succeeded"
         job["completed_at"] = _now_iso()
-        # Same rule as triage: omit mock MITRE techniques when Bedrock returns real prose.
         if llm_response:
-            job["result"] = {
-                "root_cause_narrative": llm_response,
-                "model": MODEL_ID,
-            }
+            rc_result: dict = {"root_cause_narrative": llm_response, "model": MODEL_ID}
+            mitre = _extract_mitre(llm_response)
+            if mitre:
+                rc_result["mitre_techniques"] = mitre
+            job["result"] = rc_result
         else:
             job["result"] = {**mock, "model": "mock"}
 

--- a/backend/api/ir.py
+++ b/backend/api/ir.py
@@ -59,7 +59,9 @@ def _get_bedrock_client():
     # Without an API key, boto3 discovers credentials normally (env vars, IAM role, etc.)
     return boto3.client("bedrock-runtime", region_name=region)
 
-MODEL_ID = os.environ.get("BEDROCK_MODEL_ID", "anthropic.claude-3-haiku-20240307-v1:0")
+_DEFAULT_MODEL_ID = "anthropic.claude-3-haiku-20240307-v1:0"
+# Treat empty/whitespace env var as unset so invoke_model() never receives "".
+MODEL_ID = (os.environ.get("BEDROCK_MODEL_ID") or "").strip() or _DEFAULT_MODEL_ID
 
 # ─── Runbook structured-output constants ──────────────────────────────────────
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,9 +45,12 @@ services:
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-${AWS_REGION:-us-east-1}}
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      # Required when using temporary STS/SSO credentials (assumed role sessions)
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}
       # Required for /api/v1/llm/* and /api/v1/voice/intent in Docker — set in host .env (never commit)
       - BEDROCK_API_KEY=${BEDROCK_API_KEY:-}
-      - BEDROCK_MODEL_ID=${BEDROCK_MODEL_ID:-anthropic.claude-haiku-4-5}
+      # Must be provided via host .env/env.example (contains ':' which breaks some compose defaults)
+      - BEDROCK_MODEL_ID=${BEDROCK_MODEL_ID}
       - SMTP_HOST=${SMTP_HOST:-mailhog}
       - SMTP_PORT=${SMTP_PORT:-1025}
       - SMTP_USERNAME=${SMTP_USERNAME:-}

--- a/docs/AI-Team_Documentation/Voice-Incident-Response-Agent.md
+++ b/docs/AI-Team_Documentation/Voice-Incident-Response-Agent.md
@@ -387,7 +387,7 @@ So: **Gateway = how traffic enters AWS**; **which environment** depends on **whi
 ### ✅ Phase 2 — AWS Setup (COMPLETE)
 - [x] Bedrock API key generated from AWS Console → Bedrock → API keys
 - [x] `BEDROCK_API_KEY` added to `.env`
-- [x] `BEDROCK_MODEL_ID=anthropic.claude-haiku-4-5` added to `.env` (Claude 4.5 Haiku — near-frontier performance at Haiku pricing, available on Bedrock since Oct 2025)
+- [x] `BEDROCK_MODEL_ID=anthropic.claude-3-haiku-20240307-v1:0` added to `.env`
 - [x] `AWS_DEFAULT_REGION=us-east-1` confirmed in `.env`
 - [x] `AmazonBedrockFullAccess`, `AmazonTranscribeFullAccess`, `AmazonPollyFullAccess` attached to IAM user
 - [x] Credential strategy decided: long-term Bedrock API key in `.env` for local Docker dev, IAM role for production Lambda
@@ -403,7 +403,7 @@ So: **Gateway = how traffic enters AWS**; **which environment** depends on **whi
 - [x] `/api/v1/llm/triage` — now calls Claude with finding context, returns real triage summary
 - [x] `/api/v1/llm/root-cause` — now calls Claude for root cause narrative
 - [x] `/api/v1/llm/runbook` — now calls Claude for markdown IR runbook with IDENTIFY/CONTAIN/ERADICATE/RECOVER phases
-- [x] Live/mock toggle — `model: "anthropic.claude-haiku-4-5"` in response = live, `model: "mock"` = fallback
+- [x] Live/mock toggle — `model: "anthropic.claude-3-haiku-20240307-v1:0"` in response = live, `model: "mock"` = fallback
 - [x] `VITE_IR_API_BASE=http://localhost:3001/api/v1` added to `.env`
 - [x] `VITE_FLASK_PROXY_TARGET=http://app:5000` added to `.env` — fixes Vite proxy forwarding to Flask in Docker
 - [x] `VITE_LLM_MAX_CONCURRENT=2` added to `.env` — prevents Bedrock flooding across concurrent finding rows

--- a/env.example
+++ b/env.example
@@ -18,7 +18,7 @@ AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
 
 # Amazon Bedrock (LLM + voice intent fallback) — required in Docker for live Claude; omit for mock-only
 # BEDROCK_API_KEY=your-bedrock-api-key
-# BEDROCK_MODEL_ID=anthropic.claude-haiku-4-5
+# BEDROCK_MODEL_ID=anthropic.claude-3-haiku-20240307-v1:0
 
 # SMTP Configuration (local test defaults)
 SMTP_HOST=mailhog

--- a/src/components/ir/IRActionEngine.tsx
+++ b/src/components/ir/IRActionEngine.tsx
@@ -52,6 +52,7 @@ import {
   logAuditEntry,
 } from "../../services/irEngine";
 import type { FindingData } from "../ui/FindingDetailPanel";
+import { AiAnalysisText, TRIAGE_LABELS, ROOT_CAUSE_LABELS } from "../ui/AiResponseRenderer";
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -341,87 +342,85 @@ function LLMResult({ result, type }: { result: IRActionResult; type: IRActionTyp
 
   if (type === "llm_triage" && result.triage_summary) {
     return (
-      <div style={{ marginTop: 10, display: "flex", flexDirection: "column", gap: 8 }}>
-        <p style={{ fontSize: 11, color: "#e2e8f0", lineHeight: 1.7, margin: 0 }}>
-          {result.triage_summary}
-        </p>
-        <div style={{ display: "flex", gap: 6 }}>
-          {result.mitre_techniques?.map((t) => (
-            <span
-              key={t}
-              style={{
-                ...mono,
-                padding: "2px 8px",
-                borderRadius: 4,
-                background: "rgba(129,140,248,0.1)",
-                border: "1px solid rgba(129,140,248,0.22)",
-                fontSize: 10,
-                color: "#818cf8",
-                fontWeight: 700,
-              }}
-            >
-              {t}
-            </span>
-          ))}
-          {result.false_positive_probability !== undefined && (
-            <span
-              style={{
-                ...mono,
-                marginLeft: "auto",
-                fontSize: 10,
-                color:
-                  result.false_positive_probability < 0.1
-                    ? "#00ff88"
-                    : result.false_positive_probability < 0.4
-                    ? "#ffb000"
-                    : "#ff6b35",
-              }}
-            >
-              FP: {(result.false_positive_probability * 100).toFixed(0)}%
-            </span>
-          )}
-        </div>
+      <div style={{ marginTop: 10, display: "flex", flexDirection: "column", gap: 10 }}>
+        <AiAnalysisText
+          text={result.triage_summary}
+          sectionLabels={TRIAGE_LABELS}
+          baseColor="#818cf8"
+          compact
+        />
+        {(result.mitre_techniques?.length || result.false_positive_probability !== undefined) && (
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+            {result.mitre_techniques?.map((t) => (
+              <span
+                key={t}
+                style={{
+                  ...mono,
+                  padding: "2px 8px",
+                  borderRadius: 4,
+                  background: "rgba(129,140,248,0.1)",
+                  border: "1px solid rgba(129,140,248,0.22)",
+                  fontSize: 10,
+                  color: "#818cf8",
+                  fontWeight: 700,
+                }}
+              >
+                {t}
+              </span>
+            ))}
+            {result.false_positive_probability !== undefined && (
+              <span
+                style={{
+                  ...mono,
+                  marginLeft: "auto",
+                  fontSize: 10,
+                  color:
+                    result.false_positive_probability < 0.1
+                      ? "#00ff88"
+                      : result.false_positive_probability < 0.4
+                      ? "#ffb000"
+                      : "#ff6b35",
+                }}
+              >
+                FP: {(result.false_positive_probability * 100).toFixed(0)}%
+              </span>
+            )}
+          </div>
+        )}
       </div>
     );
   }
 
   if (type === "llm_root_cause" && result.root_cause_narrative) {
-    const lines = result.root_cause_narrative.split("\n\n");
     return (
-      <div style={{ marginTop: 10, display: "flex", flexDirection: "column", gap: 6 }}>
-        {lines.map((line, i) => (
-          <p
-            key={i}
-            style={{
-              fontSize: 11,
-              color: line.startsWith("**") ? "#e2e8f0" : "rgba(148,163,184,0.85)",
-              lineHeight: 1.7,
-              margin: 0,
-            }}
-            dangerouslySetInnerHTML={{
-              __html: line.replace(/\*\*(.*?)\*\*/g, "<strong style='color:#e2e8f0'>$1</strong>"),
-            }}
-          />
-        ))}
-        <div style={{ display: "flex", gap: 6 }}>
-          {result.mitre_techniques?.map((t) => (
-            <span
-              key={t}
-              style={{
-                ...mono,
-                padding: "2px 8px",
-                borderRadius: 4,
-                background: "rgba(129,140,248,0.1)",
-                border: "1px solid rgba(129,140,248,0.22)",
-                fontSize: 10,
-                color: "#818cf8",
-                fontWeight: 700,
-              }}
-            >
-              {t}
-            </span>
-          ))}
-        </div>
+      <div style={{ marginTop: 10, display: "flex", flexDirection: "column", gap: 10 }}>
+        <AiAnalysisText
+          text={result.root_cause_narrative}
+          sectionLabels={ROOT_CAUSE_LABELS}
+          baseColor="#34d399"
+          compact
+        />
+        {result.mitre_techniques && result.mitre_techniques.length > 0 && (
+          <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+            {result.mitre_techniques.map((t) => (
+              <span
+                key={t}
+                style={{
+                  ...mono,
+                  padding: "2px 8px",
+                  borderRadius: 4,
+                  background: "rgba(129,140,248,0.1)",
+                  border: "1px solid rgba(129,140,248,0.22)",
+                  fontSize: 10,
+                  color: "#818cf8",
+                  fontWeight: 700,
+                }}
+              >
+                {t}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
     );
   }

--- a/src/components/ir/VoiceIRAgent.tsx
+++ b/src/components/ir/VoiceIRAgent.tsx
@@ -24,6 +24,7 @@ import { useVoiceIntent } from "../../hooks/useVoiceIntent";
 import type { ConversationTurn, FindingContext } from "../../hooks/useVoiceIntent";
 import type { IRActionType, IRActionResult } from "../../types/ir";
 import { ACTION_META } from "../../types/ir";
+import { AiAnalysisText, TRIAGE_LABELS } from "../ui/AiResponseRenderer";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 type AgentStatus   = "standby" | "listening" | "processing" | "speaking" | "error";
@@ -45,6 +46,20 @@ interface TriageResult {
   confidence?: number;
   mitre?: string[];
   falsePositive?: number;
+}
+
+const _CONF_RE = /confidence[^0-9]*([0-1](?:\.\d+)?|\.\d+)/i;
+const _MITRE_RE = /\bT\d{4}(?:\.\d{3})?\b/g;
+
+function extractConfidence(text: string): number | undefined {
+  const m = _CONF_RE.exec(text);
+  if (!m) return undefined;
+  const v = parseFloat(m[1]);
+  return Number.isFinite(v) ? Math.max(0, Math.min(1, v)) : undefined;
+}
+
+function extractMitre(text: string): string[] {
+  return [...new Set(text.match(_MITRE_RE) ?? [])];
 }
 
 interface IRConfirmData {
@@ -554,8 +569,13 @@ function LLMTriageCard({ data, ts }: { data: TriageResult; ts: number }) {
       </div>
       {/* Summary */}
       <div style={{ padding: "8px 10px" }}>
-        <div style={{ fontSize: 7.5, color: "rgba(100,116,139,0.4)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.1em", marginBottom: 4 }}>ANALYSIS</div>
-        <div style={{ fontSize: 10.5, color: "#cbd5e1", lineHeight: 1.55 }}>{data.summary}</div>
+        <div style={{ fontSize: 7.5, color: "rgba(100,116,139,0.4)", fontFamily: "'JetBrains Mono', monospace", letterSpacing: "0.1em", marginBottom: 6 }}>ANALYSIS</div>
+        <AiAnalysisText
+          text={data.summary}
+          sectionLabels={TRIAGE_LABELS}
+          baseColor="#818cf8"
+          compact
+        />
         {data.falsePositive !== undefined && (
           <div style={{ marginTop: 6, fontSize: 9, color: "rgba(100,116,139,0.5)", fontFamily: "'JetBrains Mono', monospace" }}>
             False positive probability: <span style={{ color: "#a78bfa" }}>{Math.round(data.falsePositive * 100)}%</span>
@@ -847,10 +867,11 @@ export function VoiceIRAgent({ onNavigate }: VoiceIRAgentProps) {
       });
 
       if (result?.triage_summary) {
+        const text = result.triage_summary;
         const triageData: TriageResult = {
-          summary:      result.triage_summary,
-          confidence:   result.confidence_score,
-          mitre:        result.mitre_techniques,
+          summary:      text,
+          confidence:   result.confidence_score   ?? extractConfidence(text),
+          mitre:        (result.mitre_techniques?.length ? result.mitre_techniques : null) ?? extractMitre(text),
           falsePositive: result.false_positive_probability,
         };
         setMessages(p => p.map(m =>

--- a/src/components/ui/AiResponseRenderer.tsx
+++ b/src/components/ui/AiResponseRenderer.tsx
@@ -1,0 +1,278 @@
+/**
+ * AiResponseRenderer — shared structured renderer for LLM prose responses.
+ *
+ * Parses numbered sections (1) ... 2) ...) from Claude's output and renders
+ * each as a distinct visual block with accent border, badge, and label.
+ * Handles inline markdown: **bold**, `code`, and bullet lists.
+ *
+ * Used by: FindingDetailPanel, IRActionEngine, VoiceIRAgent (LLMTriageCard).
+ */
+
+import React from "react";
+
+export const AI_SECTION_COLORS = ["#818cf8", "#34d399", "#fb923c", "#facc15"] as const;
+
+export const TRIAGE_LABELS: Record<number, string> = {
+  1: "Assessment",
+  2: "Confidence",
+  3: "MITRE ATT&CK",
+  4: "Recommended Actions",
+};
+
+export const ROOT_CAUSE_LABELS: Record<number, string> = {
+  1: "Root Cause",
+  2: "Attack Chain",
+  3: "MITRE Mapping",
+  4: "Contributing Factors",
+};
+
+// ─── Parser ───────────────────────────────────────────────────────────────────
+
+export function parseAiSections(
+  text: string
+): Array<{ num: number; heading: string | null; body: string }> {
+  const starts: Array<{ num: number; start: number; textStart: number }> = [];
+  const re = /(?:^|\n)[ \t]*(\d+)[).:][ \t]*/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    starts.push({
+      num: parseInt(m[1], 10),
+      start: m.index === 0 ? 0 : m.index,
+      textStart: m.index + m[0].length,
+    });
+  }
+  if (starts.length < 2) return [];
+  return starts.map((s, i) => {
+    const raw = text.slice(s.textStart, starts[i + 1]?.start ?? text.length).trim();
+    const boldHeading = raw.match(/^\*\*([^*]+)\*\*[:\s]*/);
+    const colonHeading = !boldHeading && raw.match(/^([A-Za-z][^:\n]{3,40}):\s*/);
+    const heading = boldHeading ? boldHeading[1] : colonHeading ? colonHeading[1] : null;
+    const body = boldHeading
+      ? raw.slice(boldHeading[0].length).trim()
+      : colonHeading
+      ? raw.slice(colonHeading[0].length).trim()
+      : raw;
+    return { num: s.num, heading, body };
+  });
+}
+
+// ─── Inline markdown ──────────────────────────────────────────────────────────
+
+export function renderInlineMd(text: string): React.ReactNode[] {
+  const nodes: React.ReactNode[] = [];
+  const re = /(\*\*(.+?)\*\*|`([^`]+)`)/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    if (m.index > last) nodes.push(text.slice(last, m.index));
+    if (m[2] !== undefined) {
+      nodes.push(
+        <strong key={m.index} style={{ color: "#f1f5f9", fontWeight: 700 }}>
+          {m[2]}
+        </strong>
+      );
+    } else if (m[3] !== undefined) {
+      nodes.push(
+        <code
+          key={m.index}
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: "0.9em",
+            background: "rgba(129,140,248,0.12)",
+            border: "1px solid rgba(129,140,248,0.2)",
+            borderRadius: 3,
+            padding: "1px 5px",
+            color: "#a5b4fc",
+          }}
+        >
+          {m[3]}
+        </code>
+      );
+    }
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) nodes.push(text.slice(last));
+  return nodes;
+}
+
+// ─── Body renderer ────────────────────────────────────────────────────────────
+
+function renderAiBody(body: string, accent: string, compact: boolean): React.ReactNode {
+  const fontSize = compact ? 10.5 : 12;
+  const lines = body.split("\n");
+  const elements: React.ReactNode[] = [];
+  let bulletGroup: string[] = [];
+
+  const flushBullets = (key: string) => {
+    if (bulletGroup.length === 0) return;
+    elements.push(
+      <ul key={`ul-${key}`} style={{ margin: "3px 0 0 0", padding: 0, listStyle: "none" }}>
+        {bulletGroup.map((b, bi) => (
+          <li
+            key={bi}
+            style={{
+              display: "flex",
+              gap: 6,
+              marginBottom: compact ? 2 : 3,
+              fontSize,
+              lineHeight: 1.55,
+              color: "rgba(203,213,225,0.85)",
+            }}
+          >
+            <span
+              style={{
+                color: accent,
+                flexShrink: 0,
+                marginTop: 1,
+                fontFamily: "'JetBrains Mono', monospace",
+                fontSize: compact ? 9 : 10,
+              }}
+            >
+              ›
+            </span>
+            <span>{renderInlineMd(b)}</span>
+          </li>
+        ))}
+      </ul>
+    );
+    bulletGroup = [];
+  };
+
+  lines.forEach((line, i) => {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      flushBullets(String(i));
+      return;
+    }
+    if (/^[-•*]\s+/.test(trimmed)) {
+      bulletGroup.push(trimmed.replace(/^[-•*]\s+/, ""));
+    } else {
+      flushBullets(String(i));
+      elements.push(
+        <p
+          key={i}
+          style={{
+            margin: "0 0 3px 0",
+            fontSize,
+            lineHeight: compact ? 1.55 : 1.65,
+            color: "rgba(203,213,225,0.85)",
+          }}
+        >
+          {renderInlineMd(trimmed)}
+        </p>
+      );
+    }
+  });
+  flushBullets("end");
+  return <>{elements}</>;
+}
+
+// ─── Section block ────────────────────────────────────────────────────────────
+
+function AiSectionBlock({
+  num,
+  heading,
+  body,
+  fallbackLabel,
+  accent,
+  compact,
+}: {
+  num: number;
+  heading: string | null;
+  body: string;
+  fallbackLabel: string;
+  accent: string;
+  compact: boolean;
+}) {
+  const label = heading ?? fallbackLabel;
+  return (
+    <div
+      style={{
+        borderLeft: `2px solid ${accent}40`,
+        paddingLeft: compact ? 8 : 10,
+        paddingTop: 1,
+        paddingBottom: 1,
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: 5, marginBottom: compact ? 3 : 5 }}>
+        <span
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: compact ? 8 : 9,
+            fontWeight: 700,
+            letterSpacing: "0.06em",
+            color: accent,
+            background: `${accent}18`,
+            border: `1px solid ${accent}30`,
+            borderRadius: 3,
+            padding: compact ? "0 4px" : "1px 5px",
+            lineHeight: 1.5,
+            flexShrink: 0,
+          }}
+        >
+          {String(num).padStart(2, "0")}
+        </span>
+        <span
+          style={{
+            fontFamily: "'JetBrains Mono', monospace",
+            fontSize: compact ? 8.5 : 10,
+            fontWeight: 700,
+            letterSpacing: "0.07em",
+            textTransform: "uppercase" as const,
+            color: `${accent}cc`,
+          }}
+        >
+          {label}
+        </span>
+      </div>
+      <div style={{ paddingLeft: 2 }}>{renderAiBody(body, accent, compact)}</div>
+    </div>
+  );
+}
+
+// ─── Public component ─────────────────────────────────────────────────────────
+
+export function AiAnalysisText({
+  text,
+  sectionLabels,
+  baseColor = "#818cf8",
+  compact = false,
+}: {
+  text: string;
+  sectionLabels: Record<number, string>;
+  baseColor?: string;
+  compact?: boolean;
+}) {
+  const sections = parseAiSections(text);
+
+  if (sections.length === 0) {
+    return (
+      <p
+        style={{
+          fontSize: compact ? 10.5 : 12,
+          color: "rgba(203,213,225,0.8)",
+          lineHeight: compact ? 1.55 : 1.7,
+          margin: 0,
+        }}
+      >
+        {renderInlineMd(text)}
+      </p>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: compact ? 7 : 10 }}>
+      {sections.map((s) => (
+        <AiSectionBlock
+          key={s.num}
+          num={s.num}
+          heading={s.heading}
+          body={s.body}
+          fallbackLabel={sectionLabels[s.num] ?? `Section ${s.num}`}
+          accent={AI_SECTION_COLORS[(s.num - 1) % AI_SECTION_COLORS.length]}
+          compact={compact}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/FindingDetailPanel.tsx
+++ b/src/components/ui/FindingDetailPanel.tsx
@@ -45,6 +45,7 @@ import { fetchLLMActionResult } from "../../services/irEngine";
 import { SeverityBadge } from "./SeverityBadge";
 import { IRActionEngine } from "../ir/IRActionEngine";
 import { EvidenceForensicsPanel } from "../ir/EvidenceForensicsPanel";
+import { AiAnalysisText, TRIAGE_LABELS, ROOT_CAUSE_LABELS } from "./AiResponseRenderer";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // PUBLIC TYPES  (import from here in each scanner tab)
@@ -1045,20 +1046,24 @@ export function FindingDetailPanel({
                     {/* Triage Assessment */}
                     {overviewAi.triage ? (
                       <div>
-                        <div style={{ ...ls, marginBottom: 6 }}>Triage Assessment</div>
-                        <p style={{ fontSize: 13, color: "#e2e8f0", lineHeight: 1.7, margin: 0, whiteSpace: "pre-wrap" }}>
-                          {overviewAi.triage}
-                        </p>
+                        <div style={{ ...ls, marginBottom: 8 }}>Triage Assessment</div>
+                        <AiAnalysisText
+                          text={overviewAi.triage}
+                          sectionLabels={TRIAGE_LABELS}
+                          baseColor="#818cf8"
+                        />
                       </div>
                     ) : null}
 
                     {/* Root Cause */}
                     {overviewAi.rootCause ? (
                       <div>
-                        <div style={{ ...ls, marginBottom: 6 }}>Root Cause</div>
-                        <p style={{ fontSize: 12, color: "#cbd5e1", lineHeight: 1.65, margin: 0, whiteSpace: "pre-wrap" }}>
-                          {overviewAi.rootCause}
-                        </p>
+                        <div style={{ ...ls, marginBottom: 8 }}>Root Cause</div>
+                        <AiAnalysisText
+                          text={overviewAi.rootCause}
+                          sectionLabels={ROOT_CAUSE_LABELS}
+                          baseColor="#34d399"
+                        />
                       </div>
                     ) : null}
 


### PR DESCRIPTION
Switched Bedrock model IDs used by the IR/LLM endpoints by updating BEDROCK_MODEL_ID across the repo (backend default + docs/templates) to a working Claude model (anthropic.claude-3-haiku-20240307-v1:0) after newer Haiku 4.5 IDs hit Bedrock throughput/subscription/billing constraints.

Standardized where the model ID comes from in Docker: docker-compose.yml now passes through BEDROCK_MODEL_ID from your .env (no compose default) to avoid Docker Compose mangling values that contain :0.

Updated supporting documentation and env templates (env.example, Voice IR doc) so teammates copy the correct model ID/config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI-generated analyses now display with structured section formatting and improved readability
  * Confidence scores and MITRE ATT&CK techniques are now extracted and displayed in triage and root cause analysis results
  * Enhanced layout with wrapping support for technique tags

* **Chores**
  * Updated to Claude 3 Haiku model
  * Added AWS session token support for temporary credential configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->